### PR TITLE
Add new parsers for iosxr

### DIFF
--- a/src/genie/libs/parser/iosxr/show_isis.py
+++ b/src/genie/libs/parser/iosxr/show_isis.py
@@ -57,7 +57,6 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
             out = output
         
         isis_adjacency_dict = {}
-        isis_adjacency_dict['isis'] = {}
         for line in out.splitlines():
             line = line.rstrip()
             
@@ -65,6 +64,7 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
             p1 = re.compile(r'^\s*IS-IS\s+(?P<isis_name>\S+)\s+(?P<level_name>\S+)\s*adjacencies:\s*$')
             m = p1.match(line)
             if m:
+                isis_adjacency_dict.setdefault('isis', {})
                 isis_name = m.groupdict()['isis_name']
                 level_name = m.groupdict()['level_name']
                 isis_adjacency_dict['isis'][isis_name] = {'adjacency': {level_name: {} } }

--- a/src/genie/libs/parser/iosxr/show_isis.py
+++ b/src/genie/libs/parser/iosxr/show_isis.py
@@ -78,7 +78,7 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
             if m:
                 system_id = m.groupdict()['system_id']
                 isis_adjacency_dict['isis'][isis_name]['level'][level_name].setdefault('system_id', {}).setdefault(system_id, {})
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['interface'] = m.groupdict()['interface']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['interface'] = Common.convert_intf_name(m.groupdict()['interface'])
                 isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['snpa'] = m.groupdict()['snpa']
                 isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['state'] = m.groupdict()['state']
                 isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['hold'] = m.groupdict()['hold']
@@ -150,7 +150,7 @@ class ShowIsisNeighbors(ShowIsisNeighborsSchema):
             if m:
                 system_id = m.groupdict()['system_id']
                 isis_neighbors_dict.setdefault('isis', {}).setdefault(isis_name, {}).setdefault('neighbors', {}).setdefault(system_id, {})
-                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['interface'] = m.groupdict()['interface']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['interface'] = Common.convert_intf_name(m.groupdict()['interface'])
                 isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['snpa'] = m.groupdict()['snpa']
                 isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['state'] = m.groupdict()['state']
                 isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['holdtime'] = m.groupdict()['holdtime']

--- a/src/genie/libs/parser/iosxr/show_isis.py
+++ b/src/genie/libs/parser/iosxr/show_isis.py
@@ -67,7 +67,7 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
                 isis_adjacency_dict.setdefault('isis', {})
                 isis_name = m.groupdict()['isis_name']
                 level_name = m.groupdict()['level_name']
-                isis_adjacency_dict['isis'][isis_name] = {'adjacency': {level_name: {} } }
+                isis_adjacency_dict['isis'][isis_name] = {'level': {level_name: {} } }
                 continue
             
             # BKL-P-C9010-02 BE2              *PtoP*         Up    23   16w0d    Yes Up   None
@@ -75,22 +75,22 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
             m = p2.match(line)
             if m:
                 system_id = m.groupdict()['system_id']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id] = {}
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['interface'] = m.groupdict()['interface']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['snpa'] = m.groupdict()['snpa']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['state'] = m.groupdict()['state']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['hold'] = m.groupdict()['hold']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['changed'] = m.groupdict()['changed']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['nsf'] = m.groupdict()['nsf']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['ipv4_bfd'] = m.groupdict()['ipv4_bfd']
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['ipv6_bfd'] = m.groupdict()['ipv6_bfd']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name].setdefault('adjacency', {}).setdefault(system_id, {})
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['interface'] = m.groupdict()['interface']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['snpa'] = m.groupdict()['snpa']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['state'] = m.groupdict()['state']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['hold'] = m.groupdict()['hold']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['changed'] = m.groupdict()['changed']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['nsf'] = m.groupdict()['nsf']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['ipv4_bfd'] = m.groupdict()['ipv4_bfd']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['ipv6_bfd'] = m.groupdict()['ipv6_bfd']
                 continue
             
             # Total adjacency count: 1
             p3 = re.compile(r'^\s*Total\sadjacency\scount:\s+(?P<adjacency_count>\S+)\s*$')
             m = p3.match(line)
             if m:
-                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name]['total_adjacency_count'] = int(m.groupdict()['adjacency_count'])
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['total_adjacency_count'] = int(m.groupdict()['adjacency_count'])
                 continue
         
         return isis_adjacency_dict

--- a/src/genie/libs/parser/iosxr/show_isis.py
+++ b/src/genie/libs/parser/iosxr/show_isis.py
@@ -25,20 +25,22 @@ class ShowIsisAdjacencySchema(MetaParser):
         
     schema = {
         'isis': {
-            Optional(Any()): {
-                Optional('adjacency'): {
-                    Optional(Any()): {
-                        Optional('total_adjacency_count'): int,
-                        Optional(Any()): {
-                            Optional('interface'): str,
-                            Optional('snpa'): str,
-                            Optional('state'): str,
-                            Optional('hold'): str,
-                            Optional('changed'): str,
-                            Optional('nsf'): str,
-                            Optional('ipv4_bfd'): str,
-                            Optional('ipv6_bfd'): str,
-                        },
+            Any(): {
+                'level': {
+                    Any(): {
+                        'total_adjacency_count': int,
+                        'system_id': {
+                            Any(): {
+                                'interface': str,
+                                'snpa': str,
+                                'state': str,
+                                'hold': str,
+                                'changed': str,
+                                Optional('nsf'): str,
+                                Optional('ipv4_bfd'): str,
+                                Optional('ipv6_bfd'): str,
+                            },
+                        }
                     },
                 },
             },
@@ -75,15 +77,15 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
             m = p2.match(line)
             if m:
                 system_id = m.groupdict()['system_id']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name].setdefault('adjacency', {}).setdefault(system_id, {})
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['interface'] = m.groupdict()['interface']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['snpa'] = m.groupdict()['snpa']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['state'] = m.groupdict()['state']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['hold'] = m.groupdict()['hold']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['changed'] = m.groupdict()['changed']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['nsf'] = m.groupdict()['nsf']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['ipv4_bfd'] = m.groupdict()['ipv4_bfd']
-                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['adjacency'][system_id]['ipv6_bfd'] = m.groupdict()['ipv6_bfd']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name].setdefault('system_id', {}).setdefault(system_id, {})
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['interface'] = m.groupdict()['interface']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['snpa'] = m.groupdict()['snpa']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['state'] = m.groupdict()['state']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['hold'] = m.groupdict()['hold']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['changed'] = m.groupdict()['changed']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['nsf'] = m.groupdict()['nsf']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['ipv4_bfd'] = m.groupdict()['ipv4_bfd']
+                isis_adjacency_dict['isis'][isis_name]['level'][level_name]['system_id'][system_id]['ipv6_bfd'] = m.groupdict()['ipv6_bfd']
                 continue
             
             # Total adjacency count: 1

--- a/src/genie/libs/parser/iosxr/show_isis.py
+++ b/src/genie/libs/parser/iosxr/show_isis.py
@@ -1,0 +1,172 @@
+"""
+show_isis.py
+
+IOSXR parsers for the following show commands:
+    * show isis adjacency
+    * show isis neighbors
+
+"""
+
+# Python
+import re
+from netaddr import IPAddress, IPNetwork
+
+# Metaparser
+from genie.metaparser import MetaParser
+from genie.metaparser.util.schemaengine import Schema, Any, Or, Optional
+from genie.libs.parser.utils.common import Common
+
+
+#==================================
+# Schema for 'show isis adjacency'
+#==================================
+class ShowIsisAdjacencySchema(MetaParser):
+    """Schema for show run isis adjacency"""
+        
+    schema = {
+        'isis': {
+            Optional(Any()): {
+                Optional('adjacency'): {
+                    Optional(Any()): {
+                        Optional('total_adjacency_count'): int,
+                        Optional(Any()): {
+                            Optional('interface'): str,
+                            Optional('snpa'): str,
+                            Optional('state'): str,
+                            Optional('hold'): str,
+                            Optional('changed'): str,
+                            Optional('nsf'): str,
+                            Optional('ipv4_bfd'): str,
+                            Optional('ipv6_bfd'): str,
+                        },
+                    },
+                },
+            },
+        }
+    }
+
+class ShowIsisAdjacency(ShowIsisAdjacencySchema):
+    """Parser for show isis adjacency"""
+    
+    cli_command = 'show isis adjacency'
+    
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        
+        isis_adjacency_dict = {}
+        isis_adjacency_dict['isis'] = {}
+        for line in out.splitlines():
+            line = line.rstrip()
+            
+            # IS-IS 4445 Level-2 adjacencies:
+            p1 = re.compile(r'^\s*IS-IS\s+(?P<isis_name>\S+)\s+(?P<level_name>\S+)\s*adjacencies:\s*$')
+            m = p1.match(line)
+            if m:
+                isis_name = m.groupdict()['isis_name']
+                level_name = m.groupdict()['level_name']
+                isis_adjacency_dict['isis'][isis_name] = {'adjacency': {level_name: {} } }
+                continue
+            
+            # BKL-P-C9010-02 BE2              *PtoP*         Up    23   16w0d    Yes Up   None
+            p2 = re.compile(r'^\s*(?P<system_id>\S+)\s+(?P<interface>\S+)\s+(?P<snpa>\S+)\s+(?P<state>(Up|Down|None)+)\s+(?P<hold>\S+)\s+(?P<changed>\S+)\s+(?P<nsf>\S+)\s+(?P<ipv4_bfd>(Up|Down|None)+)\s+(?P<ipv6_bfd>(Up|Down|None)+)\s*$')
+            m = p2.match(line)
+            if m:
+                system_id = m.groupdict()['system_id']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id] = {}
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['interface'] = m.groupdict()['interface']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['snpa'] = m.groupdict()['snpa']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['state'] = m.groupdict()['state']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['hold'] = m.groupdict()['hold']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['changed'] = m.groupdict()['changed']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['nsf'] = m.groupdict()['nsf']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['ipv4_bfd'] = m.groupdict()['ipv4_bfd']
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name][system_id]['ipv6_bfd'] = m.groupdict()['ipv6_bfd']
+                continue
+            
+            # Total adjacency count: 1
+            p3 = re.compile(r'^\s*Total\sadjacency\scount:\s+(?P<adjacency_count>\S+)\s*$')
+            m = p3.match(line)
+            if m:
+                isis_adjacency_dict['isis'][isis_name]['adjacency'][level_name]['total_adjacency_count'] = int(m.groupdict()['adjacency_count'])
+                continue
+        
+        return isis_adjacency_dict
+
+
+#======================================
+# Schema for 'show isis neighbors'
+#======================================
+class ShowIsisNeighborsSchema(MetaParser):
+    """Schema for show run isis neighbors"""
+    
+    schema = {
+        'isis': {
+            Optional(Any()): {
+                Optional('neighbors'): {
+                    Optional('total_neighbor_count'): int,
+                    Optional(Any()): {
+                        Optional('system_id'): str,
+                        Optional('interface'): str,
+                        Optional('snpa'): str,
+                        Optional('state'): str,
+                        Optional('holdtime'): str,
+                        Optional('type'): str,
+                        Optional('ietf_nsf'): str,
+                    },
+                },
+            },
+        }
+    }
+
+class ShowIsisNeighbors(ShowIsisNeighborsSchema):
+    """Parser for show isis neighbors"""
+    
+    cli_command = 'show isis neighbors'
+    
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        
+        isis_neighbors_dict = {}
+        isis_neighbors_dict['isis'] = {}
+        for line in out.splitlines():
+            line = line.rstrip()
+        
+            # IS-IS 4445 neighbors:
+            p1 = re.compile(r'^\s*IS-IS\s+(?P<isis_name>\S+)\s*neighbors:\s*$')
+            m = p1.match(line)
+            if m:
+                isis_name = m.groupdict()['isis_name']
+                isis_neighbors_dict['isis'][isis_name] = {'neighbors': {} }
+                continue
+            
+            # BKL-P-C9010-02 BE2              *PtoP*         Up    23       L2   Capable
+            p2 = re.compile(r'^\s*(?P<system_id>\S+)\s+(?P<interface>\S+)\s+(?P<snpa>\S+)\s+(?P<state>(Up|Down|None)+)\s+(?P<holdtime>\S+)\s+(?P<type>\S+)\s+(?P<ietf_nsf>\S+)\s*$')
+            m = p2.match(line)
+            if m:
+                system_id = m.groupdict()['system_id']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id] = {}
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['interface'] = m.groupdict()['interface']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['snpa'] = m.groupdict()['snpa']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['state'] = m.groupdict()['state']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['holdtime'] = m.groupdict()['holdtime']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['type'] = m.groupdict()['type']
+                isis_neighbors_dict['isis'][isis_name]['neighbors'][system_id]['ietf_nsf'] = m.groupdict()['ietf_nsf']
+                continue
+            
+            # Total neighbor count: 1
+            p3 = re.compile(r'^\s*Total\sneighbor\scount:\s+(?P<neighbor_count>\S+)\s*$')
+            m = p3.match(line)
+            if m:
+                isis_neighbors_dict['isis'][isis_name]['neighbors']['total_neighbor_count'] = int(m.groupdict()['neighbor_count'])
+                continue
+        
+        return isis_neighbors_dict
+
+
+

--- a/src/genie/libs/parser/iosxr/show_mpls.py
+++ b/src/genie/libs/parser/iosxr/show_mpls.py
@@ -1,0 +1,91 @@
+''' show_mpls.py
+
+IOSXR parsers for the following show commands:
+    * 'show mpls ldp neighbor brief'
+'''
+
+# Python
+import re
+
+# Metaparser
+from genie.metaparser import MetaParser
+from genie.metaparser.util.schemaengine import Schema, Any, Optional, Or, And,\
+                                         Default, Use
+
+# ======================================================
+# Parser for 'show mpls ldp neighbor brief'
+# ======================================================
+
+class ShowMplsLdpNeighborBriefSchema(MetaParser):
+    
+    """Schema for show mpls ldp neighbor brief"""
+
+    schema = {
+        'peer': 
+            {Any(): 
+                {Optional('gr'): str,
+                Optional('nsr'): str,
+                Optional('up_time'): str,
+                Optional('discovery'): 
+                    {Optional('ipv4'): int,
+                    Optional('ipv6'): int,
+                    },
+                Optional('addresses'): 
+                    {Optional('ipv4'): int,
+                    Optional('ipv6'): int,
+                    },
+                Optional('labels'): 
+                    {Optional('ipv4'): int,
+                    Optional('ipv6'): int,
+                    },
+                },
+            },
+        }
+
+class ShowMplsLdpNeighborBrief(ShowMplsLdpNeighborBriefSchema):
+
+    """Parser for show mpls ldp neighbor brief"""
+
+    cli_command = 'show mpls ldp neighbor brief'
+
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        
+        # Init vars
+        mpls_dict = {}
+        mpls_dict['peer'] = {}
+        peer = ''
+        
+        for line in out.splitlines():
+            line = line.rstrip()
+
+            # Peer               GR  NSR  Up Time     Discovery   Addresses     Labels
+            #                                         ipv4  ipv6  ipv4  ipv6  ipv4   ipv6
+            # -----------------  --  ---  ----------  ----------  ----------  ------------
+            # 85.205.2.254:0     Y   Y    31w0d       2     0     10    0     77     0
+            p1 = re.compile(r'^\s*(?P<peer>[\d\.:]+)\s+(?P<gr>[\w]+)\s+(?P<nsr>[\w]+)\s+(?P<up_time>[\w\d]+)\s+(?P<discovery_ipv4>[\d]+)\s+(?P<discovery_ipv6>[\d]+)\s+(?P<addresses_ipv4>[\d]+)\s+(?P<addresses_ipv6>[\d]+)\s+(?P<labels_ipv4>[\d]+)\s+(?P<labels_ipv6>[\d]+)\s*$')
+            m = p1.match(line)
+            if m:
+                peer = m.groupdict()['peer']
+                mpls_dict['peer'][peer] = {}
+                mpls_dict['peer'][peer]['gr'] = m.groupdict()['gr']
+                mpls_dict['peer'][peer]['nsr'] = m.groupdict()['nsr']
+                mpls_dict['peer'][peer]['up_time'] = m.groupdict()['up_time']
+
+                mpls_dict['peer'][peer]['discovery'] = {}
+                mpls_dict['peer'][peer]['discovery']['ipv4'] = int(m.groupdict()['discovery_ipv4'])
+                mpls_dict['peer'][peer]['discovery']['ipv6'] = int(m.groupdict()['discovery_ipv6'])
+
+                mpls_dict['peer'][peer]['addresses'] = {}
+                mpls_dict['peer'][peer]['addresses']['ipv4'] = int(m.groupdict()['addresses_ipv4'])
+                mpls_dict['peer'][peer]['addresses']['ipv6'] = int(m.groupdict()['addresses_ipv6'])
+
+                mpls_dict['peer'][peer]['labels'] = {}
+                mpls_dict['peer'][peer]['labels']['ipv4'] = int(m.groupdict()['labels_ipv4'])
+                mpls_dict['peer'][peer]['labels']['ipv6'] = int(m.groupdict()['labels_ipv6'])
+                continue
+        
+        return mpls_dict

--- a/src/genie/libs/parser/iosxr/show_mpls.py
+++ b/src/genie/libs/parser/iosxr/show_mpls.py
@@ -21,26 +21,26 @@ class ShowMplsLdpNeighborBriefSchema(MetaParser):
     """Schema for show mpls ldp neighbor brief"""
 
     schema = {
-        'peer': 
-            {Any(): 
-                {Optional('gr'): str,
-                Optional('nsr'): str,
-                Optional('up_time'): str,
-                Optional('discovery'): 
-                    {Optional('ipv4'): int,
-                    Optional('ipv6'): int,
-                    },
-                Optional('addresses'): 
-                    {Optional('ipv4'): int,
-                    Optional('ipv6'): int,
-                    },
-                Optional('labels'): 
-                    {Optional('ipv4'): int,
-                    Optional('ipv6'): int,
-                    },
+        'peer': { 
+            Any(): { 
+                'gr': str,
+                'nsr': str,
+                'up_time': str,
+                'discovery': { 
+                    'ipv4': int,
+                    'ipv6': int,
+                },
+                'addresses': { 
+                    'ipv4': int,
+                    'ipv6': int,
+                },
+                'labels': { 
+                    'ipv4': int,
+                    'ipv6': int,
                 },
             },
-        }
+        },
+    }
 
 class ShowMplsLdpNeighborBrief(ShowMplsLdpNeighborBriefSchema):
 
@@ -56,7 +56,6 @@ class ShowMplsLdpNeighborBrief(ShowMplsLdpNeighborBriefSchema):
         
         # Init vars
         mpls_dict = {}
-        mpls_dict['peer'] = {}
         peer = ''
         
         for line in out.splitlines():
@@ -70,7 +69,7 @@ class ShowMplsLdpNeighborBrief(ShowMplsLdpNeighborBriefSchema):
             m = p1.match(line)
             if m:
                 peer = m.groupdict()['peer']
-                mpls_dict['peer'][peer] = {}
+                mpls_dict.setdefault('peer', {}).setdefault(peer, {})
                 mpls_dict['peer'][peer]['gr'] = m.groupdict()['gr']
                 mpls_dict['peer'][peer]['nsr'] = m.groupdict()['nsr']
                 mpls_dict['peer'][peer]['up_time'] = m.groupdict()['up_time']

--- a/src/genie/libs/parser/iosxr/show_mrib.py
+++ b/src/genie/libs/parser/iosxr/show_mrib.py
@@ -80,8 +80,6 @@ class ShowMribVrfRoute(ShowMribVrfRouteSchema):
         parsed_dict = {}
         rpf_nbr = ''
 
-        import pdb; pdb.set_trace()
-
         for line in out.splitlines():
             line = line.rstrip()
 

--- a/src/genie/libs/parser/iosxr/show_mrib.py
+++ b/src/genie/libs/parser/iosxr/show_mrib.py
@@ -2,6 +2,7 @@
 
 IOSXR parsers for the following show commands:
     * 'show mrib vrf <WORD> <WORD> route'
+    * 'show mrib vrf <WORD> <WORD> route summary'
 '''
 
 # Python
@@ -63,7 +64,7 @@ class ShowMribVrfRouteSchema(MetaParser):
 class ShowMribVrfRoute(ShowMribVrfRouteSchema):
     """
     Parser for show mrib vrf <vrf> <address-family> route
-    For checking any output with the parser ,below mandatory keys have to be in cli command.
+    For checking any output with the parser, below mandatory keys have to be in cli command.
     - vrf
     - af
     """
@@ -237,4 +238,92 @@ class ShowMribVrfRoute(ShowMribVrfRouteSchema):
                     sub_dict[intf_list_type][interface]['rpf_nbr'] = rpf_nbr
                     continue
 
+        return parsed_dict
+
+# ======================================================
+# Parser for 'show mrib vrf <WORD> <WORD> route summary'
+# ======================================================
+
+class ShowMribVrfRouteSummarySchema(MetaParser):
+    
+    """Schema for show mrib vrf <vrf> <address-family> route summary"""
+
+    schema = {
+        'vrf': 
+            {Any(): 
+                {Optional('no_group_ranges'): int,
+                Optional('no_g_routes'): int,
+                Optional('no_s_g_routes'): int,
+                Optional('no_route_x_interfaces'): int,
+                Optional('total_no_interfaces'): int,
+                },
+            },
+        }
+
+class ShowMribVrfRouteSummary(ShowMribVrfRouteSummarySchema):
+    """
+    Parser for show mrib vrf <vrf> <address-family> route summary
+    For checking any output with the parser, below mandatory keys have to be in cli command.
+    - vrf
+    - af (optional)
+    """
+    cli_command = 'show mrib vrf {vrf} {af} route summary'
+
+    def cli(self, vrf='default', af='ipv4',output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command.format(vrf=vrf, af=af))
+        else:
+            out = output
+        
+        # Init vars
+        parsed_dict = {}
+        parsed_dict['vrf'] = {}
+        vrf = ''
+        
+        for line in out.splitlines():
+            line = line.rstrip()
+            
+            # MRIB Route Summary for VRF default
+            p1 = re.compile(r'^\s*MRIB +Route +Summary +for +VRF +(?P<vrf>(\S+))\s*$')
+            m = p1.match(line)
+            if m:
+                vrf = m.groupdict()['vrf']
+                parsed_dict['vrf'][vrf] = {}
+                continue
+            
+            # No. of group ranges = 5
+            p2 = re.compile(r'^\s*No\. +of +group +ranges +=\s+(?P<no_group_ranges>[0-9]+)\s*$')
+            m = p2.match(line)
+            if m:
+                parsed_dict['vrf'][vrf]['no_group_ranges'] = int(m.groupdict()['no_group_ranges'])
+                continue
+            
+            # No. of (*,G) routes = 1
+            p3 = re.compile(r'^\s*No\. +of +\(\*,G\) +routes +=\s+(?P<no_g_routes>[0-9]+)\s*$')
+            m = p3.match(line)
+            if m:
+                parsed_dict['vrf'][vrf]['no_g_routes'] = int(m.groupdict()['no_g_routes'])
+                continue
+            
+            # No. of (S,G) routes = 0
+            p4 = re.compile(r'^\s*No\. +of +\(S,G\) +routes +=\s+(?P<no_s_g_routes>[0-9]+)\s*$')
+            m = p4.match(line)
+            if m:
+                parsed_dict['vrf'][vrf]['no_s_g_routes'] = int(m.groupdict()['no_s_g_routes'])
+                continue
+            
+            # No. of Route x Interfaces (RxI) = 0
+            p5 = re.compile(r'^\s*No\. +of +Route +x +Interfaces +\(RxI\) +=\s+(?P<no_route_x_interfaces>[0-9]+)\s*$')
+            m = p5.match(line)
+            if m:
+                parsed_dict['vrf'][vrf]['no_route_x_interfaces'] = int(m.groupdict()['no_route_x_interfaces'])
+                continue
+            
+            # Total No. of Interfaces in all routes = 1
+            p6 = re.compile(r'^\s*Total +No\. +of +Interfaces +in +all +routes +=\s+(?P<total_no_interfaces>[0-9]+)\s*$')
+            m = p6.match(line)
+            if m:
+                parsed_dict['vrf'][vrf]['total_no_interfaces'] = int(m.groupdict()['total_no_interfaces'])
+                continue
+        
         return parsed_dict

--- a/src/genie/libs/parser/iosxr/show_mrib.py
+++ b/src/genie/libs/parser/iosxr/show_mrib.py
@@ -80,6 +80,8 @@ class ShowMribVrfRoute(ShowMribVrfRouteSchema):
         parsed_dict = {}
         rpf_nbr = ''
 
+        import pdb; pdb.set_trace()
+
         for line in out.splitlines():
             line = line.rstrip()
 
@@ -249,16 +251,20 @@ class ShowMribVrfRouteSummarySchema(MetaParser):
     """Schema for show mrib vrf <vrf> <address-family> route summary"""
 
     schema = {
-        'vrf': 
-            {Any(): 
-                {Optional('no_group_ranges'): int,
-                Optional('no_g_routes'): int,
-                Optional('no_s_g_routes'): int,
-                Optional('no_route_x_interfaces'): int,
-                Optional('total_no_interfaces'): int,
-                },
+        'vrf': { 
+            Any(): {
+                'address_family': {
+                    Any(): {
+                        'no_group_ranges': int,
+                        'no_g_routes': int,
+                        'no_s_g_routes': int,
+                        'no_route_x_interfaces': int,
+                        'total_no_interfaces': int,                    
+                    }
+                }
             },
-        }
+        },
+    }
 
 class ShowMribVrfRouteSummary(ShowMribVrfRouteSummarySchema):
     """
@@ -267,17 +273,31 @@ class ShowMribVrfRouteSummary(ShowMribVrfRouteSummarySchema):
     - vrf
     - af (optional)
     """
-    cli_command = 'show mrib vrf {vrf} {af} route summary'
+    cli_command = [
+                    'show mrib route summary',
+                    'show mrib vrf {vrf} route summary',
+                    'show mrib vrf {vrf} ipv4 route summary',
+                    'show mrib vrf {vrf} ipv6 route summary',
+                ]
 
-    def cli(self, vrf='default', af='ipv4',output=None):
+    def cli(self, vrf='', af='',output=None):
         if output is None:
-            out = self.device.execute(self.cli_command.format(vrf=vrf, af=af))
+            if vrf:
+                if af == 'ipv4':
+                    out = self.device.execute(self.cli_command[2].format(vrf=vrf))
+                elif af == 'ipv6':
+                    out = self.device.execute(self.cli_command[3].format(vrf=vrf))
+                else:
+                    out = self.device.execute(self.cli_command[1].format(vrf=vrf))
+                    af = 'ipv4'
+            else:
+                out = self.device.execute(self.cli_command[0])
+                af = 'ipv4'
         else:
             out = output
         
         # Init vars
         parsed_dict = {}
-        parsed_dict['vrf'] = {}
         vrf = ''
         
         for line in out.splitlines():
@@ -288,42 +308,42 @@ class ShowMribVrfRouteSummary(ShowMribVrfRouteSummarySchema):
             m = p1.match(line)
             if m:
                 vrf = m.groupdict()['vrf']
-                parsed_dict['vrf'][vrf] = {}
+                parsed_dict.setdefault('vrf', {}).setdefault(vrf, {}).setdefault('address_family', {}).setdefault(af, {})
                 continue
             
             # No. of group ranges = 5
             p2 = re.compile(r'^\s*No\. +of +group +ranges +=\s+(?P<no_group_ranges>[0-9]+)\s*$')
             m = p2.match(line)
             if m:
-                parsed_dict['vrf'][vrf]['no_group_ranges'] = int(m.groupdict()['no_group_ranges'])
+                parsed_dict['vrf'][vrf]['address_family'][af]['no_group_ranges'] = int(m.groupdict()['no_group_ranges'])
                 continue
             
             # No. of (*,G) routes = 1
             p3 = re.compile(r'^\s*No\. +of +\(\*,G\) +routes +=\s+(?P<no_g_routes>[0-9]+)\s*$')
             m = p3.match(line)
             if m:
-                parsed_dict['vrf'][vrf]['no_g_routes'] = int(m.groupdict()['no_g_routes'])
+                parsed_dict['vrf'][vrf]['address_family'][af]['no_g_routes'] = int(m.groupdict()['no_g_routes'])
                 continue
             
             # No. of (S,G) routes = 0
             p4 = re.compile(r'^\s*No\. +of +\(S,G\) +routes +=\s+(?P<no_s_g_routes>[0-9]+)\s*$')
             m = p4.match(line)
             if m:
-                parsed_dict['vrf'][vrf]['no_s_g_routes'] = int(m.groupdict()['no_s_g_routes'])
+                parsed_dict['vrf'][vrf]['address_family'][af]['no_s_g_routes'] = int(m.groupdict()['no_s_g_routes'])
                 continue
             
             # No. of Route x Interfaces (RxI) = 0
             p5 = re.compile(r'^\s*No\. +of +Route +x +Interfaces +\(RxI\) +=\s+(?P<no_route_x_interfaces>[0-9]+)\s*$')
             m = p5.match(line)
             if m:
-                parsed_dict['vrf'][vrf]['no_route_x_interfaces'] = int(m.groupdict()['no_route_x_interfaces'])
+                parsed_dict['vrf'][vrf]['address_family'][af]['no_route_x_interfaces'] = int(m.groupdict()['no_route_x_interfaces'])
                 continue
             
             # Total No. of Interfaces in all routes = 1
             p6 = re.compile(r'^\s*Total +No\. +of +Interfaces +in +all +routes +=\s+(?P<total_no_interfaces>[0-9]+)\s*$')
             m = p6.match(line)
             if m:
-                parsed_dict['vrf'][vrf]['total_no_interfaces'] = int(m.groupdict()['total_no_interfaces'])
+                parsed_dict['vrf'][vrf]['address_family'][af]['total_no_interfaces'] = int(m.groupdict()['total_no_interfaces'])
                 continue
         
         return parsed_dict

--- a/src/genie/libs/parser/iosxr/show_platform.py
+++ b/src/genie/libs/parser/iosxr/show_platform.py
@@ -625,7 +625,7 @@ class ShowInstallCommitSummarySchema(MetaParser):
     schema = {
         'committed_packages': Any(),
         Optional('num_committed_packages'): int,
-        Optional('sdr'): str,
+        Optional('sdr'): list,
         }
 
 class ShowInstallCommitSummary(ShowInstallCommitSummarySchema):
@@ -654,7 +654,7 @@ class ShowInstallCommitSummary(ShowInstallCommitSummarySchema):
             
             if previous_line_sdr:
                 previous_line_sdr = False
-                install_commit_dict['sdr'] = str(line).strip()
+                install_commit_dict.setdefault('sdr', []).append(str(line).strip())
                 continue
             
             

--- a/src/genie/libs/parser/iosxr/show_platform.py
+++ b/src/genie/libs/parser/iosxr/show_platform.py
@@ -561,7 +561,7 @@ class ShowInstallInactiveSummarySchema(MetaParser):
     schema = {
         'inactive_packages': Any(),
         Optional('num_inactive_packages'): int,
-        Optional('sdr'): str,
+        Optional('sdr'): list,
         }
 
 class ShowInstallInactiveSummary(ShowInstallInactiveSummarySchema):
@@ -590,7 +590,7 @@ class ShowInstallInactiveSummary(ShowInstallInactiveSummarySchema):
             
             if previous_line_sdr:
                 previous_line_sdr = False
-                install_inactive_dict['sdr'] = str(line).strip()
+                install_inactive_dict.setdefault('sdr', []).append(str(line).strip())
                 continue
             
             

--- a/src/genie/libs/parser/iosxr/show_platform.py
+++ b/src/genie/libs/parser/iosxr/show_platform.py
@@ -1,4 +1,4 @@
-''' show_paltform.py
+''' show_platform.py
 
 IOSXR parsers for the following show commands:
     * 'show version'
@@ -6,6 +6,8 @@ IOSXR parsers for the following show commands:
     * 'show platform'
     * 'show platform vm'
     * 'show install active summary'
+    * 'show install inactive summary'
+    * 'show install commit summary'
     * 'show inventory'
     * 'admin show diag chassis'
     * 'show redundancy summary'
@@ -550,6 +552,134 @@ class ShowInstallActiveSummary(ShowInstallActiveSummarySchema):
                     continue
 
         return install_active_dict
+
+# ========================================
+# Schema for 'show install inactive summary'
+# ========================================
+class ShowInstallInactiveSummarySchema(MetaParser):
+    """Schema for show install inactive summary"""
+    schema = {
+        'inactive_packages': Any(),
+        Optional('num_inactive_packages'): int,
+        Optional('sdr'): str,
+        }
+
+class ShowInstallInactiveSummary(ShowInstallInactiveSummarySchema):
+    """Parser for show install inactive summary"""
+    
+    cli_command = 'show install inactive summary'
+    
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        # Init vars
+        install_inactive_dict = {}
+        previous_line_sdr = False
+        previous_line_inactive_packages = False
+        
+        for line in out.splitlines():
+            line = line.rstrip()
+            
+            p1 = re.compile(r'\s*SDRs:*$')
+            m = p1.match(line)
+            if m:
+                previous_line_sdr = True
+                continue
+            
+            if previous_line_sdr:
+                previous_line_sdr = False
+                install_inactive_dict['sdr'] = str(line).strip()
+                continue
+            
+            
+            # disk0:xrvr-full-x-6.2.1.23I
+            # disk0:asr9k-mini-px-6.1.21.15I
+            # xrv9k-xr-6.2.2.14I version=6.2.2.14I [Boot image]
+            p2 = re.compile(r'\s*Inactive +Packages:'
+                             ' *(?P<num_inactive_packages>[0-9]+)?$')
+            m = p2.match(line)
+            if m:
+                previous_line_inactive_packages = True
+                if 'inactive_packages' not in install_inactive_dict:
+                    install_inactive_dict['inactive_packages'] = []
+                if m.groupdict()['num_inactive_packages']:
+                    install_inactive_dict['num_inactive_packages'] = \
+                        int(m.groupdict()['num_inactive_packages'])
+                continue
+            
+            if previous_line_inactive_packages and line is not None:
+                clean_line = str(line).strip()
+                if line and '/' not in line:
+                    install_inactive_dict['inactive_packages'].append(clean_line)
+                    continue
+        
+        return install_inactive_dict
+
+# ========================================
+# Schema for 'show install commit summary'
+# ========================================
+class ShowInstallCommitSummarySchema(MetaParser):
+    """Schema for show install commit summary"""
+    schema = {
+        'committed_packages': Any(),
+        Optional('num_committed_packages'): int,
+        Optional('sdr'): str,
+        }
+
+class ShowInstallCommitSummary(ShowInstallCommitSummarySchema):
+    """Parser for show install inactive summary"""
+    
+    cli_command = 'show install commit summary'
+    
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        # Init vars
+        install_commit_dict = {}
+        previous_line_sdr = False
+        previous_line_committed_packages = False
+        
+        for line in out.splitlines():
+            line = line.rstrip()
+            
+            p1 = re.compile(r'\s*SDRs:*$')
+            m = p1.match(line)
+            if m:
+                previous_line_sdr = True
+                continue
+            
+            if previous_line_sdr:
+                previous_line_sdr = False
+                install_commit_dict['sdr'] = str(line).strip()
+                continue
+            
+            
+            # disk0:xrvr-full-x-6.2.1.23I
+            # disk0:asr9k-mini-px-6.1.21.15I
+            # xrv9k-xr-6.2.2.14I version=6.2.2.14I [Boot image]
+            p2 = re.compile(r'\s*Committed +Packages:'
+                             ' *(?P<num_committed_packages>[0-9]+)?$')
+            m = p2.match(line)
+            if m:
+                previous_line_committed_packages = True
+                if 'committed_packages' not in install_commit_dict:
+                    install_commit_dict['committed_packages'] = []
+                if m.groupdict()['num_committed_packages']:
+                    install_commit_dict['num_committed_packages'] = \
+                        int(m.groupdict()['num_committed_packages'])
+                continue
+            
+            if previous_line_committed_packages and line is not None:
+                clean_line = str(line).strip()
+                if line and '/' not in line:
+                    install_commit_dict['committed_packages'].append(clean_line)
+                    continue
+        
+        return install_commit_dict
 
 # ===========================
 # Schema for 'show inventory'

--- a/src/genie/libs/parser/iosxr/show_run.py
+++ b/src/genie/libs/parser/iosxr/show_run.py
@@ -46,7 +46,6 @@ class ShowRunKeyChain(ShowRunKeyChainSchema):
             out = output
         
         key_chain_dict = {}
-        key_chain_dict['key_chains'] = {}
         for line in out.splitlines():
             line = line.rstrip()
         
@@ -54,6 +53,7 @@ class ShowRunKeyChain(ShowRunKeyChainSchema):
             p1 = re.compile(r'^key\schain\s+(?P<key_chain_name>.*)$')
             m = p1.match(line)
             if m:
+                key_chain_dict['key_chains'] = {}
                 key_chain_name = m.groupdict()['key_chain_name']
                 key_chain_dict['key_chains'][key_chain_name] = {}
                 key_chain_dict['key_chains'][key_chain_name]['keys'] = {}
@@ -179,7 +179,6 @@ class ShowRunRouterIsis(ShowRunRouterIsisSchema):
             out = output
         
         router_isis_dict = {}
-        router_isis_dict['isis'] = {}
         is_interface = False
         is_address_family = False
         isis_name = None
@@ -265,10 +264,11 @@ class ShowRunRouterIsis(ShowRunRouterIsisSchema):
                 continue
             
             
-            # router isis 4445
+            # router isis 65109
             p1 = re.compile(r'^\s*router\sisis\s+(?P<isis_name>.+)$')
             m = p1.match(line)
             if m:
+                router_isis_dict.setdefault('isis', {})
                 isis_name = m.groupdict()['isis_name']
                 router_isis_dict['isis'][isis_name] = {}
                 router_isis_dict['isis'][isis_name]['address_family'] = {}
@@ -345,7 +345,7 @@ class ShowRunRouterIsis(ShowRunRouterIsisSchema):
                         router_isis_dict['isis'][isis_name][m.groupdict()['generic_key'].replace('-', '_')] = m.groupdict()['generic_value']
                         continue
                     if is_interface:
-                        router_isis_dict['isis'][isis_name]['interfaces'][interface][m.groupdict()['generic_key'].replace('-', '_')] = m.groupdict()['generic_value']
+                        router_isis_dict['isis'][isis_name]['interfaces'].setdefault(interface, {}).setdefault(m.groupdict()['generic_key'].replace('-', '_'), m.groupdict()['generic_value'])
                         continue
         
         return router_isis_dict

--- a/src/genie/libs/parser/iosxr/show_run.py
+++ b/src/genie/libs/parser/iosxr/show_run.py
@@ -1,0 +1,351 @@
+"""
+show_run.py
+
+IOSXR parsers for the following show commands:
+    * show run key chain
+    * show run router isis
+
+"""
+
+import re
+from genie.metaparser import MetaParser
+from genie.metaparser.util.schemaengine import Schema, Any, Or, Optional
+
+# ===============================
+# Schema for 'show run key chain'
+# ===============================
+class ShowRunKeyChainSchema(MetaParser):
+    """Schema for show run key chain"""
+    
+    schema = {
+        'key_chains': {
+            Optional(Any()): {
+                Optional('keys'): {
+                    Optional(Any()): {
+                        Optional('accept_lifetime'): str,
+                        Optional('key_string'): str,
+                        Optional('send_lifetime'): str,
+                        Optional('cryptographic_algorithm'): str
+                    },
+                },        
+                Optional('accept_tolerance'): str
+            },
+        },
+    }
+
+
+class ShowRunKeyChain(ShowRunKeyChainSchema):
+    """Parser for show run key chain"""
+    
+    cli_command = 'show run key chain'
+    
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        
+        key_chain_dict = {}
+        key_chain_dict['key_chains'] = {}
+        for line in out.splitlines():
+            line = line.rstrip()
+        
+            # key chain ISIS-HELLO-CORE
+            p1 = re.compile(r'^key\schain\s+(?P<key_chain_name>.*)$')
+            m = p1.match(line)
+            if m:
+                key_chain_name = m.groupdict()['key_chain_name']
+                key_chain_dict['key_chains'][key_chain_name] = {}
+                key_chain_dict['key_chains'][key_chain_name]['keys'] = {}
+                continue
+            
+            # key 1
+            p2 = re.compile(r'^\s*key\s+(?P<key_name>.*)$')
+            m = p2.match(line)
+            if m:
+                key_name = m.groupdict()['key_name']
+                key_chain_dict['key_chains'][key_chain_name]['keys'][key_name] = {}
+                continue
+            
+            # accept-lifetime 00:01:00 january 01 2013 infinite
+            p3 = re.compile(r'^\s*accept-lifetime\s+(?P<accept_lifetime>.*)$')
+            m = p3.match(line)
+            if m:
+                key_chain_dict['key_chains'][key_chain_name]['keys'][key_name]['accept_lifetime'] = m.groupdict()['accept_lifetime']
+                continue
+            
+            # key-string password 020F175218
+            p4 = re.compile(r'^\s*key-string\s+(?P<key_string>.*)$')
+            m = p4.match(line)
+            if m:
+                key_chain_dict['key_chains'][key_chain_name]['keys'][key_name]['key_string'] = m.groupdict()['key_string']
+                continue
+            
+            # send-lifetime 00:01:00 january 01 2013 infinite
+            p5 = re.compile(r'^\s*send-lifetime\s+(?P<send_lifetime>.*)$')
+            m = p5.match(line)
+            if m: 
+                key_chain_dict['key_chains'][key_chain_name]['keys'][key_name]['send_lifetime'] = m.groupdict()['send_lifetime']
+                continue
+            
+            # cryptographic-algorithm HMAC-MD5
+            p6 = re.compile(r'^\s*cryptographic-algorithm\s+(?P<cryptographic_algorithm>.*)$')
+            m = p6.match(line)
+            if m:
+                key_chain_dict['key_chains'][key_chain_name]['keys'][key_name]['cryptographic_algorithm'] = m.groupdict()['cryptographic_algorithm']
+                continue
+            
+            # accept-tolerance infinite
+            p7 = re.compile(r'^\s*accept-tolerance\s+(?P<accept_tolerance>.*)$')
+            m = p7.match(line)
+            if m:
+                key_chain_dict['key_chains'][key_chain_name]['accept_tolerance'] = m.groupdict()['accept_tolerance']
+                continue
+        
+        return key_chain_dict
+
+
+
+# =================================
+# Schema for 'show run router isis'
+# =================================
+class ShowRunRouterIsisSchema(MetaParser):
+    """Schema for show run router isis"""
+    
+    schema = {
+        'isis': {
+            Any(): {
+                Optional('segment_routing'): {
+                    Optional(Any()): str,
+                },
+                Optional('lsp_gen_interval'): {
+                    Optional(Any()): Any(),
+                },
+                Optional('address_family'): {
+                    Optional(Any()): {
+                        Optional('fast_reroute'): {
+                            Optional('per_prefix'): {
+                                Optional('tiebreaker'):{
+                                    Optional(Any()): Any(),
+                                },
+                            },
+                        },
+                        Optional('mpls'): {
+                            Optional('traffic_eng'): Any(),
+                        },
+                        Optional('spf_interval'): {
+                            Optional(Any()): Any(),
+                        },
+                        Optional('spf_prefix_priority'): {
+                            Optional(Any()): Any(),
+                        },
+                        Optional('segment_routing'): {
+                            Optional(Any()): str,
+                        },
+                        Optional(Any()): str,
+                    }
+                },
+                Optional('interfaces'): {
+                    Optional(Any()): {
+                        Optional('bfd'): {
+                            Optional(Any()): Any(),
+                        },
+                        Optional('address_family'): {
+                            Optional(Any()): {
+                                Optional(Any()): Any(),
+                                Optional(Any()): {
+                                    Optional(Any()): Any(),
+                                },
+                            },
+                        },
+                        Optional(Any()): Any(),
+                    },
+                },
+                Optional(Any()): Any(),
+            }
+        }
+    }
+
+
+class ShowRunRouterIsis(ShowRunRouterIsisSchema):
+    """Parser for show run router isis"""
+    
+    cli_command = 'show run router isis'
+    
+    def cli(self, output=None):
+        if output is None:
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+        
+        router_isis_dict = {}
+        router_isis_dict['isis'] = {}
+        is_interface = False
+        is_address_family = False
+        isis_name = None
+        for line in out.splitlines():
+            line = line.rstrip()
+            
+            p0 = re.compile(r'^\s*!+\s*$')
+            m = p0.match(line)
+            if m:
+                is_address_family = False
+            
+            # Parsers for ISIS Address Family
+            if is_address_family:
+                # fast-reroute per-prefix tiebreaker srlg-disjoint index 255
+                a1 = re.compile(r'^\s*fast-reroute\sper-prefix\stiebreaker\s+(?P<key>\S+)\s+(?P<value>.+)$')
+                m = a1.match(line)
+                if m:
+                    if is_interface:
+                        if not 'fast_reroute' in router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'][address_family]:
+                            router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'][address_family]['fast_reroute'] = {'per_prefix':{'tiebreaker': {}}}
+                        router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'][address_family]['fast_reroute']['per_prefix']['tiebreaker'][m.groupdict()['key'].replace('-', '_')] = m.groupdict()['value']
+                    if not is_interface:
+                        if not 'fast_reroute' in router_isis_dict['isis'][isis_name]['address_family'][address_family]:
+                            router_isis_dict['isis'][isis_name]['address_family'][address_family]['fast_reroute'] = {'per_prefix':{'tiebreaker': {}}}
+                        router_isis_dict['isis'][isis_name]['address_family'][address_family]['fast_reroute']['per_prefix']['tiebreaker'][m.groupdict()['key'].replace('-', '_')] = m.groupdict()['value']
+                    continue
+                
+                # mpls traffic-eng level-2-only
+                a2 = re.compile(r'^\s*mpls\straffic-eng\s+(?P<mpls_traffic_eng>.+)$')
+                m = a2.match(line)
+                if m:
+                    if is_interface:
+                        if not 'mpls' in router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'][address_family]:
+                            router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'][address_family]['mpls'] = {'traffic_eng': []}
+                        router_isis_dict['isis'][isis_name][interface]['address_family'][address_family]['mpls']['traffic_eng'].append(m.groupdict()['mpls_traffic_eng'])
+                    if not is_interface:
+                        if not 'mpls' in router_isis_dict['isis'][isis_name]['address_family'][address_family]:
+                            router_isis_dict['isis'][isis_name]['address_family'][address_family]['mpls'] = {'traffic_eng': []}
+                        router_isis_dict['isis'][isis_name]['address_family'][address_family]['mpls']['traffic_eng'].append(m.groupdict()['mpls_traffic_eng'])
+                    continue
+                
+                # segment-routing mpls sr-prefer
+                a3 = re.compile(r'^\s*segment-routing\s+(?P<segment_key>\S+)\s+(?P<segment_value>.+)$')
+                m = a3.match(line)
+                if m:
+                    if not 'segment_routing' in router_isis_dict['isis'][isis_name]['address_family'][address_family]:
+                        router_isis_dict['isis'][isis_name]['address_family'][address_family]['segment_routing'] = {}
+                    router_isis_dict['isis'][isis_name]['address_family'][address_family]['segment_routing'][m.groupdict()['segment_key'].replace('-', '_')] = m.groupdict()['segment_value']
+                    continue
+                
+                # spf prefix-priority critical tag 1000
+                a4 = re.compile(r'^\s*spf\sprefix-priority\s+(?P<tag_key>\S+\stag+)\s+(?P<tag_value>.+)$')
+                m = a4.match(line)
+                if m:
+                    if not 'spf_prefix_priority' in router_isis_dict['isis'][isis_name]['address_family'][address_family]:
+                        router_isis_dict['isis'][isis_name]['address_family'][address_family]['spf_prefix_priority'] = {}
+                    router_isis_dict['isis'][isis_name]['address_family'][address_family]['spf_prefix_priority'][m.groupdict()['tag_key'].replace(' ', '_')] = m.groupdict()['tag_value']
+                    continue
+                
+                # spf-interval maximum-wait 8000 initial-wait 300 secondary-wait 500
+                a5 = re.compile(r'^\s*spf-interval\s+(?P<spf_interval>.+)$')
+                m = a5.match(line)
+                if m:
+                    spf_interval = m.groupdict()['spf_interval']
+                    pattern = re.compile('(\S+-wait)\s([0-9]+)')
+                    matches = pattern.findall(spf_interval)
+                    spf_interval_pairs = {key.replace('-', '_'):val for key,val in matches}
+                    router_isis_dict['isis'][isis_name]['address_family'][address_family]['spf_interval'] = spf_interval_pairs
+                    continue
+                
+                   
+                # Generic, catch all key/value
+                a9 = re.compile(r'^\s*(?P<generic_key>\S+)\s+(?P<generic_value>.+)$')
+                m = a9.match(line)
+                if m:
+                    if is_interface:
+                        router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'][address_family][m.groupdict()['generic_key'].replace('-', '_')] = m.groupdict()['generic_value']
+                    if not is_interface:
+                        router_isis_dict['isis'][isis_name]['address_family'][address_family][m.groupdict()['generic_key'].replace('-', '_')] = m.groupdict()['generic_value']
+                    continue
+                
+                # End Parsers for ISIS Address Family
+                continue
+            
+            
+            # router isis 4445
+            p1 = re.compile(r'^\s*router\sisis\s+(?P<isis_name>.+)$')
+            m = p1.match(line)
+            if m:
+                isis_name = m.groupdict()['isis_name']
+                router_isis_dict['isis'][isis_name] = {}
+                router_isis_dict['isis'][isis_name]['address_family'] = {}
+                router_isis_dict['isis'][isis_name]['segment_routing'] = {}
+                router_isis_dict['isis'][isis_name]['interfaces'] = {}
+                continue
+            
+            # segment-routing global-block 160000 167999
+            p2 = re.compile(r'^\s*segment-routing\s+(?P<segment_routing_key>\S+)\s+(?P<segment_routing_value>.+)$')
+            m = p2.match(line)
+            if m:
+                router_isis_dict['isis'][isis_name]['segment_routing'][m.groupdict()['segment_routing_key'].replace('-', '_')] = m.groupdict()['segment_routing_value']
+                continue
+            
+            # lsp-gen-interval maximum-wait 8000 initial-wait 1 secondary-wait 250
+            p3 = re.compile(r'^\s*lsp-gen-interval\s+(?P<lsp_gen_interval>.+)$')
+            m = p3.match(line)
+            if m:
+                lsp_gen_interval = m.groupdict()['lsp_gen_interval']
+                pattern = re.compile('(\S+-wait)\s([0-9]+)')
+                matches = pattern.findall(lsp_gen_interval)
+                lsp_gen_pairs = {key.replace('-', '_'):val for key,val in matches}
+                router_isis_dict['isis'][isis_name]['lsp_gen_interval'] = lsp_gen_pairs
+                continue
+            
+            # address-family ipv4 unicast 
+            p4 = re.compile(r'^\s*address-family\s+(?P<address_family>.+)$')
+            m = p4.match(line)
+            if m:
+                is_address_family = True
+                address_family = m.groupdict()['address_family'].replace(' ', '_')
+                if not is_interface:
+                    router_isis_dict['isis'][isis_name]['address_family'][address_family] = {}
+                if is_interface:
+                    router_isis_dict['isis'][isis_name]['interfaces'][interface]['address_family'] = {address_family: {}}
+                continue
+            
+            # interface Bundle-Ether2
+            p5 = re.compile(r'^\s*interface\s+(?P<interface>\S+)\s*$')
+            m = p5.match(line)
+            if m:
+                is_interface = True
+                interface = m.groupdict()['interface']
+                router_isis_dict['isis'][isis_name]['interfaces'][interface] = {}
+                continue
+            
+            # Parsers for Interface Only
+            if is_interface:
+                # interface Bundle-Ether2
+                i1 = re.compile(r'^\s*bfd\s+(?P<bfd_key>\S+)\s+(?P<bfd_value>.+)$')
+                m = i1.match(line)
+                if m:
+                    if not 'bfd' in router_isis_dict['isis'][isis_name]['interfaces'][interface]:
+                        router_isis_dict['isis'][isis_name]['interfaces'][interface]['bfd'] = {}
+                    router_isis_dict['isis'][isis_name]['interfaces'][interface]['bfd'][m.groupdict()['bfd_key'].replace('-', '_')] = m.groupdict()['bfd_value']
+                    continue
+                # passive
+                i1 = re.compile(r'^\s*(?P<other>[^\s!]+)\s*$')
+                m = i1.match(line)
+                if m:
+                    if not 'other' in router_isis_dict['isis'][isis_name]['interfaces'][interface]:
+                        router_isis_dict['isis'][isis_name]['interfaces'][interface]['other'] = []
+                    router_isis_dict['isis'][isis_name]['interfaces'][interface]['other'].append(m.groupdict()['other'])
+                    continue
+            # End Parsers for Interface Only
+            
+            # Generic, catch all key/value
+            # Skip if isis_name has not been found yet - skip timestamp value
+            if not isis_name == None:
+                p9 = re.compile(r'^\s*(?P<generic_key>\S+)\s+(?P<generic_value>.+)$')
+                m = p9.match(line)
+                if m:
+                    if not is_interface:
+                        router_isis_dict['isis'][isis_name][m.groupdict()['generic_key'].replace('-', '_')] = m.groupdict()['generic_value']
+                        continue
+                    if is_interface:
+                        router_isis_dict['isis'][isis_name]['interfaces'][interface][m.groupdict()['generic_key'].replace('-', '_')] = m.groupdict()['generic_value']
+                        continue
+        
+        return router_isis_dict


### PR DESCRIPTION
Some iosxr show commands are not supported in Version 19.0.1
Add parsers for the following show commands

A  src/genie/libs/parser/iosxr/show_isis.py
 * show isis adjacency
 * show isis neighbors

A  src/genie/libs/parser/iosxr/show_mpls.py
 * show mpls ldp neighbor brief

M  src/genie/libs/parser/iosxr/show_mrib.py
 * show mrib vrf <vrf> <address-family> route summary

M  src/genie/libs/parser/iosxr/show_platform.py
 * show install inactive summary
 * show install commit summary

A  src/genie/libs/parser/iosxr/show_run.py
 * show run key chain
 * show run router isis