### PR TITLE
Improve parsing of 'show cdp neighbors' for IOS XE

### DIFF
--- a/src/genie/libs/parser/iosxe/show_cdp.py
+++ b/src/genie/libs/parser/iosxe/show_cdp.py
@@ -52,14 +52,15 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
             out = output
 
         # Capability Codes: R - Router, T - Trans Bridge, B - Source Route Bridge
-        #                   S - Switch, H - Host, I - IGMP, r - Repeater
+        #                   S - Switch, H - Host, I - IGMP, r - Repeater, P - Phone,
+        #                   D - Remote, C - CVTA, M - Two-port Mac Relay
 
         # Specifically for situations when Platform and Port Id are concatenated        
         # RX-SWV.cisco.com Fas 0/1            167         T S       WS-C3524-XFas 0/13
         # C2950-1          Fas 0/0            148         S I       WS-C2950T-Fas 0/15
         p1 = re.compile(r'^(?P<device_id>\S+) +'
                          '(?P<local_interface>[a-zA-Z]+[\s]*[\d\/\.]+) +'
-                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIr\s]+) +'
+                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIrPDCM\s]+) +'
                          '(?P<platform>\S+)'
                          '(?P<port_id>(Fa|Gi|GE).\s*\d*\/*\d*)$')
 
@@ -67,17 +68,21 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
         # R5.cisco.com Gig 0/0 125 R B Gig 0/0
         p2 = re.compile(r'^(?P<device_id>\S+) +'
                          '(?P<local_interface>[a-zA-Z]+[\s]*[\d\/\.]+) +'
-                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIr\s]+)'
+                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIrPDCM\s]+)'
                          '(?: +(?P<platform>[\w\-]+) )? +'
                          '(?P<port_id>[a-zA-Z0-9\/\s]+)$')
 
         # device6 Gig 0 157 R S I C887VA-W-W Gi 0
         p3 = re.compile(r'^(?P<device_id>\S+) +'
                          '(?P<local_interface>[a-zA-Z]+[\s]*[\d\/\.]+) +'
-                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIr\s]+) +'
+                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIrPDCM\s]+) +'
                          '(?P<platform>\S+) (?P<port_id>[a-zA-Z0-9\/\s]+)$')
 
-        
+        # p4 and p5 for two-line output, where device id is on a separate line
+        p4 = re.compile(r'^(?P<device_id>\S+)$')
+        p5 = re.compile(r'(?P<local_interface>[a-zA-Z]+[\s]*[\d/.]+) +'
+                        r'(?P<hold_time>\d+) +(?P<capability>[RTBSHIrPDCM\s]+) +'
+                        r'(?P<platform>\S+) (?P<port_id>[a-zA-Z0-9/\s]+)$')
 
         device_id_index = 0
         parsed_dict = {}
@@ -112,6 +117,39 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
 
                 device_dict['port_id'] = Common.convert_intf_name\
                     (intf=group['port_id'].strip())
+                continue
+
+            result = p4.match(line)
+            if result:
+                group = result.groupdict()
+                if 'Eth' not in group['device_id']:
+                    device_id_index += 1
+                    device_dict = parsed_dict.setdefault('cdp', {}) \
+                        .setdefault('index', {}).setdefault(device_id_index, {})
+                    device_dict['device_id'] = group['device_id'].strip()
+                else:
+                    device_dict['port_id'] = Common \
+                        .convert_intf_name(intf=group['device_id'].strip())
+                continue
+
+            result = p5.match(line)
+            if result:
+                group = result.groupdict()
+                device_dict = parsed_dict.setdefault('cdp', {}) \
+                    .setdefault('index', {}).setdefault(device_id_index, {})
+                device_dict['local_interface'] = Common \
+                    .convert_intf_name(intf=group['local_interface'].strip())
+                device_dict['hold_time'] = int(group['hold_time'])
+                device_dict['capability'] = group['capability'].strip()
+                if group['platform']:
+                    device_dict['platform'] = group['platform'].strip()
+                elif not group['platform']:
+                    device_dict['platform'] = ''
+
+                device_dict['port_id'] = Common \
+                    .convert_intf_name(intf=group['port_id'].strip())
+                continue
+
         if device_id_index:
             parsed_dict.setdefault('cdp', {}).\
                 setdefault('index', devices_dict_info)

--- a/src/genie/libs/parser/iosxe/tests/test_show_cdp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_cdp.py
@@ -182,6 +182,30 @@ class test_show_cdp_neighbors(unittest.TestCase):
         device5      Eth 0            164                  7206      Eth 1/0
     '''}
 
+    expected_parsed_output_5 = {
+        'cdp': {
+            'index': {
+                1: {
+                    'capability': 'R S C',
+                    'device_id': 'Device_With_A_Particularly_Long_Name',
+                    'hold_time': 134,
+                    'local_interface': 'GigabitEthernet1',
+                    'platform': 'N9K-9000v',
+                    'port_id': 'Ethernet0/0'}
+            }
+        }
+    }
+
+    device_output_5 = {'execute.return_value': '''
+        Capability Codes: R - Router, T - Trans Bridge, B - Source Route Bridge
+                      S - Switch, H - Host, I - IGMP, r - Repeater, P - Phone,
+                      D - Remote, C - CVTA, M - Two-port Mac Relay
+
+        Device ID        Local Intrfce     Holdtme    Capability  Platform  Port ID
+        Device_With_A_Particularly_Long_Name
+                         Gig 1             134             R S C  N9K-9000v Eth 0/0
+    '''}
+
     def test_show_cdp_neighbors_1(self):
         self.maxDiff = None
         self.device = Mock(**self.device_output_1)
@@ -209,6 +233,13 @@ class test_show_cdp_neighbors(unittest.TestCase):
         obj = ShowCdpNeighbors(device=self.device)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.expected_parsed_output_4)
+
+    def test_show_cdp_neighbors_5(self):
+        self.maxDiff = None
+        self.device = Mock(**self.device_output_5)
+        obj = ShowCdpNeighbors(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.expected_parsed_output_5)
 
     def test_show_cdp_neighbors_empty_output(self):
         self.maxDiff = None


### PR DESCRIPTION
Support output where device ID is on a separate line (similar to NXOS)