### PR TITLE
Update Cisco IOS ShowIpArp to pass "output" kwarg

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -52,3 +52,7 @@
     * Updated ShowRoute:
         * Update regex to support various outputs.
 
+* IOS 
+    * Updated ShowIpArp
+        * Added argument 'output' into super().cli()
+

--- a/src/genie/libs/parser/ios/show_arp.py
+++ b/src/genie/libs/parser/ios/show_arp.py
@@ -46,7 +46,7 @@ class ShowIpArp(ShowArp_iosxe):
         if not vrf and not intf_or_ip:
             cmd = self.cli_command[0]
 
-        ret_dict = super().cli(self, cmd=cmd)
+        ret_dict = super().cli(self, cmd=cmd, output=output)
 
         return ret_dict
 


### PR DESCRIPTION
Currently the Cisco IOS show_arp.py parser for ShowIpArp is calling super() to the iosxe parser. At this time the "output" kwarg is not being passed to the base class. I propose the following simple edit to pass the "output" kwarg to the base class.