### PR TITLE
Added IOS/IOS-XE parser for 'show vtp password'

### DIFF
--- a/src/genie/libs/parser/ios/show_vtp.py
+++ b/src/genie/libs/parser/ios/show_vtp.py
@@ -12,6 +12,15 @@ from genie.metaparser import MetaParser
 
 # import iosxe parser
 from genie.libs.parser.iosxe.show_vtp import ShowVtpStatus as ShowVtpStatus_iosxe
+from genie.libs.parser.iosxe.show_vtp import ShowVtpPassword as ShowVtpPassword_iosxe
+
+
+# =============================================
+# Parser for 'show vtp password'
+# =============================================
+class ShowVtpPassword(ShowVtpPassword_iosxe):
+    """Parser for show vtp password"""
+    pass
 
 
 # =============================================

--- a/src/genie/libs/parser/ios/tests/test_show_vtp.py
+++ b/src/genie/libs/parser/ios/tests/test_show_vtp.py
@@ -10,6 +10,57 @@ from genie.metaparser.util.exceptions import SchemaEmptyParserError, \
                                        SchemaMissingKeyError
 # Parser
 from genie.libs.parser.ios.show_vtp import ShowVtpStatus
+from genie.libs.parser.ios.show_vtp import ShowVtpPassword
+
+
+# ============================================
+# Parser for 'show vtp password'
+# ============================================
+class test_show_vtp_password(unittest.TestCase):
+
+    device = Device(name='aDevice')
+    empty_output = {'execute.return_value': ''}
+
+    golden_parsed_output = {
+        "vtp": {
+            "configured": False,
+        }
+    }
+
+    golden_output = {'execute.return_value': '''\
+        The VTP password is not configured.
+    '''}
+
+    golden_parsed_output_2 = {
+        "vtp": {
+            "configured": True,
+            "password": 'testing',
+        }
+    }
+
+    golden_output_2 = {'execute.return_value': '''\
+        VTP Password: testing
+    '''}
+
+    def test_empty(self):
+        self.device1 = Mock(**self.empty_output)
+        obj = ShowVtpPassword(device=self.device1)
+        with self.assertRaises(SchemaEmptyParserError):
+            parsed_output = obj.parse()
+
+    def test_golden(self):
+        self.device = Mock(**self.golden_output)
+        obj = ShowVtpPassword(device=self.device)
+        parsed_output = obj.parse()
+        self.maxDiff = None
+        self.assertEqual(parsed_output,self.golden_parsed_output)
+
+    def test_golden_2(self):
+        self.device = Mock(**self.golden_output_2)
+        obj = ShowVtpPassword(device=self.device)
+        parsed_output_2 = obj.parse()
+        self.maxDiff = None
+        self.assertEqual(parsed_output_2,self.golden_parsed_output_2)
 
 
 # ============================================

--- a/src/genie/libs/parser/iosxe/tests/test_show_vtp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_vtp.py
@@ -10,7 +10,57 @@ from genie.metaparser.util.exceptions import SchemaEmptyParserError, \
                                        SchemaMissingKeyError
 
 # Parser
-from genie.libs.parser.iosxe.show_vtp import ShowVtpStatus
+from genie.libs.parser.iosxe.show_vtp import ShowVtpStatus, \
+                                        ShowVtpPassword
+
+# ============================================
+# Parser for 'show vtp password'
+# ============================================
+class test_show_vtp_password(unittest.TestCase):
+
+    device = Device(name='aDevice')
+    empty_output = {'execute.return_value': ''}
+
+    golden_parsed_output = {
+        "vtp": {
+            "configured": False,
+        }
+    }
+
+    golden_output = {'execute.return_value': '''\
+        The VTP password is not configured.
+    '''}
+
+    golden_parsed_output_2 = {
+        "vtp": {
+            "configured": True,
+            "password": 'testing',
+        }
+    }
+
+    golden_output_2 = {'execute.return_value': '''\
+        VTP Password: testing
+    '''}
+
+    def test_empty(self):
+        self.device1 = Mock(**self.empty_output)
+        obj = ShowVtpPassword(device=self.device1)
+        with self.assertRaises(SchemaEmptyParserError):
+            parsed_output = obj.parse()
+
+    def test_golden(self):
+        self.device = Mock(**self.golden_output)
+        obj = ShowVtpPassword(device=self.device)
+        parsed_output = obj.parse()
+        self.maxDiff = None
+        self.assertEqual(parsed_output,self.golden_parsed_output)
+
+    def test_golden_2(self):
+        self.device = Mock(**self.golden_output_2)
+        obj = ShowVtpPassword(device=self.device)
+        parsed_output_2 = obj.parse()
+        self.maxDiff = None
+        self.assertEqual(parsed_output_2,self.golden_parsed_output_2)
 
 
 # ============================================


### PR DESCRIPTION
Added parser for `show vtp password`

**Schema:**
```
{
  'vtp': {
     'configured': <class 'bool'>,
     Optional (str) 'password': <class 'str'>,
  }
}
```

This simple parser allows for checking whether a VTP password is configured and what the contents of the password string returned is (if configured).