### PR TITLE
show vtp status issue (iosxe)

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -37,6 +37,8 @@
         * Fixed regex for VRF name, now supports the '-' character in name.
     * Updated ShowAccessLists:
         * Fixed a typo in code.
+    * Update ShowVtpStatus:
+        * Changed the following keys into Optional: 'maximum_vlans' and 'md5_digest'.
 
 * NXOS
     * Updated ShowIpStaticRouteMulticast:

--- a/src/genie/libs/parser/iosxe/show_vtp.py
+++ b/src/genie/libs/parser/iosxe/show_vtp.py
@@ -96,13 +96,13 @@ class ShowVtpStatusSchema(MetaParser):
                     'vlan': {
                         'enabled': bool,
                         'operating_mode': str,
-                        'maximum_vlans': int,
+                        Optional('maximum_vlans'): int,
                         'existing_vlans': int,
                         'existing_extended_vlans': int,
                         'configuration_revision': int,
                         'primary_id': str,
                         Optional('primary_description'): str,
-                        'md5_digest': str,
+                        Optional('md5_digest'): str,
                     },
                     'mst': {
                         'enabled': bool,

--- a/src/genie/libs/parser/iosxe/tests/test_show_vtp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_vtp.py
@@ -284,6 +284,71 @@ class test_show_vtp_status(unittest.TestCase):
             'version_capable': [1, 2, 3]
         }
     }
+
+    golden_output_5 = {'execute.return_value': '''\
+        show vtp status
+        VTP Version capable             : 1 to 3
+        VTP version running             : 3
+        VTP Domain Name                 : Domain-Name
+        VTP Pruning Mode                : Enabled
+        VTP Traps Generation            : Enabled
+        Device ID                       : ffff.aaaa.0000
+        
+        Feature VLAN:
+        --------------
+        VTP Operating Mode                : Client
+        Number of existing VLANs          : 40
+        Number of existing extended VLANs : 2
+        Configuration Revision            : 13
+        Primary ID                        : 3333.1111.2222
+        Primary Description               : description
+        MD5 digest                        : 
+        
+        
+        Feature MST:
+        --------------
+        VTP Operating Mode                : Transparent
+        
+        
+        Feature UNKNOWN:
+        --------------
+        VTP Operating Mode                : Transparent
+        '''}
+
+    golden_parsed_output_5 = {
+        'vtp': {
+            'version_capable': [
+              1,
+              2,
+              3
+            ],
+            'version': '3',
+            'feature': {
+              'vlan': {
+                'operating_mode': 'client',
+                'enabled': True,
+                'existing_vlans': 40,
+                'existing_extended_vlans': 2,
+                'configuration_revision': 13,
+                'primary_id': '3333.1111.2222',
+                'primary_description': 'description'
+              },
+              'mst': {
+                'operating_mode': 'transparent',
+                'enabled': False
+              },
+              'unknown': {
+                'operating_mode': 'transparent',
+                'enabled': False
+              }
+            },
+            'domain_name': 'Domain-Name',
+            'pruning_mode': True,
+            'traps_generation': True,
+            'device_id': 'ffff.aaaa.0000'
+        }
+    }
+
     def test_empty(self):
         self.device1 = Mock(**self.empty_output)
         obj = ShowVtpStatus(device=self.device1)
@@ -317,6 +382,13 @@ class test_show_vtp_status(unittest.TestCase):
         parsed_output = obj.parse()
         self.maxDiff = None
         self.assertEqual(parsed_output,self.golden_parsed_output_4)
+
+    def test_golden_5(self):
+        self.device = Mock(**self.golden_output_5)
+        obj = ShowVtpStatus(device=self.device)
+        parsed_output = obj.parse()
+        self.maxDiff = None
+        self.assertEqual(parsed_output,self.golden_parsed_output_5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,

we ran into some issues with devices without 'maximum_vlans' and 'md5_digest'. I made both keys optional in the schema.

Example:

```
VTP Version capable             : 1 to 3
VTP version running             : 3
VTP Domain Name                 : Domain-Name
VTP Pruning Mode                : Enabled
VTP Traps Generation            : Enabled
Device ID                       : ffff.aaaa.0000

Feature VLAN:
--------------
VTP Operating Mode                : Client
Number of existing VLANs          : 40
Number of existing extended VLANs : 2
Configuration Revision            : 13
Primary ID                        : 3333.1111.2222
Primary Description               : description
MD5 digest                        : 


Feature MST:
--------------
VTP Operating Mode                : Transparent


Feature UNKNOWN:
--------------
VTP Operating Mode                : Transparent
```

Also added a new test

![tests](https://user-images.githubusercontent.com/32892378/81541781-f211db00-9373-11ea-8e77-1c17be28c876.jpg)
