### PR TITLE
fixed IOS-XE reference in junos parser comment

### DIFF
--- a/src/genie/libs/parser/junos/show_ospf.py
+++ b/src/genie/libs/parser/junos/show_ospf.py
@@ -1,7 +1,8 @@
 ''' show_ospf.py
 
-IOSXE parsers for the following show commands:
+JunOS parsers for the following show commands:
 
+    * show ospf interface brief instance {instance}
     * show ospf interface brief
 
 '''


### PR DESCRIPTION
minor fix to change reference to IOS-XE in Junos parser ;-)