### PR TITLE
Updated Regex for NXOS Show Interface

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -40,6 +40,10 @@
         * Change key 'address_family' into Optional
     * Updated ShowRunInterface:
         * Add regex to support various sample outputs
+    * Updated ShowInterface
+        * Added regex to support interfaces down for SFP Not Inserted
+        * Added regex to support interfaces down for ErrDisabled
+        * Added regex to support interfaces down due to being suspended (LACP)
 
 * IOSXR
     * Updated ShowBgpSessions:

--- a/src/genie/libs/parser/nxos/show_interface.py
+++ b/src/genie/libs/parser/nxos/show_interface.py
@@ -211,6 +211,9 @@ class ShowInterface(ShowInterfaceSchema):
                         r'(,\s*line\s+protocol\s+is\s+(?P<line_protocol>\w+))?'
                         r'(,\s+autostate\s+(?P<autostate>\S+))?'
                         r'(\(Link\s+not\s+connected\))?'
+                        r'(\(SFP\s+not\s+inserted\))?'
+                        r'(\(suspended\(.*\)\))?'
+                        r'(\(\S+ErrDisabled\))?'
                         r'(\(.*ACK.*\))?$')
 
         # admin state is up


### PR DESCRIPTION
PR to update the regex in the NXOS show interface command to match interfaces which have been LACP suspended, have SFP not inserted, and have been ErrDisabled