### PR TITLE
 Issue parsing platform, capabilities and port-id from 'show cdp neighbors detail' on ios / iosxe devices

### DIFF
--- a/src/genie/libs/parser/iosxe/show_cdp.py
+++ b/src/genie/libs/parser/iosxe/show_cdp.py
@@ -168,7 +168,7 @@ class ShowCdpNeighborsDetailSchema(MetaParser):
             {Any():
                 {'device_id': str,
                  'platform': str,
-                 'capabilities': str,
+                 Optional('capabilities'): str,
                  'local_interface': str,
                  'port_id': str,
                  'hold_time': int,
@@ -209,8 +209,8 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
         # Platform: N9K_9000v,  Capabilities: Router Switch Two-port phone port
         # Platform: cisco WS_C6506_E,  Capabilities: Router Switch-6506 IGMP
         # Platform: cisco WS-C6506-E,  Capabilities: Router Switch_6506 IGMP
-        platf_cap_re = re.compile(r'Platform:\s+(?P<platform>[\w +(\-|\_)]+)'
-                                   '\,\s*Capabilities:\s+(?P<capabilities>[\w\s\-]+)$')
+        platf_cap_re = re.compile(r'Platform:\s+(?P<platform>[\w +(\-|\_\/)]+)'
+                                   '(\,\s*Capabilities:\s+(?P<capabilities>[\w\s\-]+))?$')
 
         # Interface: GigabitEthernet0/0,  Port ID (outgoing port): mgmt0
         # Interface: Ethernet0/1,  Port ID (outgoing port): Ethernet0/1
@@ -219,7 +219,7 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
         interface_port_re = re.compile(r'Interface:\s*'
                                       '(?P<interface>[\w\s\-\/\/]+)\s*\,'
                                       '*\s*Port\s*ID\s*[\(\w\)\s]+:\s*'
-                                      '(?P<port_id>\S+)')
+                                      '(?P<port_id>\S+\s*\w*$)')
 
         # Native VLAN: 42
         native_vlan_re = re.compile(r'Native\s*VLAN\s*:\s*'
@@ -297,8 +297,12 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
             if result:
                 platf_cap_dict = result.groupdict()
 
-                devices_dict['capabilities'] = \
-                    platf_cap_dict['capabilities']
+                if platf_cap_dict['capabilities'] is not None:
+                    devices_dict['capabilities'] = \
+                        platf_cap_dict['capabilities']
+                else:
+                    devices_dict['capabilities'] = ''
+
                 devices_dict['platform'] = \
                     platf_cap_dict['platform']
 

--- a/src/genie/libs/parser/iosxe/tests/test_show_cdp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_cdp.py
@@ -562,6 +562,89 @@ class test_show_cdp_neighbors_detail(unittest.TestCase):
         Total cdp entries displayed : 2
     '''}
 
+    device_output_6 = {'execute.return_value': '''
+        Device# show cdp neighbors detail
+        Device ID: e0553d849f1a
+        Entry address(es):
+          IP address: 10.0.0.7
+        Platform: Meraki MV21 Cloud Managed Indoor HD Dom
+        Interface: GigabitEthernet3/0/29,  Port ID (outgoing port): Port 0
+        Holdtime : 145 sec
+
+        Version :
+        1
+
+        advertisement version: 2
+        Power drawn: 0.000 Watts
+        Power request id: 31314, Power management id: 0
+        Power request levels are:15400 0 0 0 0
+
+        -------------------------
+        Device ID: System1
+        Entry address(es):
+          IP address: 10.0.0.8
+        Platform: cisco ISR4351/K9,  Capabilities: Router Switch IGMP
+        Interface: GigabitEthernet1/0/47,  Port ID (outgoing port): GigabitEthernet0/0/2
+        Holdtime : 129 sec
+
+        Version :
+        Cisco IOS Software [Fuji], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.9.4, RELEASE SOFTWARE (fc2)
+        Technical Support: http://www.cisco.com/techsupport
+        Copyright (c) 1986-2019 by Cisco Systems, Inc.
+        Compiled Thu 22-Aug-19 18:09 by mcpre
+
+        advertisement version: 2
+        VTP Management Domain: ''
+        Duplex: full
+        Management address(es):
+          IP address: 10.0.0.8
+
+        Total cdp entries displayed : 2
+    '''}
+
+    expected_parsed_output_6 = {
+        'total_entries_displayed': 2,
+        'index': {
+            1: {
+                'device_id': 'e0553d849f1a',
+                'duplex_mode': '',
+                'vtp_management_domain': '',
+                'native_vlan': '',
+                'management_addresses': {},
+                'entry_addresses': {
+                    '10.0.0.7': {}
+                },
+                'capabilities': '',
+                'platform': 'Meraki MV21 Cloud Managed Indoor HD Dom',
+                'port_id': 'Port 0',
+                'local_interface': 'GigabitEthernet3/0/29',
+                'hold_time': 145,
+                'software_version': '1',
+                'advertisement_ver': 2},
+            2: {
+                'device_id': 'System1',
+                'duplex_mode': 'full',
+                'vtp_management_domain': ' ',
+                'native_vlan': '',
+                'management_addresses': {
+                    '10.0.0.8': {}
+                },
+                'entry_addresses': {
+                    '10.0.0.8': {}
+                },
+                'capabilities': 'Router Switch IGMP',
+                'platform': 'cisco ISR4351/K9',
+                'port_id': 'GigabitEthernet0/0/2',
+                'local_interface': 'GigabitEthernet1/0/47',
+                'hold_time': 129,
+                'software_version': 'Cisco IOS Software [Fuji], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.9.4, RELEASE SOFTWARE (fc2)\n'
+                                    'Technical Support: http://www.cisco.com/techsupport\n'
+                                    'Copyright (c) 1986-2019 by Cisco Systems, Inc.\n'
+                                    'Compiled Thu 22-Aug-19 18:09 by mcpre',
+                'advertisement_ver': 2},
+        },
+    }
+
     def test_show_cdp_neighbors_detail_1(self):
         self.maxDiff = None
         self.device = Mock(**self.device_output_1)
@@ -596,6 +679,13 @@ class test_show_cdp_neighbors_detail(unittest.TestCase):
         obj = ShowCdpNeighborsDetail(device=self.device)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.expected_parsed_output_5)
+
+    def test_show_cdp_neighbors_detail_missing_capabilities(self):
+        self.maxDiff = None
+        self.device = Mock(**self.device_output_6)
+        obj = ShowCdpNeighborsDetail(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.expected_parsed_output_6)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I'm sorry I managed to fail to rebase my pull requests properly, so I closed the old ones and reopen them.

* We encountered some issues with Meraki devices having no capabilities and whitespaces in the Port ID, like:
```
Device ID: e0553d849f1a
Entry address(es):
          IP address: 10.0.0.7
Platform: Meraki MV21 Cloud Managed Indoor HD Dom
Interface: GigabitEthernet3/0/29,  Port ID (outgoing port): Port 0
Holdtime : 145 sec
```

or devices with a slash in the platform description:

```
Device ID: System1
Entry address(es):
          IP address: 10.0.0.8
Platform: cisco ISR4351/K9,  Capabilities: Router Switch IGMP
Interface: GigabitEthernet1/0/47,  Port ID (outgoing port): GigabitEthernet0/0/2
Holdtime : 129 sec
```

Therefore I propose to make the regex part handling the capabilities optional as well as the capabilities filed in the schema. Also changing the platform regex part to support slashes.

On Meraki devices we also had issues parsing the port id correctly, because of a white space. I changed regex to support white spaces as well.

* Also added a test, testing both cases:
![test_show_cdp_neighbors_detail](https://user-images.githubusercontent.com/32892378/73969856-6e7fc280-491c-11ea-84fd-d42be7f5a3db.jpg)
