### PR TITLE
Modified IOS/IOSXE parser for command "show interfaces status".

### DIFF
--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -3220,39 +3220,42 @@ class ShowInterfacesStatus(ShowInterfacesStatusSchema):
         else:
             out = output
 
-        result_dict = {}
+        parsed_dict = {}
 
         # Port      Name               Status       Vlan       Duplex  Speed Type
         # Gi1/2     TelenlqPOIU        notconnect   125          full    100 10/100/1000-TX
-        # Gi1/3     SE                 connected    132        a-full a-1000 10/100/1000-TX
-        # Gi1/7                        notconnect   99           auto   auto 10/100/1000-TX
-        # Gi1/10    To cft123     connected    trunk      a-full a-1000 10/100/1000-TX
+        # Gi1/1/0/1      FAST-HELLO         connected    4094       a-full a-1000 10/100/1000BaseTX
+        # Te1/1/2   VSL                connected    trunk        full  a-10G 10GBase-SR
+        # Po1       ES1SW80AUN6        connected    trunk      a-full  a-10G
 
-        p1 = re.compile(r'^(?P<interfaces>\w+\d+\/\d+)(?: +(?P<name>([\S ]+)))?'
-                        r' +(?P<status>\S+) +(?P<vlan>\S+) +(?P<duplex_code>[\S\-]+)'
-                        r' +(?P<port_speed>[\S\-]+) +(?P<type>\S+)$')
+        if out:
+            res = parsergen.oper_fill_tabular(device_output=out,
+                                              device_os='iosxe',
+                                              table_terminal_pattern=r"^\n",
+                                              header_fields=
+                                               [ "Port",
+                                                 "Name",
+                                                 "Status",
+                                                 "Vlan",
+                                                 "Duplex",
+                                                 "Speed",
+                                                 "Type"],
+                                              label_fields=
+                                              ["Interface",
+                                               "name",
+                                               "status",
+                                               "vlan",
+                                               "duplex_code",
+                                               "port_speed",
+                                               "type"],
+                                              index=[0]
+                                              )
 
-        for line in out.splitlines():
-            line = line.strip()
+            #Building the schema out of the parsergen output
+            if res.entries:
+                 for intf, intf_dict in res.entries.items():
+                     intf = Common.convert_intf_name(intf)
+                     del intf_dict['Interface']
+                     parsed_dict.setdefault('interfaces', {}).update({intf: intf_dict})
 
-            m = p1.match(line)
-            if m:
-                group = m.groupdict()
-
-                intf_dict = result_dict.setdefault('interfaces', {}).\
-                                        setdefault(Common.convert_intf_name(group['interfaces']), {})
-
-                name_val = group['name'].strip()
-                if len(name_val)>0 :
-                    intf_dict['name'] = name_val
-
-                keys = ['status',
-                        'vlan', 'duplex_code', 'port_speed',
-                        'type']
-
-                for k in keys:
-                    intf_dict[k] = group[k]
-                continue
-
-        return result_dict
-
+        return (parsed_dict)

--- a/src/genie/libs/parser/iosxe/tests/test_show_interface.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_interface.py
@@ -18931,7 +18931,7 @@ class TestShowInterfacesStatus(unittest.TestCase):
     Gi1/2     TelenlqPOIU        notconnect   125          full    100 10/100/1000-TX
     Gi1/3     SE                 connected    132        a-full a-1000 10/100/1000-TX
     Gi1/7                        notconnect   99           auto   auto 10/100/1000-TX
-    Gi1/10    To cft123     connected    trunk      a-full a-1000 10/100/1000-TX
+    Gi1/10    To cft123          connected    trunk      a-full a-1000 10/100/1000-TX
     Gi1/44                       connected    550        a-full a-1000 10/100/1000-TX
     Gi1/45    ASDFGH             connected    trunk      a-full a-1000 10/100/1000-TX
     Gi1/46                       notconnect   99           auto   auto 10/100/1000-TX
@@ -18943,17 +18943,30 @@ class TestShowInterfacesStatus(unittest.TestCase):
     Gi3/4                        notconnect   99           full   1000 No Gbic
     Gi3/5     To loedutjb234     connected    trunk        full   1000 1000BaseSX
     Gi3/6     To loedutjb345     connected    trunk        full   1000 1000BaseSX
+    Gi1/1/0/1 FAST-HELLO         connected    4094       a-full a-1000 10/100/1000BaseTX
+    Te1/1/2   VSL                connected    trunk        full  a-10G 10GBase-SR
+    Te2/1/20                     disabled     1            full   auto No XCVR
+    Te2/1/21  VSL LINK1          disabled     1            full   auto No XCVR
+    Po10      VSL LINK2          connected    trunk      a-full  a-10G
     '''}
 
     golden_parsed_interface_output1 = {
         'interfaces': {
             'GigabitEthernet1/1': {
-                'duplex_code': 'auto',
-                'name': 'To Abcde',
-                'port_speed': 'auto',
-                'status': 'notconnect',
-                'type': '10/100/1000-TX',
-                'vlan': '1',
+               'duplex_code': 'auto',
+               'name': 'To Abcde',
+               'port_speed': 'auto',
+               'status': 'notconnect',
+               'type': '10/100/1000-TX',
+               'vlan': '1'
+            },
+            'GigabitEthernet1/1/0/1': {
+               'duplex_code': 'a-full',
+               'name': 'FAST-HELLO',
+               'port_speed': 'a-1000',
+               'status': 'connected',
+               'type': '10/100/1000BaseTX',
+               'vlan': '4094'
             },
             'GigabitEthernet1/10': {
                 'duplex_code': 'a-full',
@@ -18961,30 +18974,30 @@ class TestShowInterfacesStatus(unittest.TestCase):
                 'port_speed': 'a-1000',
                 'status': 'connected',
                 'type': '10/100/1000-TX',
-                'vlan': 'trunk',
+                'vlan': 'trunk'
             },
             'GigabitEthernet1/2': {
-                'duplex_code': 'full',
-                'name': 'TelenlqPOIU',
-                'port_speed': '100',
-                'status': 'notconnect',
-                'type': '10/100/1000-TX',
-                'vlan': '125',
+               'duplex_code': 'full',
+               'name': 'TelenlqPOIU',
+               'port_speed': '100',
+               'status': 'notconnect',
+               'type': '10/100/1000-TX',
+               'vlan': '125'
             },
             'GigabitEthernet1/3': {
-                'duplex_code': 'a-full',
-                'name': 'SE',
-                'port_speed': 'a-1000',
-                'status': 'connected',
-                'type': '10/100/1000-TX',
-                'vlan': '132',
+               'duplex_code': 'a-full',
+               'name': 'SE',
+               'port_speed': 'a-1000',
+               'status': 'connected',
+               'type': '10/100/1000-TX',
+               'vlan': '132'
             },
             'GigabitEthernet1/44': {
                 'duplex_code': 'a-full',
                 'port_speed': 'a-1000',
                 'status': 'connected',
                 'type': '10/100/1000-TX',
-                'vlan': '550',
+                'vlan': '550'
             },
             'GigabitEthernet1/45': {
                 'duplex_code': 'a-full',
@@ -18992,21 +19005,21 @@ class TestShowInterfacesStatus(unittest.TestCase):
                 'port_speed': 'a-1000',
                 'status': 'connected',
                 'type': '10/100/1000-TX',
-                'vlan': 'trunk',
+                'vlan': 'trunk'
             },
             'GigabitEthernet1/46': {
                 'duplex_code': 'auto',
                 'port_speed': 'auto',
                 'status': 'notconnect',
                 'type': '10/100/1000-TX',
-                'vlan': '99',
+                'vlan': '99'
             },
             'GigabitEthernet1/7': {
-                'duplex_code': 'auto',
-                'port_speed': 'auto',
-                'status': 'notconnect',
-                'type': '10/100/1000-TX',
-                'vlan': '99',
+               'duplex_code': 'auto',
+               'port_speed': 'auto',
+               'status': 'notconnect',
+               'type': '10/100/1000-TX',
+               'vlan': '99'
             },
             'GigabitEthernet2/11': {
                 'duplex_code': 'a-full',
@@ -19014,21 +19027,21 @@ class TestShowInterfacesStatus(unittest.TestCase):
                 'port_speed': 'a-1000',
                 'status': 'connected',
                 'type': '10/100/1000-TX',
-                'vlan': '136',
+                'vlan': '136'
             },
             'GigabitEthernet2/12': {
                 'duplex_code': 'auto',
                 'port_speed': 'auto',
                 'status': 'notconnect',
                 'type': '10/100/1000-TX',
-                'vlan': '99',
+                'vlan': '99'
             },
             'GigabitEthernet2/23': {
                 'duplex_code': 'a-full',
                 'port_speed': 'a-100',
                 'status': 'connected',
                 'type': '10/100/1000-TX',
-                'vlan': '140',
+                'vlan': '140'
             },
             'GigabitEthernet2/24': {
                 'duplex_code': 'a-full',
@@ -19036,41 +19049,69 @@ class TestShowInterfacesStatus(unittest.TestCase):
                 'port_speed': 'a-1000',
                 'status': 'connected',
                 'type': '10/100/1000-TX',
-                'vlan': 'trunk',
+                'vlan': 'trunk'
             },
             'GigabitEthernet3/4': {
-                'duplex_code': '1000',
-                'name': 'notconnect',
-                'port_speed': 'No',
-                'status': '99',
-                'type': 'Gbic',
-                'vlan': 'full',
+               'duplex_code': 'full',
+               'port_speed': '1000',
+               'status': 'notconnect',
+               'type': 'No Gbic',
+               'vlan': '99'
             },
             'GigabitEthernet3/5': {
-                'duplex_code': 'full',
-                'name': 'To loedutjb234',
-                'port_speed': '1000',
-                'status': 'connected',
-                'type': '1000BaseSX',
-                'vlan': 'trunk',
+               'duplex_code': 'full',
+               'name': 'To loedutjb234',
+               'port_speed': '1000',
+               'status': 'connected',
+               'type': '1000BaseSX',
+               'vlan': 'trunk'
             },
             'GigabitEthernet3/6': {
-                'duplex_code': 'full',
-                'name': 'To loedutjb345',
-                'port_speed': '1000',
-                'status': 'connected',
-                'type': '1000BaseSX',
-                'vlan': 'trunk',
+               'duplex_code': 'full',
+               'name': 'To loedutjb345',
+               'port_speed': '1000',
+               'status': 'connected',
+               'type': '1000BaseSX',
+               'vlan': 'trunk'
+            },
+            'Port-channel10': {
+               'duplex_code': 'a-full',
+               'name': 'VSL LINK2',
+               'port_speed': 'a-10G',
+               'status': 'connected',
+               'vlan': 'trunk'
+            },
+            'TenGigabitEthernet1/1/2': {
+               'duplex_code': 'full',
+               'name': 'VSL',
+               'port_speed': 'a-10G',
+               'status': 'connected',
+               'type': '10GBase-SR',
+               'vlan': 'trunk'
+            },
+            'TenGigabitEthernet2/1/20': {
+               'duplex_code': 'full',
+               'port_speed': 'auto',
+               'status': 'disabled',
+               'type': 'No XCVR',
+               'vlan': '1'
+            },
+            'TenGigabitEthernet2/1/21': {
+               'duplex_code': 'full',
+               'name': 'VSL LINK1',
+               'port_speed': 'auto',
+               'status': 'disabled',
+               'type': 'No XCVR',
+               'vlan': '1'
             },
             'TenGigabitEthernet3/2': {
-                'duplex_code': 'auto',
-                'name': 'inactive',
-                'port_speed': 'No',
-                'status': '1',
-                'type': 'XCVR',
-                'vlan': 'full',
-            },
-        },
+               'duplex_code': 'full',
+               'port_speed': 'auto',
+               'status': 'inactive',
+               'type': 'No XCVR',
+               'vlan': '1'
+            }
+        }
     }
 
     def test_empty(self):


### PR DESCRIPTION
In current implementation the regex expression assumes the Port has only two components (like Gi1/2) but it can have 3 (like Te1/1/1) or even 4 (like Gi1/1/0/1.
Also I think that implementing the parser with oper_fill_tabular is better in this case.