### PR TITLE
show version issues (ios / iosxe)

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -69,6 +69,11 @@
         * Fixed regex for vlan name, now also supports multiple white spaces.
         * Added regex for toking ring table.
         * Added the following keys: 'token_ring', 'are_hops', 'ste_hops' and 'backup_crf'.
+    * Update ShowVersion:
+        * Fixed regex for interface and ethernet_type, now also supports 'FastEthernet'.
+        * Changed the key 'virtual_ethernet' value to optional.
+        * Added the following keys 'fastethernet', 'power_supply_part_nr', 'power_supply_sn', 'db_assembly_num', 'db_sn', 'top_assembly_part_num', 'top_assembly_rev_num', 'version_id', 'clei_code_num', 'db_rev_num' and 'hb_rev_num'
+        * Added regex for swith table without 'Mode' column.
 
 * NXOS
     * Updated ShowIpStaticRouteMulticast:

--- a/src/genie/libs/parser/ios/tests/test_show_platform.py
+++ b/src/genie/libs/parser/ios/tests/test_show_platform.py
@@ -176,7 +176,30 @@ class TestShowVersion(unittest.TestCase):
                         'data_base': '0x02800000',
                         'text_base': '0x00003000',
                         },
+                    'switch_num': {
+                        '1': {
+                            'ports': '30',
+                            'model': 'WS-C3750X-24P',
+                            'sw_ver': '12.2(55)SE8',
+                            'sw_image': 'C3750E-UNIVERSALK9-M',
+                            'active': True,
+                            'mac_address': '84:3D:C6:FF:F1:B8',
+                            'mb_assembly_num': '73-15476-04',
+                            'mb_sn': 'FDO202907UH',
+                            'model_rev_num': 'W0',
+                            'mb_rev_num': 'B0',
+                            'model_num': 'WS-C3750X-24P-L',
+                            'db_assembly_num': '800-32727-03',
+                            'db_sn': 'FDO202823P8',
+                            'system_sn': 'FDO2028F1WK',
+                            'top_assembly_part_num': '800-38990-01',
+                            'top_assembly_rev_num': 'F0',
+                            'version_id': 'V07',
+                            'clei_code_num': 'CMMPP00DRB',
+                            'hb_rev_num': '0x05'
+                        }
                     }
+        }
     }
 
     golden_output_ios = {'execute.return_value': '''\

--- a/src/genie/libs/parser/iosxe/show_platform.py
+++ b/src/genie/libs/parser/iosxe/show_platform.py
@@ -250,7 +250,8 @@ class ShowVersionSchema(MetaParser):
                 'data_base': str,
             },
             Optional('interfaces'): {
-                'virtual_ethernet': int,
+                Optional('virtual_ethernet'): int,
+                Optional('fastethernet'): int,
                 'gigabit_ethernet': int,
             },
             Optional('revision'): {
@@ -508,7 +509,7 @@ class ShowVersion(ShowVersionSchema):
 
         # 1 Virtual Ethernet/IEEE 802.3 interface(s)
         # 50 Gigabit Ethernet/IEEE 802.3 interface(s)
-        p48 = re.compile(r'^(?P<interface>\d+) +(?P<ethernet_type>Virtual Ethernet|Gigabit Ethernet)'
+        p48 = re.compile(r'^(?P<interface>\d+) +(?P<ethernet_type>Virtual Ethernet|Gigabit Ethernet|FastEthernet)'
                          r'/IEEE 802\.3 +interface\(s\)$')
 
         # Dagobah Revision 95, Swamp Revision 6

--- a/src/genie/libs/parser/iosxe/show_platform.py
+++ b/src/genie/libs/parser/iosxe/show_platform.py
@@ -751,7 +751,6 @@ class ShowVersion(ShowVersionSchema):
                 version_dict['version']['processor_type'] = group['processor_type']
 
                 if 'C3850' in version_dict['version']['chassis'] or \
-                   'C2960' in version_dict['version']['chassis'] or \
                    'C3650' in version_dict['version']['chassis']:
                     version_dict['version']['rtr_type'] = rtr_type = 'Edison'
                 elif 'ASR1' in version_dict['version']['chassis']:
@@ -835,11 +834,12 @@ class ShowVersion(ShowVersionSchema):
             m = p26.match(line)
             if m:
                 switch_number = m.groupdict()['switch_number']
-                if 'Edison' in rtr_type:
-                    if 'switch_num' not in version_dict['version']:
-                        version_dict['version']['switch_num'] = {}
-                    if switch_number not in version_dict['version']['switch_num']:
-                        version_dict['version']['switch_num'][switch_number] = {}
+
+                if 'switch_num' not in version_dict['version']:
+                    version_dict['version']['switch_num'] = {}
+                if switch_number not in version_dict['version']['switch_num']:
+                    version_dict['version']['switch_num'][switch_number] = {}
+
                 continue
 
             # uptime

--- a/src/genie/libs/parser/iosxe/show_platform.py
+++ b/src/genie/libs/parser/iosxe/show_platform.py
@@ -208,11 +208,21 @@ class ShowVersionSchema(MetaParser):
                     Optional('uptime'): str,
                     Optional('mac_address'): str,
                     Optional('mb_assembly_num'): str,
+                    Optional('power_supply_part_nr'): str,
                     Optional('mb_sn'): str,
+                    Optional('power_supply_sn'): str,
                     Optional('model_rev_num'): str,
                     Optional('mb_rev_num'): str,
                     Optional('model_num'): str,
+                    Optional('db_assembly_num'): str,
+                    Optional('db_sn'): str,
                     Optional('system_sn'): str,
+                    Optional('top_assembly_part_num'): str,
+                    Optional('top_assembly_rev_num'): str,
+                    Optional('version_id'): str,
+                    Optional('clei_code_num'): str,
+                    Optional('db_rev_num'): str,
+                    Optional('hb_rev_num'): str,
                     Optional('mode'): str,
                     Optional('model'): str,
                     Optional('sw_image'): str,
@@ -419,7 +429,7 @@ class ShowVersion(ShowVersionSchema):
         p26 = re.compile(r'^[Ss]witch +0(?P<switch_number>\d+)$')
 
         # uptime
-        p27 = re.compile(r'^[Ss]witch +uptime +\: +(?P<uptime>.+)$')
+        p27 = re.compile(r'^[Ss]witch +[Uu]ptime +\: +(?P<uptime>.+)$')
 
         # mac_address
         p28 = re.compile(r'^[Bb]ase +[Ee]thernet +MAC +[Aa]ddress '
@@ -515,6 +525,40 @@ class ShowVersion(ShowVersionSchema):
         # Dagobah Revision 95, Swamp Revision 6
         p50 = re.compile(r'^(?P<group1>\S+)\s+Revision\s+(?P<group1_int>\d+),'
                          r'\s+(?P<group2>\S+)\s+Revision\s+(?P<group2_int>\d+)$')
+
+        # power_supply_part_nr
+        p51 = re.compile(r'^[Pp]ower\s+[Ss]upply\s+[Pp]art\s+[Nn]umber\s+\:\s+(?P<power_supply_part_nr>.+)$')
+
+        # power_supply_sn
+        p52 = re.compile(r'^[Pp]ower\s+[Ss]upply\s+[Ss]erial\s+[Nn]umber\s+\:\s+(?P<power_supply_sn>.+)$')
+
+        # Daughterboard assembly number
+        # db_assembly_num
+        p53 = re.compile(r'^[Dd]aughterboard\s+[Aa]ssembly\s+[Nn]umber\s+\:\s+(?P<db_assembly_num>.+)$')
+
+        # Daughterboard serial number
+        # db_sn
+        p54 = re.compile(r'^[Dd]aughterboard\s+[Ss]erial\s+[Nn]umber\s+\:\s+(?P<db_sn>.+)$')
+
+        # top_assembly_part_num
+        p55 = re.compile(r'^[Tt]op\s+[Aa]ssembly\s+[Pp]art\s+[Nn]umber\s+\:\s+(?P<top_assembly_part_num>.+)$')
+
+        # top_assembly_rev_num
+        p56 = re.compile(r'^[Tt]op\s+[Aa]ssembly\s+[Rr]evision\s+[Nn]umber\s+\:\s+(?P<top_assembly_rev_num>.+)$')
+
+        # version_id
+        p57 = re.compile(r'^[Vv]ersion\s+ID\s+\:\s+(?P<version_id>.+)$')
+
+        # clei_code_num
+        p58 = re.compile(r'^CLEI\s+[Cc]ode\s+[Nn]umber\s+\:\s+(?P<clei_code_num>.+)$')
+
+        # Daughterboard revision number
+        # db_rev_num
+        p59 = re.compile(r'^[Dd]aughterboard\s+[Rr]evision\s+[Nn]umber\s+\:\s+(?P<db_rev_num>.+)$')
+
+        # Hardware board revision number
+        # hb_rev_num
+        p60 = re.compile(r'^[Hh]ardware\s+[Bb]oard\s+[Rr]evision\s+[Nn]umber\s+\:\s+(?P<hb_rev_num>.+)$')
 
         for line in out.splitlines():
             line = line.strip()
@@ -707,6 +751,7 @@ class ShowVersion(ShowVersionSchema):
                 version_dict['version']['processor_type'] = group['processor_type']
 
                 if 'C3850' in version_dict['version']['chassis'] or \
+                   'C2960' in version_dict['version']['chassis'] or \
                    'C3650' in version_dict['version']['chassis']:
                     version_dict['version']['rtr_type'] = rtr_type = 'Edison'
                 elif 'ASR1' in version_dict['version']['chassis']:
@@ -723,7 +768,7 @@ class ShowVersion(ShowVersionSchema):
             m = p19.match(line)
             if m:
                 version_dict['version']['chassis_sn'] \
-                    = m.groupdict()['chassis_sn']
+                    = m.groupdict()['chassis_sn']   
                 continue
 
             # number_of_intfs
@@ -866,6 +911,96 @@ class ShowVersion(ShowVersionSchema):
                     active_dict.setdefault('system_sn', m.groupdict()['system_sn'])
                     continue
                 version_dict['version']['switch_num'][switch_number]['system_sn'] = m.groupdict()['system_sn']
+                continue
+
+            # power_supply_part_nr
+            m = p51.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('power_supply_part_nr', m.groupdict()['power_supply_part_nr'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['power_supply_part_nr'] = m.groupdict()['power_supply_part_nr']
+                continue
+
+            # power_supply_sn
+            m = p52.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('power_supply_sn', m.groupdict()['power_supply_sn'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['power_supply_sn'] = m.groupdict()['power_supply_sn']
+                continue
+
+            # db_assembly_num
+            m = p53.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('db_assembly_num', m.groupdict()['db_assembly_num'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['db_assembly_num'] = m.groupdict()['db_assembly_num']
+                continue
+
+            # db_sn
+            m = p54.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('db_sn', m.groupdict()['db_sn'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['db_sn'] = m.groupdict()['db_sn']
+                continue
+
+            # top_assembly_part_num
+            m = p55.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('top_assembly_part_num', m.groupdict()['top_assembly_part_num'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['top_assembly_part_num'] = m.groupdict()['top_assembly_part_num']
+                continue
+
+            # top_assembly_rev_num
+            m = p56.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('top_assembly_rev_num', m.groupdict()['top_assembly_rev_num'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['top_assembly_rev_num'] = m.groupdict()['top_assembly_rev_num']
+                continue
+
+            # version_id
+            m = p57.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('version_id', m.groupdict()['version_id'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['version_id'] = m.groupdict()['version_id']
+                continue
+
+            # clei_code_num
+            m = p58.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('clei_code_num', m.groupdict()['clei_code_num'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['clei_code_num'] = m.groupdict()['clei_code_num']
+                continue
+
+            # db_rev_num
+            m = p59.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('db_rev_num', m.groupdict()['db_rev_num'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['db_rev_num'] = m.groupdict()['db_rev_num']
+                continue
+
+            # hb_rev_num
+            m = p60.match(line)
+            if m:
+                if 'switch_num' not in version_dict['version']:
+                    active_dict.setdefault('hb_rev_num', m.groupdict()['hb_rev_num'])
+                    continue
+                version_dict['version']['switch_num'][switch_number]['hb_rev_num'] = m.groupdict()['hb_rev_num']
                 continue
 
             # Compiled Mon 10-Apr-17 04:35 by mcpre
@@ -1063,10 +1198,27 @@ class ShowVersion(ShowVersionSchema):
                                                                'sw_image',
                                                                'mode'],
                                                  index=[0, ],
-                                                 table_terminal_pattern=r"^\n",
+                                                 table_terminal_pattern=r"(^\n|^\s*$)",
                                                  device_output=out,
                                                  device_os='iosxe')
 
+        if not tmp2.entries:
+            # table2 for IOS
+            tmp2 = genie.parsergen.oper_fill_tabular(right_justified=True,
+                                                     header_fields=["Switch",
+                                                                    "Ports",
+                                                                    "Model             ",
+                                                                    'SW Version       ',
+                                                                    "SW Image              "],
+                                                     label_fields=["switch_num",
+                                                                   "ports",
+                                                                   "model",
+                                                                   "sw_ver",
+                                                                   'sw_image'],
+                                                     index=[0, ],
+                                                     table_terminal_pattern=r"(^\n|^\s*$)",
+                                                     device_output=out,
+                                                     device_os='ios')
         # switch_number
         # license table for Cat3850
         tmp = genie.parsergen.oper_fill_tabular(right_justified=True,
@@ -1076,7 +1228,7 @@ class ShowVersion(ShowVersionSchema):
                                                 label_fields=["license_level",
                                                               "license_type",
                                                               "next_reload_license_level"],
-                                                table_terminal_pattern=r"^\n",
+                                                table_terminal_pattern=r"(^\n|^\s*$)",
                                                 device_output=out,
                                                 device_os='iosxe')
 
@@ -1085,32 +1237,36 @@ class ShowVersion(ShowVersionSchema):
             for key in res.entries.keys():
                 for k, v in res.entries[key].items():
                     version_dict['version'][k] = v
-            if tmp2.entries:
-                res2 = tmp2
-                for key in res2.entries.keys():
-                    if 'switch_num' not in version_dict['version']:
-                        version_dict['version']['switch_num'] = {}
-                    if '*' in key:
-                        p = re.compile(r'\**\ *(?P<new_key>\d)')
-                        m = p.match(key)
-                        switch_no = m.groupdict()['new_key']
-                        if m:
-                            if switch_no not in version_dict['version']['switch_num']:
-                                version_dict['version']['switch_num'][switch_no] = {}
-                            for k, v in res2.entries[key].items():
-                                if 'switch_num' != k:
-                                    version_dict['version']['switch_num'][switch_no][k] = v
-                            version_dict['version']['switch_num'][switch_no]['uptime'] = uptime_this_cp
-                            version_dict['version']['switch_num'][switch_no]['active'] = True
-                            version_dict['version']['switch_num'][switch_no].\
-                                update(active_dict) if active_dict else None
-                    else:
+
+        if tmp2.entries:
+            res2 = tmp2
+            for key in res2.entries.keys():
+                if 'switch_num' not in version_dict['version']:
+                    version_dict['version']['switch_num'] = {}
+                if '*' in key:
+                    p = re.compile(r'\**\ *(?P<new_key>\d)')
+                    m = p.match(key)
+                    switch_no = m.groupdict()['new_key']
+                    if m:
+                        if switch_no not in version_dict['version']['switch_num']:
+                            version_dict['version']['switch_num'][switch_no] = {}
                         for k, v in res2.entries[key].items():
-                            if key not in version_dict['version']['switch_num']:
-                                version_dict['version']['switch_num'][key] = {}
                             if 'switch_num' != k:
-                                version_dict['version']['switch_num'][key][k] = v
-                        version_dict['version']['switch_num'][key]['active'] = False
+                                version_dict['version']['switch_num'][switch_no][k] = v
+
+                        if 'uptime_this_cp' in locals():
+                            version_dict['version']['switch_num'][switch_no]['uptime'] = uptime_this_cp
+
+                        version_dict['version']['switch_num'][switch_no]['active'] = True
+                        version_dict['version']['switch_num'][switch_no].\
+                            update(active_dict) if active_dict else None
+                else:
+                    for k, v in res2.entries[key].items():
+                        if key not in version_dict['version']['switch_num']:
+                            version_dict['version']['switch_num'][key] = {}
+                        if 'switch_num' != k:
+                            version_dict['version']['switch_num'][key][k] = v
+                    version_dict['version']['switch_num'][key]['active'] = False
 
         return version_dict
 

--- a/src/genie/libs/parser/iosxe/show_platform.py
+++ b/src/genie/libs/parser/iosxe/show_platform.py
@@ -527,36 +527,42 @@ class ShowVersion(ShowVersionSchema):
                          r'\s+(?P<group2>\S+)\s+Revision\s+(?P<group2_int>\d+)$')
 
         # power_supply_part_nr
+        # Power supply part number: 444-8888-00
         p51 = re.compile(r'^[Pp]ower\s+[Ss]upply\s+[Pp]art\s+[Nn]umber\s+\:\s+(?P<power_supply_part_nr>.+)$')
 
         # power_supply_sn
+        # Power supply serial number: CCC4466B6LL
         p52 = re.compile(r'^[Pp]ower\s+[Ss]upply\s+[Ss]erial\s+[Nn]umber\s+\:\s+(?P<power_supply_sn>.+)$')
 
-        # Daughterboard assembly number
+        # Daughterboard assembly number   : 73-11111-00
         # db_assembly_num
         p53 = re.compile(r'^[Dd]aughterboard\s+[Aa]ssembly\s+[Nn]umber\s+\:\s+(?P<db_assembly_num>.+)$')
 
-        # Daughterboard serial number
+        # Daughterboard serial number     : FOC87654CWW
         # db_sn
         p54 = re.compile(r'^[Dd]aughterboard\s+[Ss]erial\s+[Nn]umber\s+\:\s+(?P<db_sn>.+)$')
 
         # top_assembly_part_num
+        # Top Assembly Part Number        : 800-55555-11
         p55 = re.compile(r'^[Tt]op\s+[Aa]ssembly\s+[Pp]art\s+[Nn]umber\s+\:\s+(?P<top_assembly_part_num>.+)$')
 
         # top_assembly_rev_num
+        # Top Assembly Revision Number    : C0
         p56 = re.compile(r'^[Tt]op\s+[Aa]ssembly\s+[Rr]evision\s+[Nn]umber\s+\:\s+(?P<top_assembly_rev_num>.+)$')
 
         # version_id
+        # Version ID                      : V02
         p57 = re.compile(r'^[Vv]ersion\s+ID\s+\:\s+(?P<version_id>.+)$')
 
         # clei_code_num
+        # CLEI Code Number                : AAALJ00ERT
         p58 = re.compile(r'^CLEI\s+[Cc]ode\s+[Nn]umber\s+\:\s+(?P<clei_code_num>.+)$')
 
-        # Daughterboard revision number
+        # Daughterboard revision number   : A0
         # db_rev_num
         p59 = re.compile(r'^[Dd]aughterboard\s+[Rr]evision\s+[Nn]umber\s+\:\s+(?P<db_rev_num>.+)$')
 
-        # Hardware board revision number
+        # Hardware Board Revision Number  : 0x12
         # hb_rev_num
         p60 = re.compile(r'^[Hh]ardware\s+[Bb]oard\s+[Rr]evision\s+[Nn]umber\s+\:\s+(?P<hb_rev_num>.+)$')
 

--- a/src/genie/libs/parser/iosxe/tests/test_show_platform.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_platform.py
@@ -1068,6 +1068,96 @@ class TestShowVersion(unittest.TestCase):
         }
     }
 
+    golden_output_2 = {'execute.return_value': '''
+        Cisco Internetwork Operating System Software 
+        IOS (tm) C2940 Software (C2940-I6K2L2Q4-M), Version 12.1(22)EA12, RELEASE SOFTWARE (fc1)
+        Copyright (c) 1986-2008 by cisco Systems, Inc.
+        Compiled Tue 08-Jul-08 00:06 by amvarma
+        Image text-base: 0x80010000, data-base: 0x8068C000
+        
+        ROM: Bootstrap program is C2950 boot loader
+        
+        testsw01 uptime is 24 weeks, 1 day, 20 hours, 50 minutes
+        System returned to ROM by power-on
+        System restarted at 09:17:28 UTC Sun Oct 27 2019
+        System image file is "flash:f1111-aei43934-mz.121-22.EA12.bin"
+        
+        
+        This product contains cryptographic features and is subject to United
+        States and local country laws governing import, export, transfer and
+        use. Delivery of Cisco cryptographic products does not imply
+        third-party authority to import, export, distribute or use encryption.
+        Importers, exporters, distributors and users are responsible for
+        compliance with U.S. and local country laws. By using this product you
+        agree to comply with applicable laws and regulations. If you are unable
+        to comply with U.S. and local laws, return this product immediately.
+        
+        A summary of U.S. laws governing Cisco cryptographic products may be found at:
+        http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+        
+        If you require further assistance please contact us by sending email to
+        export@cisco.com.
+        
+        cisco WS-C2940-8TT-S (RC32300) processor (revision H0) with 19868K bytes of memory.
+        Processor board ID FOC2345C3DB
+        Last reset from system-reset
+        Running Standard Image
+        8 FastEthernet/IEEE 802.3 interface(s)
+        1 Gigabit Ethernet/IEEE 802.3 interface(s)
+        The password-recovery mechanism is disabled.
+        
+        32K bytes of flash-simulated non-volatile configuration memory.
+        Base ethernet MAC Address: 00:11:22:54:00:44
+        Motherboard assembly number: 99-6666-88
+        Power supply part number: 444-8888-00
+        Motherboard serial number: FOC99344ERT
+        Power supply serial number: CCC4466B6LL
+        Model revision number: H0
+        Motherboard revision number: A0
+        Model number: WS-C2940-8TT-S
+        System serial number: FOC6666U4BB
+        Configuration register is 0xF
+
+        '''}
+
+    golden_parsed_output_2 = {
+        'version': {
+        'version_short': '12.1',
+        'platform': 'C2940',
+        'version': '12.1(22)EA12',
+        'image_id': 'C2940-I6K2L2Q4-M',
+        'os': 'IOS',
+        'image_type': 'developer image',
+        'compiled_date': 'Tue 08-Jul-08 00:06',
+        'compiled_by': 'amvarma',
+        'image': {
+          'text_base': '0x80010000',
+          'data_base': '0x8068C000'
+        },
+        'rom': 'Bootstrap program is C2950 boot loader',
+        'hostname': 'testsw01',
+        'uptime': '24 weeks, 1 day, 20 hours, 50 minutes',
+        'returned_to_rom_by': 'power-on',
+        'system_restarted_at': '09:17:28 UTC Sun Oct 27 2019',
+        'system_image': 'flash:f1111-aei43934-mz.121-22.EA12.bin',
+        'chassis': 'WS-C2940-8TT-S',
+        'main_mem': '19868',
+        'processor_type': 'RC32300',
+        'rtr_type': 'WS-C2940-8TT-S',
+        'chassis_sn': 'FOC2345C3DB',
+        'last_reload_reason': 'system-reset',
+        'interfaces': {
+          'fastethernet': 8,
+          'gigabit_ethernet': 1
+        },
+        'mem_size': {
+          'flash-simulated non-volatile configuration': '32'
+        },
+        'curr_config_register': '0xF'
+      }
+    }
+    
+    
     def test_empty(self):
         self.dev1 = Mock(**self.empty_output)
         version_obj = ShowVersion(device=self.dev1)
@@ -1122,6 +1212,12 @@ class TestShowVersion(unittest.TestCase):
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.golden_parsed_output_1)
 
+    def test_golden_2(self):
+        self.maxDiff = None
+        self.dev_1 = Mock(**self.golden_output_2)
+        obj = ShowVersion(device=self.dev_1)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_2)
 
 class TestDir(unittest.TestCase):
     dev1 = Device(name='empty')

--- a/src/genie/libs/parser/iosxe/tests/test_show_platform.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_platform.py
@@ -1156,6 +1156,385 @@ class TestShowVersion(unittest.TestCase):
         'curr_config_register': '0xF'
       }
     }
+
+    golden_output_3 = {'execute.return_value': '''
+            Cisco IOS Software, IOS-XE Software, Catalyst L3 Switch Software (CAT3K_CAA-UNIVERSALK9-M), Version 03.06.07E RELEASE SOFTWARE (fc3)
+            Technical Support: http://www.cisco.com/techsupport
+            Copyright (c) 1986-2017 by Cisco Systems, Inc.
+            Compiled Wed 12-Jul-17 16:55 by prod_rel_team
+            
+            
+            
+            Cisco IOS-XE software, Copyright (c) 2005-2015 by cisco Systems, Inc.
+            All rights reserved.  Certain components of Cisco IOS-XE software are
+            licensed under the GNU General Public License ("GPL") Version 2.0.  The
+            software code licensed under GPL Version 2.0 is free software that comes
+            with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
+            GPL code under the terms of GPL Version 2.0.
+            (http://www.gnu.org/licenses/gpl-2.0.html) For more details, see the
+            documentation or "License Notice" file accompanying the IOS-XE software,
+            or the applicable URL provided on the flyer accompanying the IOS-XE
+            software.
+            
+            
+            
+            ROM: IOS-XE ROMMON
+            BOOTLDR: CAT3K_CAA Boot Loader (CAT3K_CAA-HBOOT-M) Version 1.2, RELEASE SOFTWARE (P)
+            
+            testhost uptime is 1 year, 51 weeks, 2 days, 41 minutes
+            Uptime for this control processor is 1 year, 51 weeks, 2 days, 46 minutes
+            System returned to ROM by reload at 10:29:35 CEST Sat Apr 14 2018
+            System restarted at 10:36:03 CEST Sat Apr 14 2018
+            System image file is "flash:packages.conf"
+            Last reload reason: Reload command
+            
+            
+            
+            This product contains cryptographic features and is subject to United
+            States and local country laws governing import, export, transfer and
+            use. Delivery of Cisco cryptographic products does not imply
+            third-party authority to import, export, distribute or use encryption.
+            Importers, exporters, distributors and users are responsible for
+            compliance with U.S. and local country laws. By using this product you
+            agree to comply with applicable laws and regulations. If you are unable
+            to comply with U.S. and local laws, return this product immediately.
+            
+            A summary of U.S. laws governing Cisco cryptographic products may be found at:
+            http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+            
+            If you require further assistance please contact us by sending email to
+            export@cisco.com.
+            
+            License Level: License
+            License Type: Type
+            Next reload license Level: License
+            
+            cisco WS-C3650-48PD (MIPS) processor with 4194304K bytes of physical memory.
+            Processor board ID FDO0000E1C8
+            3 Virtual Ethernet interfaces
+            100 Gigabit Ethernet interfaces
+            4 Ten Gigabit Ethernet interfaces
+            2048K bytes of non-volatile configuration memory.
+            4194304K bytes of physical memory.
+            257008K bytes of Crash Files at crashinfo:.
+            257008K bytes of Crash Files at crashinfo-1:.
+            1550272K bytes of Flash at flash:.
+            1550272K bytes of Flash at flash-1:.
+            0K bytes of Dummy USB Flash at usbflash0:.
+            0K bytes of Dummy USB Flash at usbflash0-1:.
+            0K bytes of  at webui:.
+            
+            Base Ethernet MAC Address          : 88:88:00:ff:33:00
+            Motherboard Assembly Number        : 73-12345-67
+            Motherboard Serial Number          : FDO668866S6E
+            Model Revision Number              : D0
+            Motherboard Revision Number        : A0
+            Model Number                       : WS-C3650-48PD
+            System Serial Number               : FDO668866F908
+            
+            
+            Switch Ports Model              SW Version        SW Image              Mode   
+            ------ ----- -----              ----------        ----------            ----   
+                 1 52    WS-C3650-48PD      03.06.07E         cat3k_caa-universalk9 INSTALL
+            *    2 52    WS-C3650-48PD      03.06.07E         cat3k_caa-universalk9 INSTALL
+            
+            
+            Switch 01
+            ---------
+            Switch uptime                      : 1 year, 51 weeks, 2 days, 44 minutes 
+            Base Ethernet MAC Address          : bb:aa:77:00:aa:88
+            Motherboard Assembly Number        : 73-12345-89
+            Motherboard Serial Number          : FDO668866D8F
+            Model Revision Number              : D0
+            Motherboard Revision Number        : A0
+            Model Number                       : WS-C3650-48PD
+            System Serial Number               : FDO668866F910
+            
+            Configuration register is 0x102
+
+            '''}
+
+    golden_parsed_output_3 = {
+        'version': {
+        'version_short': '03.06',
+        'platform': 'Catalyst L3 Switch',
+        'version': '03.06.07E',
+        'image_id': 'CAT3K_CAA-UNIVERSALK9-M',
+        'os': 'IOS-XE',
+        'image_type': 'production image',
+        'compiled_date': 'Wed 12-Jul-17 16:55',
+        'compiled_by': 'prod_rel_team',
+        'rom': 'IOS-XE ROMMON',
+        'bootldr': 'CAT3K_CAA Boot Loader (CAT3K_CAA-HBOOT-M) Version 1.2, RELEASE SOFTWARE (P)',
+        'hostname': 'testhost',
+        'uptime': '1 year, 51 weeks, 2 days, 41 minutes',
+        'uptime_this_cp': '1 year, 51 weeks, 2 days, 46 minutes',
+        'returned_to_rom_by': 'reload',
+        'returned_to_rom_at': '10:29:35 CEST Sat Apr 14 2018',
+        'system_restarted_at': '10:36:03 CEST Sat Apr 14 2018',
+        'system_image': 'flash:packages.conf',
+        'last_reload_reason': 'Reload command',
+        'license_level': 'License',
+        'license_type': 'Type',
+        'next_reload_license_level': 'License',
+        'chassis': 'WS-C3650-48PD',
+        'main_mem': '4194304',
+        'processor_type': 'MIPS',
+        'rtr_type': 'Edison',
+        'chassis_sn': 'FDO0000E1C8',
+        'number_of_intfs': {
+          'Virtual Ethernet': '3',
+          'Gigabit Ethernet': '100',
+          'Ten Gigabit Ethernet': '4'
+        },
+        'mem_size': {
+          'non-volatile configuration': '2048',
+          'physical': '4194304'
+        },
+        'disks': {
+          'crashinfo:.': {
+            'disk_size': '257008',
+            'type_of_disk': 'Crash Files'
+          },
+          'crashinfo-1:.': {
+            'disk_size': '257008',
+            'type_of_disk': 'Crash Files'
+          },
+          'flash:.': {
+            'disk_size': '1550272',
+            'type_of_disk': 'Flash'
+          },
+          'flash-1:.': {
+            'disk_size': '1550272',
+            'type_of_disk': 'Flash'
+          },
+          'usbflash0:.': {
+            'disk_size': '0',
+            'type_of_disk': 'Dummy USB Flash'
+          },
+          'usbflash0-1:.': {
+            'disk_size': '0',
+            'type_of_disk': 'Dummy USB Flash'
+          },
+          'webui:.': {
+            'disk_size': '0',
+            'type_of_disk': ''
+          }
+        },
+        'switch_num': {
+          '1': {
+            'uptime': '1 year, 51 weeks, 2 days, 44 minutes',
+            'mac_address': 'bb:aa:77:00:aa:88',
+            'mb_assembly_num': '73-12345-89',
+            'mb_sn': 'FDO668866D8F',
+            'model_rev_num': 'D0',
+            'mb_rev_num': 'A0',
+            'model_num': 'WS-C3650-48PD',
+            'system_sn': 'FDO668866F910',
+            'ports': '52',
+            'model': 'WS-C3650-48PD',
+            'sw_ver': '03.06.07E',
+            'sw_image': 'cat3k_caa-universalk9',
+            'mode': 'INSTALL',
+            'active': False
+          },
+          '2': {
+            'ports': '52',
+            'model': 'WS-C3650-48PD',
+            'sw_ver': '03.06.07E',
+            'sw_image': 'cat3k_caa-universalk9',
+            'mode': 'INSTALL',
+            'uptime': '1 year, 51 weeks, 2 days, 46 minutes',
+            'active': True,
+            'mac_address': '88:88:00:ff:33:00',
+            'mb_assembly_num': '73-12345-67',
+            'mb_sn': 'FDO668866S6E',
+            'model_rev_num': 'D0',
+            'mb_rev_num': 'A0',
+            'model_num': 'WS-C3650-48PD',
+            'system_sn': 'FDO668866F908'
+          }
+        },
+        'curr_config_register': '0x102'
+      }
+    }
+
+    golden_output_4 = {'execute.return_value': '''
+            Cisco IOS Software, C2960X Software (C2960X-UNIVERSALK9-M), Version 15.2(2)E7, RELEASE SOFTWARE (fc3)
+            Technical Support: http://www.cisco.com/techsupport
+            Copyright (c) 1986-2017 by Cisco Systems, Inc.
+            Compiled Wed 12-Jul-17 13:06 by prod_rel_team
+            
+            ROM: Bootstrap program is C2960X boot loader
+            BOOTLDR: C2960X Boot Loader (C2960X-HBOOT-M) Version 15.2(2r)E1, RELEASE SOFTWARE (fc1)
+            
+            testname uptime is 25 weeks, 5 days, 15 hours, 45 minutes
+            System returned to ROM by power-on
+            System restarted at 19:24:47 UTC+2 Wed Oct 9 2019
+            System image file is "flash:c2960x-universalk9-mz.152-2.E7/c2960x-universalk9-mz.152-2.E7.bin"
+            Last reload reason: Reload command
+            
+            
+            
+            This product contains cryptographic features and is subject to United
+            States and local country laws governing import, export, transfer and
+            use. Delivery of Cisco cryptographic products does not imply
+            third-party authority to import, export, distribute or use encryption.
+            Importers, exporters, distributors and users are responsible for
+            compliance with U.S. and local country laws. By using this product you
+            agree to comply with applicable laws and regulations. If you are unable
+            to comply with U.S. and local laws, return this product immediately.
+            
+            A summary of U.S. laws governing Cisco cryptographic products may be found at:
+            http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+            
+            If you require further assistance please contact us by sending email to
+            export@cisco.com.
+            
+            cisco WS-C2960X-48FPD-L (APM86XXX) processor (revision F0) with 524288K bytes of memory.
+            Processor board ID FOC1913S46M
+            Last reset from power-on
+            4 Virtual Ethernet interfaces
+            1 FastEthernet interface
+            100 Gigabit Ethernet interfaces
+            4 Ten Gigabit Ethernet interfaces
+            The password-recovery mechanism is enabled.
+            
+            512K bytes of flash-simulated non-volatile configuration memory.
+            Base ethernet MAC Address       : CC:44:33:22:77:00
+            Motherboard assembly number     : 71-123456-02
+            Power supply part number        : 311-4567-11
+            Motherboard serial number       : FOC123456U12
+            Power supply serial number      : DCB324354RH
+            Model revision number           : F0
+            Motherboard revision number     : C0
+            Model number                    : WS-C2960X-48FPD-L
+            Daughterboard assembly number   : 73-11111-00
+            Daughterboard serial number     : FOC87654CWW
+            System serial number            : FOC4444S23V
+            Top Assembly Part Number        : 800-55555-11
+            Top Assembly Revision Number    : C0
+            Version ID                      : V02
+            CLEI Code Number                : AAALJ00ERT
+            Daughterboard revision number   : A0
+            Hardware Board Revision Number  : 0x12
+            
+            
+            Switch Ports Model                     SW Version            SW Image                 
+            ------ ----- -----                     ----------            ----------               
+                 1 52    WS-C2960X-48FPD-L         15.2(2)E7             C2960X-UNIVERSALK9-M     
+            *    2 52    WS-C2960X-48FPD-L         15.2(2)E7             C2960X-UNIVERSALK9-M     
+            
+            
+            Switch 01
+            ---------
+            Switch Uptime                   : 9 weeks, 5 days, 16 hours, 1 minute 
+            Base ethernet MAC Address       : 00:11:22:33:44:55
+            Motherboard assembly number     : 77-99999-00
+            Power supply part number        : 111-0111-03
+            Motherboard serial number       : FOC666777G4
+            Power supply serial number      : LIT122334DD
+            Model revision number           : V0
+            Motherboard revision number     : D0
+            Model number                    : WS-C2960X-48FPD-L
+            Daughterboard assembly number   : 73-12230-13
+            Daughterboard serial number     : FOC33144FDG
+            System serial number            : FOC3333S00A
+            Top assembly part number        : 00-100000-00
+            Top assembly revision number    : D0
+            Version ID                      : V07
+            CLEI Code Number                : CDFER00DFG
+            Daughterboard revision number   : B0
+            
+            Configuration register is 0xF
+
+    '''}
+
+    golden_parsed_output_4 = {
+        'version': {
+        'version_short': '15.2',
+        'platform': 'C2960X',
+        'version': '15.2(2)E7',
+        'image_id': 'C2960X-UNIVERSALK9-M',
+        'os': 'IOS',
+        'image_type': 'production image',
+        'compiled_date': 'Wed 12-Jul-17 13:06',
+        'compiled_by': 'prod_rel_team',
+        'rom': 'Bootstrap program is C2960X boot loader',
+        'bootldr': 'C2960X Boot Loader (C2960X-HBOOT-M) Version 15.2(2r)E1, RELEASE SOFTWARE (fc1)',
+        'hostname': 'testname',
+        'uptime': '25 weeks, 5 days, 15 hours, 45 minutes',
+        'returned_to_rom_by': 'power-on',
+        'system_restarted_at': '19:24:47 UTC+2 Wed Oct 9 2019',
+        'system_image': 'flash:c2960x-universalk9-mz.152-2.E7/c2960x-universalk9-mz.152-2.E7.bin',
+        'last_reload_reason': 'power-on',
+        'chassis': 'WS-C2960X-48FPD-L',
+        'main_mem': '524288',
+        'processor_type': 'APM86XXX',
+        'rtr_type': 'Edison',
+        'chassis_sn': 'FOC1913S46M',
+        'number_of_intfs': {
+          'Virtual Ethernet': '4',
+          'FastEthernet': '1',
+          'Gigabit Ethernet': '100',
+          'Ten Gigabit Ethernet': '4'
+        },
+        'mem_size': {
+          'flash-simulated non-volatile configuration': '512'
+        },
+        'switch_num': {
+          '1': {
+            'uptime': '9 weeks, 5 days, 16 hours, 1 minute',
+            'mac_address': '00:11:22:33:44:55',
+            'mb_assembly_num': '77-99999-00',
+            'power_supply_part_nr': '111-0111-03',
+            'mb_sn': 'FOC666777G4',
+            'power_supply_sn': 'LIT122334DD',
+            'model_rev_num': 'V0',
+            'mb_rev_num': 'D0',
+            'model_num': 'WS-C2960X-48FPD-L',
+            'db_assembly_num': '73-12230-13',
+            'db_sn': 'FOC33144FDG',
+            'system_sn': 'FOC3333S00A',
+            'top_assembly_part_num': '00-100000-00',
+            'top_assembly_rev_num': 'D0',
+            'version_id': 'V07',
+            'clei_code_num': 'CDFER00DFG',
+            'db_rev_num': 'B0',
+            'ports': '52',
+            'model': 'WS-C2960X-48FPD-L',
+            'sw_ver': '15.2(2)E7',
+            'sw_image': 'C2960X-UNIVERSALK9-M',
+            'active': False
+          },
+          '2': {
+            'ports': '52',
+            'model': 'WS-C2960X-48FPD-L',
+            'sw_ver': '15.2(2)E7',
+            'sw_image': 'C2960X-UNIVERSALK9-M',
+            'active': True,
+            'mac_address': 'CC:44:33:22:77:00',
+            'mb_assembly_num': '71-123456-02',
+            'power_supply_part_nr': '311-4567-11',
+            'mb_sn': 'FOC123456U12',
+            'power_supply_sn': 'DCB324354RH',
+            'model_rev_num': 'F0',
+            'mb_rev_num': 'C0',
+            'model_num': 'WS-C2960X-48FPD-L',
+            'db_assembly_num': '73-11111-00',
+            'db_sn': 'FOC87654CWW',
+            'system_sn': 'FOC4444S23V',
+            'top_assembly_part_num': '800-55555-11',
+            'top_assembly_rev_num': 'C0',
+            'version_id': 'V02',
+            'clei_code_num': 'AAALJ00ERT',
+            'db_rev_num': 'A0',
+            'hb_rev_num': '0x12'
+          }
+        },
+        'curr_config_register': '0xF'
+      }
+    }
     
     
     def test_empty(self):
@@ -1218,6 +1597,20 @@ class TestShowVersion(unittest.TestCase):
         obj = ShowVersion(device=self.dev_1)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.golden_parsed_output_2)
+
+    def test_golden_3(self):
+        self.maxDiff = None
+        self.dev_1 = Mock(**self.golden_output_3)
+        obj = ShowVersion(device=self.dev_1)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_3)
+
+    def test_golden_4(self):
+        self.maxDiff = None
+        self.dev_1 = Mock(**self.golden_output_4)
+        obj = ShowVersion(device=self.dev_1)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_4)
 
 class TestDir(unittest.TestCase):
     dev1 = Device(name='empty')

--- a/src/genie/libs/parser/iosxe/tests/test_show_platform.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_platform.py
@@ -1471,7 +1471,7 @@ class TestShowVersion(unittest.TestCase):
         'chassis': 'WS-C2960X-48FPD-L',
         'main_mem': '524288',
         'processor_type': 'APM86XXX',
-        'rtr_type': 'Edison',
+        'rtr_type': 'WS-C2960X-48FPD-L',
         'chassis_sn': 'FOC1913S46M',
         'number_of_intfs': {
           'Virtual Ethernet': '4',


### PR DESCRIPTION
Hi,

we had some issue parsing the show version information on ios devices.

```
512K bytes of flash-simulated non-volatile configuration memory.
Base ethernet MAC Address       : CC:44:33:22:77:00
Motherboard assembly number     : 71-123456-02
Power supply part number        : 311-4567-11
Motherboard serial number       : FOC123456U12
Power supply serial number      : DCB324354RH
Model revision number           : F0
Motherboard revision number     : C0
Model number                    : WS-C2960X-48FPD-L
Daughterboard assembly number   : 73-11111-00
Daughterboard serial number     : FOC87654CWW
System serial number            : FOC4444S23V
Top Assembly Part Number        : 800-55555-11
Top Assembly Revision Number    : C0
Version ID                      : V02
CLEI Code Number                : AAALJ00ERT
Daughterboard revision number   : A0
Hardware Board Revision Number  : 0x12


Switch Ports Model                     SW Version            SW Image                 
------ ----- -----                     ----------            ----------               
     1 52    WS-C2960X-48FPD-L         15.2(2)E7             C2960X-UNIVERSALK9-M     
*    2 52    WS-C2960X-48FPD-L         15.2(2)E7             C2960X-UNIVERSALK9-M     


Switch 01
---------
Switch Uptime                   : 9 weeks, 5 days, 16 hours, 1 minute 
Base ethernet MAC Address       : 00:11:22:33:44:55
Motherboard assembly number     : 77-99999-00
Power supply part number        : 111-0111-03
Motherboard serial number       : FOC666777G4
Power supply serial number      : LIT122334DD
Model revision number           : V0
Motherboard revision number     : D0
Model number                    : WS-C2960X-48FPD-L
Daughterboard assembly number   : 73-12230-13
Daughterboard serial number     : FOC33144FDG
System serial number            : FOC3333S00A
Top assembly part number        : 00-100000-00
Top assembly revision number    : D0
Version ID                      : V07
CLEI Code Number                : CDFER00DFG
Daughterboard revision number   : B0

Configuration register is 0xF
```

First of all I was not sure if I should keep this implementation in the same file or should split it in an ios and iosxe implementation? For now I just modified the iosxe implementation. 


The main issue was that the switch table does not have a 'Mode' column and thus the result was empty. I therefore added a second attempt to parse the table if the result of the first one was empty. I also added several new fields to the schema.

One thing I'm also not really sure about is the check for 'Edison' (Beginning at line 835) on initialising the 'switch_num' dictionary. What is the reason for it? I removed it because the 'WS-C2960X-48FPD-L' is no 'Edison' as far as I know. 

![tests](https://user-images.githubusercontent.com/32892378/81544815-48811880-9378-11ea-8657-a5385f603de5.jpg)
