### PR TITLE
NXOS 'show cdp': handle 3-line output

### DIFF
--- a/src/genie/libs/parser/nxos/show_cdp.py
+++ b/src/genie/libs/parser/nxos/show_cdp.py
@@ -92,7 +92,15 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
         p5 = re.compile(r'^(?P<device_id>\S+) +'
                         '(?P<local_interface>[a-zA-Z]+[\s]*[\d\/\.]+) +'
                         '(?P<hold_time>\d+) +(?P<capability>[RTBSHIVDrs\s]+) +'
-                        '(?P<platform>[\S\s]+)$')        
+                        '(?P<platform>[\S\s]+)$')
+
+        # p3, p6, p3 (again) when device id AND port id are on separate lines
+        # 1111-2222-3333
+        #               Eth1/30        156    R         ASR9K Series
+        #                                            Ten-GigabitEthernet2/0/30
+        p6 = re.compile(r'^(?P<local_interface>[a-zA-Z]+[\s]*[\d\/\.]+) +'
+                        r'(?P<hold_time>\d+)\s+(?P<capability>[RTBSHIVDrs\s]+)\s+'
+                        r'(?P<platform>.+)$')
 
         device_id_index = 0
 
@@ -132,14 +140,21 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
             result = p3.match(line)
             if result:
                 group = result.groupdict()
-                if 'Eth' not in group['device_id']:
+                # NOTE:
+                # this detection of whether p3 matched a device id or port ID
+                # is rather error prone.
+                if 'Eth' not in group['device_id'] and '/' not in group['device_id']:
                     device_id_index += 1
                     device_dict = parsed_dict.setdefault('cdp', {})\
                         .setdefault('index', {}).setdefault(device_id_index, {})
                     device_dict['device_id'] = group['device_id'].strip()
                 else:
+                    device_dict = parsed_dict.setdefault('cdp', {}) \
+                        .setdefault('index', {}).setdefault(device_id_index, {})
+                    # Note: dict key mismatch is intentional.
+                    # p3 matches both device and port IDs.
                     device_dict['port_id'] = Common\
-                    .convert_intf_name(intf=group['device_id'].strip())
+                        .convert_intf_name(intf=group['device_id'].strip())
 
                 continue
 
@@ -171,6 +186,23 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
 
                 device_dict['device_id'] = group['device_id'].strip()
                 device_dict['local_interface'] = Common\
+                    .convert_intf_name(intf=group['local_interface'].strip())
+                device_dict['hold_time'] = int(group['hold_time'])
+                device_dict['capability'] = group['capability'].strip()
+                if group['platform']:
+                    device_dict['platform'] = group['platform'].strip()
+                elif not group['platform']:
+                    device_dict['platform'] = ''
+                continue
+
+            result = p6.match(line)
+            if result:
+                device_dict = parsed_dict.setdefault('cdp', {}) \
+                    .setdefault('index', {}).setdefault(device_id_index, {})
+
+                group = result.groupdict()
+
+                device_dict['local_interface'] = Common \
                     .convert_intf_name(intf=group['local_interface'].strip())
                 device_dict['hold_time'] = int(group['hold_time'])
                 device_dict['capability'] = group['capability'].strip()

--- a/src/genie/libs/parser/nxos/tests/test_show_cdp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_cdp.py
@@ -175,7 +175,7 @@ class test_show_cdp_neighbors(unittest.TestCase):
                     'port_id': 'Ten-GigabitEthernet2/0/20'
                 }
             }
-        }   
+        }
     }
 
     device_output_4 = {'execute.return_value': '''
@@ -202,6 +202,33 @@ class test_show_cdp_neighbors(unittest.TestCase):
                                                                Ten-GigabitEthernet2/0/20
         
     '''}
+
+    expected_parsed_output_5 = {
+        'cdp': {
+            'index': {
+                1: {
+                    'capability': 'R',
+                    'device_id': '1111-2222-77777',
+                    'hold_time': 172,
+                    'local_interface': 'Ethernet1/5',
+                    'platform': 'NCS-6000',
+                    'port_id': 'HundredGigE0/4/0/6'
+                },
+            }
+        }
+    }
+
+    device_output_5 = {'execute.return_value': '''
+        Capability Codes: R - Router, T - Trans-Bridge, B - Source-Route-Bridge
+                          S - Switch, H - Host, I - IGMP, r - Repeater,
+                          V - VoIP-Phone, D - Remotely-Managed-Device,
+                          s - Supports-STP-Dispute
+
+        Device-ID          Local Intrfce  Hldtme Capability  Platform      Port ID
+        1111-2222-77777
+                    Eth1/5         172    R         NCS-6000
+                                                              HundredGigE0/4/0/6
+        '''}
 
     empty_device_output = {'execute.return_value': '''
         Device# show cdp neighbors
@@ -240,6 +267,13 @@ class test_show_cdp_neighbors(unittest.TestCase):
         obj = ShowCdpNeighbors(device=self.device)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.expected_parsed_output_4)
+
+    def test_show_cdp_neighbors_5(self):
+        self.maxDiff = None
+        self.device = Mock(**self.device_output_5)
+        obj = ShowCdpNeighbors(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.expected_parsed_output_5)
 
     def test_show_cdp_neighbors_empty_output(self):
         self.maxDiff = None


### PR DESCRIPTION
Handle the case where both device ID and port ID appear on separate
lines.

As a side effect of making my test case pass, updated disambiguation
logic for whether the match is a device ID vs port ID.