### PR TITLE
Corrections for ShowInterfacesSwitchport Class

### DIFF
--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -1331,7 +1331,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
 
             # Access Mode VLAN: 1 (default)
             p8 =  re.compile(r'^Access +Mode +VLAN: +(?P<access_vlan>[\d\-]+)'
-                              '( *\((?P<dummy>\w+)\))?$')
+                              '( *\((?P<access_vlan_name>\w+)\))?$')
             m = p8.match(line)
             if m:
                 ret_dict[intf]['access_vlan'] = m.groupdict()['access_vlan']
@@ -1340,7 +1340,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
 
             # Trunking Native Mode VLAN: 1 (default)
             p9 =  re.compile(r'^Trunking +Native +Mode +VLAN: +(?P<native_vlan>[\d\-]+)'
-                              '( *\((?P<dummy>\w+)\))?$')
+                              '( *\((?P<native_vlan_name>\w+)\))?$')
             m = p9.match(line)
             if m:
                 if 'encapsulation' not in ret_dict[intf]:

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -1187,9 +1187,11 @@ class ShowInterfacesSwitchportSchema(MetaParser):
                         Optional('administrative_encapsulation'): str,
                         Optional('operational_encapsulation'): str,
                         Optional('native_vlan'): str,
+                        Optional('native_vlan_name'): str,
                     },
                     Optional('negotiation_of_trunk'): bool,
                     Optional('access_vlan'): str,
+                    Optional('access_vlan_name'): str,
                     Optional('native_vlan_tagging'): bool,
                     Optional('private_vlan'): {
                         Optional('host_association'): str,
@@ -1333,6 +1335,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
             m = p8.match(line)
             if m:
                 ret_dict[intf]['access_vlan'] = m.groupdict()['access_vlan']
+                ret_dict[intf]['access_vlan_name'] = m.groupdict()['access_vlan_name']
                 continue
 
             # Trunking Native Mode VLAN: 1 (default)
@@ -1343,6 +1346,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
                 if 'encapsulation' not in ret_dict[intf]:
                     ret_dict[intf]['encapsulation'] = {}
                 ret_dict[intf]['encapsulation']['native_vlan'] = m.groupdict()['native_vlan']
+                ret_dict[intf]['encapsulation']['native_vlan_name'] = m.groupdict()['native_vlan_name']
                 continue
 
             # Administrative Native VLAN tagging: enabled

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -1331,7 +1331,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
 
             # Access Mode VLAN: 1 (default)
             p8 =  re.compile(r'^Access +Mode +VLAN: +(?P<access_vlan>[\d\-]+)'
-                              '( *\((?P<access_vlan_name>\w+)\))?$')
+                              '( *\((?P<access_vlan_name>.*)\))?$')
             m = p8.match(line)
             if m:
                 ret_dict[intf]['access_vlan'] = m.groupdict()['access_vlan']
@@ -1340,7 +1340,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
 
             # Trunking Native Mode VLAN: 1 (default)
             p9 =  re.compile(r'^Trunking +Native +Mode +VLAN: +(?P<native_vlan>[\d\-]+)'
-                              '( *\((?P<native_vlan_name>\w+)\))?$')
+                              '( *\((?P<native_vlan_name>.*)\))?$')
             m = p9.match(line)
             if m:
                 if 'encapsulation' not in ret_dict[intf]:


### PR DESCRIPTION
Corrected regex for VLAN names to allow special characters and save 
matched name in ShowInterfacesSwitchport class

Added handling for invisible characters at front of string for
ShowInterfacesSwitchport class