### PR TITLE
Fixed IOSXE ShowCdpNeighborsDetail to support more outputs.

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -35,6 +35,9 @@
     * Fixed ShowDmvpn not executing the command properly on device
     * Update ShowIpRoute:
         * Fixed regex for VRF name, now supports the '-' character in name.
+    * Update ShowCdpNeighborsDetail:
+        * Modified regex to parse interface and port_id like FastEthernet0/0.1 and Serial0/0/0:1
+
 * NXOS
     * Updated ShowIpStaticRouteMulticast:
         * Change key 'address_family' into Optional

--- a/src/genie/libs/parser/iosxe/show_cdp.py
+++ b/src/genie/libs/parser/iosxe/show_cdp.py
@@ -218,9 +218,11 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
         # Interface: GigabitEthernet0/0,  Port ID (outgoing port): GigabitEthernet0/0
         # Interface: GigabitEthernet0/0/2,  Port ID (outgoing port): GigabitEthernet0/0/3
         # Interface: GigabitEthernet3/0/29,  Port ID (outgoing port): Port 0
+        # Interface: Serial0/0/0:1,  Port ID (outgoing port): Serial1/4:1
+        # Interface: FastEthernet0/0.1,  Port ID (outgoing port): GigabitEthernet7/27
         interface_port_re = re.compile(r'Interface:\s*'
-                                      '(?P<interface>[\w\s\-\/\/]+)\s*\,'
-                                      '*\s*Port\s*ID\s*[\(\w\)\s]+:\s*'
+                                      '(?P<interface>[\w\s\-\/\/\:\.]+)\s*\,'
+                                      '*\s*Port\s*ID\s*[\(\w\)\s\:]+:\s*'
                                       '(?P<port_id>[\S\s]+$)')
 
         # Native VLAN: 42

--- a/src/genie/libs/parser/iosxe/tests/test_show_cdp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_cdp.py
@@ -653,6 +653,96 @@ class test_show_cdp_neighbors_detail(unittest.TestCase):
         },
     }
 
+    device_output_7 = {'execute.return_value': '''
+        Device# show cdp neighbors detail
+        Device ID: MXMERCN5.cosmos.es.ftgroup
+        Entry address(es): 
+          IP address: 10.2.3.41
+        Platform: Cisco 3825,  Capabilities: Router Switch 
+        Interface: Serial0/0/0:1,  Port ID (outgoing port): Serial1/4:1
+        Holdtime : 160 sec
+        
+        Version :
+        Cisco IOS Software, 3800 Software (C3825-ENTSERVICESK9-M), Version 12.4(24)T8, RELEASE SOFTWARE (fc1)
+        Technical Support: http://www.cisco.com/techsupport
+        Copyright (c) 1986-2012 by Cisco Systems, Inc.
+        Compiled Sun 09-Sep-12 05:35 by prod_rel_team
+        
+        advertisement version: 2
+        VTP Management Domain: 'NotUsed'
+        
+        -------------------------
+        Device ID: BXPEDRCN2.cosmos.es.ftgroup
+        Entry address(es): 
+          IP address: 10.32.0.2
+        Platform: cisco WS-C6509-E,  Capabilities: Router Switch 
+        Interface: FastEthernet0/0.1,  Port ID (outgoing port): GigabitEthernet7/27
+        Holdtime : 164 sec
+        
+        Version :
+        Cisco IOS Software, s3223_rp Software (s3223_rp-IPSERVICESK9_WAN-M), Version 12.2(33)SXI14, RELEASE SOFTWARE (fc2)
+        Technical Support: http://www.cisco.com/techsupport
+        Copyright (c) 1986-2014 by Cisco Systems, Inc.
+        Compiled Wed 03-Sep-14 23:45 by prod_rel_team
+        
+        advertisement version: 2
+        VTP Management Domain: 'alpi'
+        Native VLAN: 1
+        Duplex: full
+        
+        Total cdp entries displayed : 2
+    '''}
+
+    expected_parsed_output_7 = {
+        'index': {
+            1: {
+                'advertisement_ver': 2,
+                'capabilities': 'Router Switch',
+                'device_id': 'MXMERCN5.cosmos.es.ftgroup',
+                'duplex_mode': '',
+                'entry_addresses': {'10.2.3.41': {}},
+                'hold_time': 160,
+                'local_interface': 'Serial0/0/0:1',
+                'management_addresses': {},
+                'native_vlan': '',
+                'platform': 'Cisco 3825',
+                'port_id': 'Serial1/4:1',
+                'software_version': 'Cisco IOS Software, 3800 Software '
+                                    '(C3825-ENTSERVICESK9-M), Version '
+                                    '12.4(24)T8, RELEASE SOFTWARE (fc1)\n'
+                                    'Technical Support: '
+                                    'http://www.cisco.com/techsupport\n'
+                                    'Copyright (c) 1986-2012 by Cisco Systems, '
+                                    'Inc.\n'
+                                    'Compiled Sun 09-Sep-12 05:35 by '
+                                    'prod_rel_team',
+                'vtp_management_domain': 'NotUsed'},
+            2: {
+                'advertisement_ver': 2,
+                'capabilities': 'Router Switch',
+                'device_id': 'BXPEDRCN2.cosmos.es.ftgroup',
+                'duplex_mode': 'full',
+                'entry_addresses': {'10.32.0.2': {}},
+                'hold_time': 164,
+                'local_interface': 'FastEthernet0/0.1',
+                'management_addresses': {},
+                'native_vlan': '1',
+                'platform': 'cisco WS-C6509-E',
+                'port_id': 'GigabitEthernet7/27',
+                'software_version': 'Cisco IOS Software, s3223_rp Software '
+                                    '(s3223_rp-IPSERVICESK9_WAN-M), Version '
+                                    '12.2(33)SXI14, RELEASE SOFTWARE (fc2)\n'
+                                    'Technical Support: '
+                                    'http://www.cisco.com/techsupport\n'
+                                    'Copyright (c) 1986-2014 by Cisco Systems, '
+                                    'Inc.\n'
+                                    'Compiled Wed 03-Sep-14 23:45 by '
+                                    'prod_rel_team',
+                'vtp_management_domain': 'alpi'}
+                },
+        'total_entries_displayed': 2
+    }
+
     def test_show_cdp_neighbors_detail_1(self):
         self.maxDiff = None
         self.device = Mock(**self.device_output_1)
@@ -694,6 +784,13 @@ class test_show_cdp_neighbors_detail(unittest.TestCase):
         obj = ShowCdpNeighborsDetail(device=self.device)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.expected_parsed_output_6)
+
+    def test_show_cdp_neighbors_detail_5(self):
+        self.maxDiff = None
+        self.device = Mock(**self.device_output_7)
+        obj = ShowCdpNeighborsDetail(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.expected_parsed_output_7)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

* Update ShowCdpNeighborsDetail:
     * Modified regex to parse interface and port_id like FastEthernet0/0.1 and Serial0/0/0:1

python -m unittest
Ran 3875 tests in 31.253s