### PR TITLE
show vlan issues (iosxe)

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -37,6 +37,10 @@
         * Fixed regex for VRF name, now supports the '-' character in name.
     * Updated ShowAccessLists:
         * Fixed a typo in code.
+    * Update ShowVlan:
+        * Fixed regex for vlan name, now also supports multiple white spaces.
+        * Added regex for toking ring table.
+        * Added the following keys: 'token_ring', 'are_hops', 'ste_hops' and 'backup_crf'.
 
 * NXOS
     * Updated ShowIpStaticRouteMulticast:

--- a/src/genie/libs/parser/iosxe/show_vlan.py
+++ b/src/genie/libs/parser/iosxe/show_vlan.py
@@ -86,13 +86,10 @@ class ShowVlan(ShowVlanSchema):
         # 2    VLAN_0002                        active
         # 20   VLAN-0020                        active
         # 100  V100                             suspended
-        # 101  VLAN-0101                        active
-        # 102  VLAN_0102                        active
-        # 103  VLAN-0103                        act/unsup
-        # 104  VLAN_0104                        act/lshut
         # 105  Misc. Name                       active    Gi1/0/13, Gi1/0/14, Gi1/0/15, Gi1/0/16, Gi1/0/19
         p1 = re.compile(r'^(?P<vlan_id>[0-9]+)\s+(?P<name>(?=\S).*(?<=\S))'
-                         '\s+(?P<status>(active|suspended|(.*)lshut|(.*)unsup)+)(?P<interfaces>[\w\d\/\d, ]+)?$')
+                         '\s+(?P<status>(active|suspended|(.*)lshut|(.*)unsup)+)'
+                         '(?P<interfaces>[\w\d\/\d, ]+)?$')
 
         #                                                Gi1/0/19, Gi1/0/20, Gi1/0/21, Gi1/0/22
         p2 = re.compile(r'^\s*(?P<space>\s{48})(?P<interfaces>[\w\s\/\,]+)?$')

--- a/src/genie/libs/parser/iosxe/show_vlan.py
+++ b/src/genie/libs/parser/iosxe/show_vlan.py
@@ -58,6 +58,12 @@ class ShowVlanSchema(MetaParser):
                         Optional('type'): str,
                         Optional('ports'): list,
                     },
+                Optional('token_ring'):
+                    {
+                        Optional('are_hops'): int,
+                        Optional('ste_hops'): int,
+                        Optional('backup_crf'): str,
+                    }
                 },
             },
         }
@@ -75,6 +81,59 @@ class ShowVlan(ShowVlanSchema):
         else:
             out = output
 
+        # VLAN Name                             Status    Ports
+        # 1    default                          active    Gi1/0/1, Gi1/0/2, Gi1/0/3, Gi1/0/5, Gi1/0/6, Gi1/0/12,
+        # 2    VLAN_0002                        active
+        # 20   VLAN-0020                        active
+        # 100  V100                             suspended
+        # 101  VLAN-0101                        active
+        # 102  VLAN_0102                        active
+        # 103  VLAN-0103                        act/unsup
+        # 104  VLAN_0104                        act/lshut
+        # 105  Misc. Name                       active    Gi1/0/13, Gi1/0/14, Gi1/0/15, Gi1/0/16, Gi1/0/19
+        p1 = re.compile(r'^(?P<vlan_id>[0-9]+)\s+(?P<name>(?=\S).*(?<=\S))'
+                         '\s+(?P<status>(active|suspended|(.*)lshut|(.*)unsup)+)(?P<interfaces>[\w\d\/\d, ]+)?$')
+
+        #                                                Gi1/0/19, Gi1/0/20, Gi1/0/21, Gi1/0/22
+        p2 = re.compile(r'^\s*(?P<space>\s{48})(?P<interfaces>[\w\s\/\,]+)?$')
+
+        # VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+        # ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
+        # 1    enet  100001     1500  -      -      -        -    -        0      0
+        p3 = re.compile(r'^\s*(?P<vlan_id>[0-9]+) +(?P<type>[a-zA-Z]+)'
+                        ' +(?P<said>\d+) +(?P<mtu>[\d\-]+) +(?P<parent>[\w\-]+)?'
+                        ' +(?P<ring_no>[\w\-]+)? +(?P<bridge_no>[\w\-]+)? +(?P<stp>[\w\-]+)?'
+                        ' +(?P<bridge_mode>[\w\-]+)? +(?P<trans1>[\d\-]+) +(?P<trans2>[\d\-]+)$')
+
+        # Remote SPAN VLANs
+        # -------------------------------------
+        # 201-202
+        # 201,202
+        # 201,202-205
+        p4 = re.compile(r'^\s*(?P<remote_span_vlans>[^--][0-9\-\,]+)?$')
+
+        # Primary Secondary Type              Ports
+        # ------- --------- ----------------- ------------------------------------------
+        # 2       301       community         Fa5/3, Fa5/25
+        #  2       302       community
+        #          10        community
+        #  none    20        community
+        # 20      105       isolated
+        # 100     151       non-operational
+        # none    202       community
+        #         303       community
+        # 101     402       non-operational
+        p5 = re.compile(r'^\s*(?P<primary>[0-9a-zA-Z]+)? +(?P<secondary>\d+)'
+                        ' +(?P<type>[\w\-]+)( +(?P<interfaces>[\w\/, ]+))?')
+
+        # VLAN AREHops STEHops Backup CRF
+        # ---- ------- ------- ----------
+        # 1003 7       7       off
+        p6 = re.compile(r'^\s*(?P<vlan_id>\d+)\s+'
+                         '(?P<are_hops>\d{1,2})\s+'
+                         '(?P<ste_hops>\d{1,2})\s+'
+                         '(?P<backup_crf>\S+)\s*$')
+
         vlan_dict = {}
         primary = ""
         for line in out.splitlines():
@@ -82,6 +141,7 @@ class ShowVlan(ShowVlanSchema):
                 line = line.rstrip()
             else:
                 continue
+
             # VLAN Name                             Status    Ports
             # 1    default                          active    Gi1/0/1, Gi1/0/2, Gi1/0/3, Gi1/0/5, Gi1/0/6, Gi1/0/12,
             # 2    VLAN_0002                        active
@@ -91,11 +151,7 @@ class ShowVlan(ShowVlanSchema):
             # 102  VLAN_0102                        active
             # 103  VLAN-0103                        act/unsup
             # 104  VLAN_0104                        act/lshut
-
-            p1 = re.compile(r'^(?P<vlan_id>[0-9]+) +(?P<name>\S+)'
-                             ' +(?P<status>(active|suspended|(.*)lshut|(.*)unsup)+)(?P<interfaces>[\w\d\/\d, ]+)?$')
             m = p1.match(line)
-
             if m:
                 vlan_id = m.groupdict()['vlan_id']
                 if 'vlans' not in vlan_dict:
@@ -125,7 +181,6 @@ class ShowVlan(ShowVlanSchema):
                 continue
 
             #                                                Gi1/0/19, Gi1/0/20, Gi1/0/21, Gi1/0/22
-            p2 = re.compile(r'^\s*(?P<space>\s{48})(?P<interfaces>[\w\s\/\,]+)?$')
             m = p2.match(line)
             if m:
                 vlan_dict['vlans'][vlan_id]['interfaces'] = vlan_dict['vlans'][vlan_id]['interfaces']+\
@@ -135,10 +190,6 @@ class ShowVlan(ShowVlanSchema):
             # VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
             # ---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------
             # 1    enet  100001     1500  -      -      -        -    -        0      0
-            p3 = re.compile(r'^\s*(?P<vlan_id>[0-9]+) +(?P<type>[a-zA-Z]+)'
-                            ' +(?P<said>\d+) +(?P<mtu>[\d\-]+) +(?P<parent>[\w\-]+)?'
-                            ' +(?P<ring_no>[\w\-]+)? +(?P<bridge_no>[\w\-]+)? +(?P<stp>[\w\-]+)?'
-                            ' +(?P<bridge_mode>[\w\-]+)? +(?P<trans1>[\d\-]+) +(?P<trans2>[\d\-]+)$')
             m = p3.match(line)
             if m:
                 vlan_id = m.groupdict()['vlan_id']
@@ -177,12 +228,36 @@ class ShowVlan(ShowVlanSchema):
 
                 continue
 
+            # VLAN AREHops STEHops Backup CRF
+            # ---- ------- ------- ----------
+            # 1003 7       7       off
+            m = p6.match(line)
+            if m:
+                vlan_id = m.groupdict()['vlan_id']
+                are_hops = m.groupdict()['are_hops']
+                ste_hops = m.groupdict()['ste_hops']
+                backup_crf = m.groupdict()['backup_crf']
+
+                if 'vlans' not in vlan_dict:
+                    vlan_dict['vlans'] = {}
+
+                if vlan_id not in vlan_dict['vlans']:
+                    vlan_dict['vlans'][vlan_id] = {}
+
+                if 'token_ring' not in vlan_dict['vlans'][vlan_id]:
+                    vlan_dict['vlans'][vlan_id]['token_ring'] = {}
+
+                vlan_dict['vlans'][vlan_id]['token_ring']['are_hops'] = int(are_hops)
+                vlan_dict['vlans'][vlan_id]['token_ring']['ste_hops'] = int(ste_hops)
+                vlan_dict['vlans'][vlan_id]['token_ring']['backup_crf'] = backup_crf
+
+                continue
+
             # Remote SPAN VLANs
             # -------------------------------------
             # 201-202
             # 201,202
             # 201,202-205
-            p4 = re.compile(r'^\s*(?P<remote_span_vlans>[^--][0-9\-\,]+)?$')
             m = p4.match(line)
             if m:
                 if m.groupdict()['remote_span_vlans']:
@@ -209,7 +284,6 @@ class ShowVlan(ShowVlanSchema):
 
                 continue
 
-
             # Primary Secondary Type              Ports
             # ------- --------- ----------------- ------------------------------------------
             # 2       301       community         Fa5/3, Fa5/25
@@ -221,11 +295,7 @@ class ShowVlan(ShowVlanSchema):
             # none    202       community
             #         303       community
             # 101     402       non-operational
-
-            p5 = re.compile(r'^\s*(?P<primary>[0-9a-zA-Z]+)? +(?P<secondary>\d+)'
-                             ' +(?P<type>[\w\-]+)( +(?P<interfaces>[\w\/, ]+))?')
             m = p5.match(line)
-
             if m:
                 if m.groupdict()['primary'] and m.groupdict()['primary'].lower() != "none":
                     primary = m.groupdict()['primary']

--- a/src/genie/libs/parser/iosxe/tests/test_show_vlan.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_vlan.py
@@ -553,6 +553,211 @@ Primary Secondary Type              Ports
     },
 }
 
+    golden_output_vlan_4 = {'execute.return_value': '''
+VLAN Name                             Status    Ports
+---- -------------------------------- --------- -------------------------------   
+3    Part1 Part2                      active    
+4    Part1 Part/2                     active        
+9    Misc. Name                       active    Gi1/0/13, Gi1/0/14, Gi1/0/15, Gi1/0/16, Gi1/0/19
+                                                Gi1/0/20
+130  SO MANY SPACES                   active    Gi1/0/21
+
+VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------ 
+3    enet  100003     1500  -      -      -        -    -        0      0   
+4    enet  100004     1500  -      -      -        -    -        0      0   
+9    enet  100009     1500  -      -      -        -    -        0      0   
+130  enet  100130     1500  -      -      -        -    -        0      0    
+          
+VLAN AREHops STEHops Backup CRF
+---- ------- ------- ----------
+
+Remote SPAN VLANs
+------------------------------------------------------------------------------
+
+
+Primary Secondary Type              Ports
+------- --------- ----------------- ------------------------------------------
+    '''}
+
+    golden_parsed_output_vlan_4 = {
+        'vlans': {
+            '3': {
+              'vlan_id': '3',
+              'name': 'Part1 Part2',
+              'shutdown': False,
+              'state': 'active',
+              'type': 'enet',
+              'said': 100003,
+              'mtu': 1500,
+              'trans1': 0,
+              'trans2': 0
+            },
+            '4': {
+              'vlan_id': '4',
+              'name': 'Part1 Part/2',
+              'shutdown': False,
+              'state': 'active',
+              'type': 'enet',
+              'said': 100004,
+              'mtu': 1500,
+              'trans1': 0,
+              'trans2': 0
+            },
+            '9': {
+              'vlan_id': '9',
+              'name': 'Misc. Name',
+              'shutdown': False,
+              'state': 'active',
+              'interfaces': [
+                'GigabitEthernet1/0/13',
+                'GigabitEthernet1/0/14',
+                'GigabitEthernet1/0/15',
+                'GigabitEthernet1/0/16',
+                'GigabitEthernet1/0/19',
+                'GigabitEthernet1/0/20'
+              ],
+              'type': 'enet',
+              'said': 100009,
+              'mtu': 1500,
+              'trans1': 0,
+              'trans2': 0
+            },
+            '130': {
+              'vlan_id': '130',
+              'name': 'SO MANY SPACES',
+              'shutdown': False,
+              'state': 'active',
+              'interfaces': [
+                'GigabitEthernet1/0/21'
+              ],
+              'type': 'enet',
+              'said': 100130,
+              'mtu': 1500,
+              'trans1': 0,
+              'trans2': 0
+            }
+        }
+    }
+
+    golden_output_vlan_5 = {'execute.return_value': '''
+VLAN Name                             Status    Ports
+---- -------------------------------- --------- -------------------------------  
+1    default                          active    Gi1/0/23, Gi1/0/25, Gi1/0/26, Gi1/0/27, Gi1/0/28 
+2    Test                             active    
+1003 trcrf-default                    act/unsup 
+1004 fddinet-default                  act/unsup 
+1005 trbrf-default                    act/unsup 
+
+VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
+---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------ 
+1    enet  100001     1500  -      -      -        -    -        0      0   
+2    enet  100002     1500  -      -      -        -    -        0      0   
+1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
+1004 fdnet 101004     1500  -      -      -        ieee -        0      0   
+1005 trbrf 101005     4472  -      -      15       ibm  -        0      0   
+
+VLAN AREHops STEHops Backup CRF
+---- ------- ------- ----------
+1003 7       7       off
+
+Remote SPAN VLANs
+------------------------------------------------------------------------------
+
+
+Primary Secondary Type              Ports
+------- --------- ----------------- ------------------------------------------
+1       2         community
+        '''}
+
+    golden_parsed_output_vlan_5 = {
+        'vlans': {
+            '1': {
+              'vlan_id': '1',
+              'name': 'default',
+              'shutdown': False,
+              'state': 'active',
+              'interfaces': [
+                'GigabitEthernet1/0/23',
+                'GigabitEthernet1/0/25',
+                'GigabitEthernet1/0/26',
+                'GigabitEthernet1/0/27',
+                'GigabitEthernet1/0/28'
+              ],
+              'type': 'enet',
+              'said': 100001,
+              'mtu': 1500,
+              'trans1': 0,
+              'trans2': 0,
+              'private_vlan': {
+                'primary': True,
+                'association': [
+                  '2'
+                ]
+              }
+            },
+            '2': {
+              'vlan_id': '2',
+              'name': 'Test',
+              'shutdown': False,
+              'state': 'active',
+              'type': 'enet',
+              'said': 100002,
+              'mtu': 1500,
+              'trans1': 0,
+              'trans2': 0,
+              'private_vlan': {
+                'primary': False,
+                'type': 'community'
+              }
+            },
+            '1003': {
+              'vlan_id': '1003',
+              'name': 'trcrf-default',
+              'shutdown': False,
+              'state': 'unsupport',
+              'type': 'trcrf',
+              'said': 101003,
+              'mtu': 4472,
+              'parent': '1005',
+              'ring_no': '3276',
+              'bridge_mode': 'srb',
+              'trans1': 0,
+              'trans2': 0,
+              'token_ring': {
+                'are_hops': 7,
+                'ste_hops': 7,
+                'backup_crf': 'off'
+              }
+            },
+            '1004': {
+              'vlan_id': '1004',
+              'name': 'fddinet-default',
+              'shutdown': False,
+              'state': 'unsupport',
+              'type': 'fdnet',
+              'said': 101004,
+              'mtu': 1500,
+              'stp': 'ieee',
+              'trans1': 0,
+              'trans2': 0
+            },
+            '1005': {
+              'vlan_id': '1005',
+              'name': 'trbrf-default',
+              'shutdown': False,
+              'state': 'unsupport',
+              'type': 'trbrf',
+              'said': 101005,
+              'mtu': 4472,
+              'bridge_no': '15',
+              'stp': 'ibm',
+              'trans1': 0,
+              'trans2': 0
+            }
+        }
+    }
+
     def test_empty_1(self):
         self.device = Mock(**self.empty_output)
         obj = ShowVlan(device=self.device)
@@ -579,6 +784,21 @@ Primary Secondary Type              Ports
         obj = ShowVlan(device=self.device)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output_vlan_3)
+
+    def test_show_vlan_4(self):
+        self.maxDiff = None
+        self.device = Mock(**self.golden_output_vlan_4)
+        obj = ShowVlan(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_vlan_4)
+
+    def test_show_vlan_5(self):
+        self.maxDiff = None
+        self.device = Mock(**self.golden_output_vlan_5)
+        obj = ShowVlan(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_vlan_5)
+
 
 ###########################################################################
 #


### PR DESCRIPTION
Hi,

we ran into some issues, when the token ring table is present in the output. 
For Example:

```
VLAN Name                             Status    Ports
---- -------------------------------- --------- -------------------------------  
1    default                          active    Gi1/0/23, Gi1/0/25, Gi1/0/26, Gi1/0/27, Gi1/0/28 
2    Test                             active    
1003 trcrf-default                    act/unsup 
1004 fddinet-default                  act/unsup 
1005 trbrf-default                    act/unsup 

VLAN Type  SAID       MTU   Parent RingNo BridgeNo Stp  BrdgMode Trans1 Trans2
---- ----- ---------- ----- ------ ------ -------- ---- -------- ------ ------ 
1    enet  100001     1500  -      -      -        -    -        0      0   
2    enet  100002     1500  -      -      -        -    -        0      0   
1003 trcrf 101003     4472  1005   3276   -        -    srb      0      0
1004 fdnet 101004     1500  -      -      -        ieee -        0      0   
1005 trbrf 101005     4472  -      -      15       ibm  -        0      0   

VLAN AREHops STEHops Backup CRF
---- ------- ------- ----------
1003 7       7       off

Remote SPAN VLANs
------------------------------------------------------------------------------


Primary Secondary Type              Ports
------- --------- ----------------- ------------------------------------------
1       2         community
```
The issue here was, that the p5 regex also matched the values in the token ring table and produced wrong results.
For this reason I added a new regex for the token ring table and also added new values to the schema. I also moved the regex compilation before the loop and changed the regex for the vlan name to also support white spaces in the name.

I also added two tests:

![tests](https://user-images.githubusercontent.com/32892378/81542787-7e70cd80-9375-11ea-8e3c-27735a0bc4dd.jpg)
