### PR TITLE
Fix `out referenced before assignment` in NX-OS `show access-lists`

### DIFF
--- a/src/genie/libs/parser/nxos/show_acl.py
+++ b/src/genie/libs/parser/nxos/show_acl.py
@@ -130,6 +130,8 @@ class ShowAccessLists(ShowAccessListsSchema):
             else:
                 cmd = self.cli_command[0]
             out = self.device.execute(cmd)
+        else:
+            out = output
 
         # IP access list acl_name
         # IP access list test22


### PR DESCRIPTION
When the `output` variable is passed to the `cli` function for the `ShowAccessLists` class, an exception is raised because `out` is never assigned.  This fixes that to set `out` to the value of `output` when `output` is passed, which matches other classes/show commands.