### PR TITLE
Fix processing VRF names with dashes

### DIFF
--- a/src/genie/libs/parser/iosxe/show_ntp.py
+++ b/src/genie/libs/parser/iosxe/show_ntp.py
@@ -372,7 +372,7 @@ class ShowNtpConfig(ShowNtpConfigSchema):
         # ntp server vrf VRF1 10.64.4.4
         # ntp server 10.16.2.2 source Loopback0
 
-        p1 = re.compile(r"^ntp +(?P<type>\w+)( +vrf +(?P<vrf>[\d\w]+))? "
+        p1 = re.compile(r"^ntp +(?P<type>\w+)( +vrf +(?P<vrf>\S+))? "
             "+(?P<address>[\w\.\:]+)( +source +(?P<source_interface>[\w]+))?$")
 
         for line in out.splitlines():


### PR DESCRIPTION
Many common configurations use dashes as part of the VRF name.
Because of the current regular expression used to match vrf names, these VRF names will be ignored.

The fix adds the full range of special characters as valid VRF names, as this is supported on IOS.

```
ip vrf !@#$%^&*()
ntp server vrf !@#$%^&*() 1.2.3.4
```