### PR TITLE
Show lldp issues

### DIFF
--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -174,7 +174,7 @@ class ShowLldpEntry(ShowLldpEntrySchema):
         p1 = re.compile(r'^Local\s+Intf:\s+(?P<intf>[\w\/\.\-]+)$')
 
         # Port id: Gi1/0/4
-        p1_1 = re.compile(r'^Port\s+id:\s+(?P<port_id>\S+)$')
+        p1_1 = re.compile(r'^Port\s+id:\s+(?P<port_id>[\S\s]+)$')
 
         # Chassis id: 843d.c638.b980
         p2 = re.compile(r'^Chassis\s+id:\s+(?P<chassis_id>[\w\.]+)$')

--- a/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
@@ -1472,6 +1472,142 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
     'total_entries': 1,
 }
 
+    device_output_1 = {'execute.return_value': '''\
+            ------------------------------------------------
+            Local Intf: Gi4/0/38
+            Chassis id: 10.0.0.7
+            Port id: F8B7E2958F6F:P1
+            Port Description: SW PORT
+            System Name: SEPF8B7E29
+            
+            System Description:
+            Cisco IP Phone 8865, V1, sip8845_65.12-1-1SR1-4.loads
+            
+            Time remaining: 178 seconds
+            System Capabilities: B,T
+            Enabled Capabilities: B,T
+            Management Addresses:
+                IP: 10.0.0.7
+            Auto Negotiation - supported, enabled
+            Physical media capabilities:
+                1000baseT(FD)
+                100base-TX(FD)
+                100base-TX(HD)
+                10base-T(FD)
+                10base-T(HD)
+            Media Attachment Unit type: 30
+            Vlan ID: - not advertised
+            ------------------------------------------------
+            Local Intf: Gi4/0/15
+            Chassis id: 10.0.0.8
+            Port id: CC5A5363E4F6:P1
+            Port Description: SW PORT
+            System Name: SEPCC5A536
+            
+            System Description:
+            Cisco IP Phone 8845, V1, sip8845_65.12-5-1SR1-4.loads
+            
+            Time remaining: 124 seconds
+            System Capabilities: B,T
+            Enabled Capabilities: B,T
+            Management Addresses:
+                IP: 10.0.0.8
+            Auto Negotiation - supported, enabled
+            Physical media capabilities:
+                1000baseT(FD)
+                100base-TX(FD)
+                100base-TX(HD)
+                10base-T(FD)
+                10base-T(HD)
+            Media Attachment Unit type: 30
+            Vlan ID: - not advertised
+            Total entries displayed: 2
+        '''}
+
+    expected_parsed_output_1 = {
+        'interfaces': {
+            'GigabitEthernet4/0/38': {
+                'if_name': 'GigabitEthernet4/0/38',
+                'port_id': {
+                    'F8B7E2958F6F:P1': {
+                        'neighbors': {
+                            'SEPF8B7E29': {
+                                'neighbor_id': 'SEPF8B7E29',
+                                'chassis_id': '10.0.0.7',
+                                'port_id': 'F8B7E2958F6F:P1',
+                                'system_name': 'SEPF8B7E29',
+                                'system_description': '',
+                                'time_remaining': 178,
+                                'capabilities': {
+                                    'mac_bridge': {
+                                        'name': 'mac_bridge',
+                                        'system': True,
+                                        'enabled': True
+                                    },
+                                    'telephone': {
+                                        'name': 'telephone',
+                                        'system': True,
+                                        'enabled': True
+                                    }
+                                },
+                                'management_address': '10.0.0.7',
+                                'auto_negotiation': 'supported, enabled',
+                                'physical_media_capabilities': [
+                                    '1000baseT(FD)',
+                                    '100base-TX(FD)',
+                                    '100base-TX(HD)',
+                                    '10base-T(FD)',
+                                    '10base-T(HD)'
+                                ],
+                                'unit_type': 30
+                            }
+                        }
+                    }
+                }
+            },
+            'GigabitEthernet4/0/15': {
+                'if_name': 'GigabitEthernet4/0/15',
+                'port_id': {
+                    'CC5A5363E4F6:P1': {
+                        'neighbors': {
+                            'SEPCC5A536': {
+                                'neighbor_id': 'SEPCC5A536',
+                                'chassis_id': '10.0.0.8',
+                                'port_id': 'CC5A5363E4F6:P1',
+                                'system_name': 'SEPCC5A536',
+                                'system_description': '',
+                                'time_remaining': 124,
+                                'capabilities': {
+                                    'mac_bridge': {
+                                        'name': 'mac_bridge',
+                                        'system': True,
+                                        'enabled': True
+                                    },
+                                    'telephone': {
+                                        'name': 'telephone',
+                                        'system': True,
+                                        'enabled': True
+                                    }
+                                },
+                                'management_address': '10.0.0.8',
+                                'auto_negotiation': 'supported, enabled',
+                                'physical_media_capabilities': [
+                                    '1000baseT(FD)',
+                                    '100base-TX(FD)',
+                                    '100base-TX(HD)',
+                                    '10base-T(FD)',
+                                    '10base-T(HD)'
+                                ],
+                                'unit_type': 30
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        'total_entries': 2
+    }
+
     def test_empty(self):
         self.dev1 = Mock(**self.empty_output)
         obj = ShowLldpNeighborsDetail(device=self.dev1)
@@ -1491,6 +1627,12 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
         obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output_2)
+    def test_show_lldp_neighbors_detail_colon_in_port_id(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.device_output_1)
+        obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output,self.expected_parsed_output_1)
 
 
 class test_show_lldp_traffic(unittest.TestCase):

--- a/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
@@ -1535,8 +1535,9 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
                                 'neighbor_id': 'SEPF8B7E29',
                                 'chassis_id': '10.0.0.7',
                                 'port_id': 'F8B7E2958F6F:P1',
+                                'port_description': 'SW PORT',
                                 'system_name': 'SEPF8B7E29',
-                                'system_description': '',
+                                'system_description': 'Cisco IP Phone 8865, V1, sip8845_65.12-1-1SR1-4.loads\n',
                                 'time_remaining': 178,
                                 'capabilities': {
                                     'mac_bridge': {
@@ -1574,8 +1575,9 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
                                 'neighbor_id': 'SEPCC5A536',
                                 'chassis_id': '10.0.0.8',
                                 'port_id': 'CC5A5363E4F6:P1',
+                                'port_description': 'SW PORT',
                                 'system_name': 'SEPCC5A536',
-                                'system_description': '',
+                                'system_description': 'Cisco IP Phone 8845, V1, sip8845_65.12-5-1SR1-4.loads\n',
                                 'time_remaining': 124,
                                 'capabilities': {
                                     'mac_bridge': {
@@ -1627,6 +1629,7 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
         obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output_2)
+
     def test_show_lldp_neighbors_detail_colon_in_port_id(self):
         self.maxDiff = None
         self.dev_c3850 = Mock(**self.device_output_1)

--- a/src/genie/libs/parser/nxos/show_lldp.py
+++ b/src/genie/libs/parser/nxos/show_lldp.py
@@ -192,7 +192,7 @@ class ShowLldpNeighborsDetailSchema(MetaParser):
                                     }
                                 },
                                 'management_address_v4': str,
-                                'management_address_v6': str,
+                                Optional('management_address_v6'): str,
                                 Optional('system_capabilities'): str,
                                 Optional('enabled_capabilities'): str,
                                 'vlan_id': str

--- a/src/genie/libs/parser/nxos/tests/test_show_lldp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_lldp.py
@@ -598,6 +598,55 @@ class TestShowLldpNeighborsDetail(unittest.TestCase):
             'total_entries': 22
         }
 
+    device_output_1 = {'execute.return_value': '''
+              show lldp neighbors detail
+              Capability codes:
+              (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+              (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+              Device ID            Local Intf      Hold-time  Capability  Port ID  
+              Chassis id: 547f.ee44.51e1
+              Port id: mgmt:0
+              Local Port id: mgmt0
+              Port Description: mgmt0
+              System Name: System1
+              System Description: Cisco NX-OS n5000, Software (n5000-uk9), Version 7.3(2)N1(1), RELEASE SOFTWARE Copyright (c) 2002-2012, 2016-2017 by Cisco Systems, Inc. Compiled 5/12/2017 23:00:00
+              Time remaining: 116 seconds
+              System Capabilities: B
+              Enabled Capabilities: B
+              Management Address: 10.0.0.7
+              Vlan ID: not advertised
+              Total entries displayed: 1            
+              '''}
+
+    expected_parsed_output_1 = {
+        'interfaces': {
+            'mgmt0': {
+                'port_id': {
+                    'mgmt0': {
+                        'neighbors': {
+                            'System1': {
+                                'chassis_id': '547f.ee44.51e1',
+                                'port_description': 'mgmt0',
+                                'system_name': 'System1',
+                                'system_description': 'Cisco NX-OS n5000, Software (n5000-uk9), Version 7.3(2)N1(1), RELEASE SOFTWARE Copyright (c) 2002-2012, 2016-2017 by Cisco Systems, Inc. Compiled 5/12/2017 23:00:00',
+                                'time_remaining': 116,
+                                'capabilities': {
+                                    'bridge': {
+                                        'name': 'bridge',
+                                        'system': True,
+                                        'enabled': True
+                                    }
+                                },
+                                'management_address_v4': '10.0.0.7',
+                                'vlan_id': 'not advertised'
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        'total_entries': 1
+    }
 
     def test_empty(self):
         self.maxDiff = None
@@ -619,6 +668,13 @@ class TestShowLldpNeighborsDetail(unittest.TestCase):
         obj = ShowLldpNeighborsDetail(device=self.device)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.golden_parsed_output_customer)
+
+    def test_show_lldp_neighbors_detail_missing_ipv6(self):
+        self.maxDiff = None
+        self.device = Mock(**self.device_output_1)
+        obj = ShowLldpNeighborsDetail(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.expected_parsed_output_1)
 
 # =================================
 # Unit test for 'show lldp traffic'


### PR DESCRIPTION
I'm sorry I managed to fail to rebase my pull requests properly, so I closed the old ones and reopen them.

**NXOS:**

On some nxos devices we got results with no 'management_address_v6' information, like:

```
Chassis id: 547f.ee44.51e1 
Port id: mgmt:0 
Local Port id: mgmt0 
Port Description: mgmt0 
System Name: System1 
System Description: Cisco NX-OS n5000, Software (n5000-uk9), Version 7.3(2)N1(1), RELEASE SOFTWARE Copyright (c) 2002-2012, 2016-2017 by Cisco Systems, Inc. Compiled 5/12/2017 23:00:00 
Time remaining: 116 seconds 
System Capabilities: B 
Enabled Capabilities: B 
Management Address: 10.0.0.7 
Vlan ID: not advertised 
```

Because of that I propose to make the 'management_address_v6' field optional.


**IOS / IOSXE:**

On ios / iosxe devices we had issues parsing port id's containing a colon, like:

```
Port id: F8B7E2958F6F:P1
```

Because of that we changed the regex parsing the port id to the same pattern used for nxos devices, which can handle colons inside of the port id.

Also added tests, testing the cases:

NXOS
![test_show_lldp_neighbors_detail_on_nxos](https://user-images.githubusercontent.com/32892378/73970278-290fc500-491d-11ea-850e-08e79c04918c.jpg)

IOS / IOSXE
![test_show_lldp_neighbors_detail_on_iosxe](https://user-images.githubusercontent.com/32892378/73970284-2ad98880-491d-11ea-965c-34428713443d.jpg)
