### PR TITLE
Fix port role parsing

### DIFF
--- a/src/genie/libs/parser/iosxe/show_spanning_tree.py
+++ b/src/genie/libs/parser/iosxe/show_spanning_tree.py
@@ -887,7 +887,8 @@ class ShowSpanningTree(ShowSpanningTreeSchema):
                 'Desg': 'designated',
                 'Root': 'root',
                 'BLK': 'blocking',
-                'Altn': 'alternate',}
+                'Altn': 'alternate',
+                'Back': 'backup'}
     cli_command = ['show spanning-tree vlan {vlan}','show spanning-tree mst {mst}','show spanning-tree']
 
     def cli(self, mst='', vlan='',output=None):


### PR DESCRIPTION
The backup port role was missing from ROLE_MAP which led to KeyError on line 1006.
Example cli output:
```
Interface           Role Sts Cost      Prio.Nbr Type
------------------- ---- --- --------- -------- --------------------------------
Te5/4               Desg FWD 2         128.516  P2p 
Te5/5               Desg FWD 2         128.517  P2p 
Te9/1               Back BLK 2         128.1025 P2p 
Te9/3               Desg FWD 2         128.1027 P2p Peer(STP) 
Te9/4               Desg FWD 2         128.1028 P2p Peer(STP) 
```