### PR TITLE
show lldp neighbors detail issues (iosxe)

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -37,6 +37,11 @@
         * Fixed regex for VRF name, now supports the '-' character in name.
     * Updated ShowAccessLists:
         * Fixed a typo in code.
+    * Update ShowLldpEntry:
+        * Fixed regex for chassis id, now also supports ':' and '-'.
+        * Fixed regex for description, now also supports messages like '{"SN":"SN-NR","Owner":"OWNER"}'.
+        * Fixed regex for management addresses, now also supports IPv6 addresses.
+        * Changed the following keys into Optional for 'med_information': 'f/w_revision', 'power_source', 'power_priority', 'wattage' and 'capabilities'.
 
 * NXOS
     * Updated ShowIpStaticRouteMulticast:

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -178,7 +178,8 @@ class ShowLldpEntry(ShowLldpEntrySchema):
         p1_1 = re.compile(r'^Port\s+id:\s+(?P<port_id>[\S\s]+)$')
 
         # Chassis id:  843d.c6ff.f1b8
-        p2 = re.compile(r'^Chassis\s+id:\s+(?P<chassis_id>[\w\.:]+)$')
+        # Chassis id: r2-rf2222-qwe
+        p2 = re.compile(r'^Chassis\s+id:\s+(?P<chassis_id>[\w\.\:\-]+)$')
 
         # Port Description: GigabitEthernet1/0/4
         p3 = re.compile(r'^Port\s+Description:\s+(?P<desc>[\w\/\.\-\s]+)$')

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -199,7 +199,8 @@ class ShowLldpEntry(ShowLldpEntrySchema):
         # Compiled Thu 21-Jul-11 01:23 by prod_rel_team
         # Avaya 1220 IP Deskphone, Firmware:06Q
         # IP Phone, Firmware:90234AP
-        p5_2 = re.compile(r'^(?P<msg>(Compile|Avaya|IP Phone).*)$')
+        # {"SN":"SN-NR","Owner":"OWNER"}
+        p5_2 = re.compile(r'^(?P<msg>(Compile|Avaya|IP Phone|{).*)$')
 
         # Time remaining: 112 seconds
         p6 = re.compile(r'^Time\s+remaining:\s+(?P<time_remaining>\w+)\s+seconds$')

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -213,8 +213,10 @@ class ShowLldpEntry(ShowLldpEntrySchema):
 
         # Management Addresses:
         #     IP: 10.9.1.1
+        # Management Addresses:
+        #     IPV6: 0000:0000:0000:0000:0000:ffff:7f00:0001
         # Management Addresses - not advertised
-        p9 = re.compile(r'^IP:\s+(?P<ip>[\w\.]+)$')
+        p9 = re.compile(r'^(IP|IPV6):\s+(?P<ip>[\w\.:]+)$')
         p9_1 = re.compile(r'^Management\s+Addresses\s+-\s+(?P<ip>not\sadvertised)$')
 
         # Auto Negotiation - supported, enabled

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -118,7 +118,7 @@ class ShowLldpEntrySchema(MetaParser):
             }
         },
         Optional('med_information'): {
-            'f/w_revision': str,
+            Optional('f/w_revision'): str,
             Optional('h/w_revision'): str,
             Optional('s/w_revision'): str,
             'manufacturer': str,
@@ -134,9 +134,9 @@ class ShowLldpEntrySchema(MetaParser):
                 },
             },
             Optional('serial_number'): str,
-            'power_source': str,
-            'power_priority': str,
-            'wattage': float,
+            Optional('power_source'): str,
+            Optional('power_priority'): str,
+            Optional('wattage'): float,
             'location': str,
         }
     }

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -123,7 +123,7 @@ class ShowLldpEntrySchema(MetaParser):
             Optional('s/w_revision'): str,
             Optional('manufacturer'): str,
             Optional('model'): str,
-            'capabilities': list,
+            Optional('capabilities'): list,
             'device_type': str,
             Optional('network_policy'): {
                 Any(): { # 'voice'; 'voice_signal'
@@ -258,7 +258,7 @@ class ShowLldpEntry(ShowLldpEntrySchema):
         med_p3 = re.compile(r'^Model:\s+(?P<model>[\S\s]+)$')
 
         # Capabilities: NP, LI, PD, IN
-        med_p4 = re.compile(r'^Capabilities:\s*(?P<capabilities>[\S\s]*)$')
+        med_p4 = re.compile(r'^Capabilities:\s*(?P<capabilities>[\S\s]+)$')
 
         # Device type: Endpoint Class III
         med_p5 = re.compile(r'^Device\s+type:\s+(?P<device_type>[\S\s]+)$')

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -459,8 +459,6 @@ class ShowLldpEntry(ShowLldpEntrySchema):
             m = med_p4.match(line)
             if m:
                 list_capabilities = m.groupdict()['capabilities'].split(', ')
-                # Capabilities can be empty -> remove empty strings
-                list_capabilities = [x for x in list_capabilities if x]
                 med_dict['capabilities'] = list_capabilities
                 continue
 

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -178,7 +178,7 @@ class ShowLldpEntry(ShowLldpEntrySchema):
         p1_1 = re.compile(r'^Port\s+id:\s+(?P<port_id>[\S\s]+)$')
 
         # Chassis id:  843d.c6ff.f1b8
-        p2 = re.compile(r'^Chassis\s+id:\s+(?P<chassis_id>[\w\.]+)$')
+        p2 = re.compile(r'^Chassis\s+id:\s+(?P<chassis_id>[\w\.:]+)$')
 
         # Port Description: GigabitEthernet1/0/4
         p3 = re.compile(r'^Port\s+Description:\s+(?P<desc>[\w\/\.\-\s]+)$')

--- a/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
@@ -1689,7 +1689,6 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
             }
         },
         'med_information': {
-            'capabilities': [],
             'device_type': 'Endpoint Class I',
             'location': 'not advertised'
         },
@@ -1733,13 +1732,6 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
     def test_golden_5(self):
         self.maxDiff = None
         self.dev_c3850 = Mock(**self.golden_output_5)
-        obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
-        parsed_output = obj.parse()
-        self.assertEqual(parsed_output, self.golden_parsed_output_5)
-
-    def test_golden_6(self):
-        self.maxDiff = None
-        self.dev_c3850 = Mock(**self.golden_output_6)
         obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output, self.golden_parsed_output_5)

--- a/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_lldp.py
@@ -1474,6 +1474,228 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
     'total_entries': 1,
 }
 
+    golden_output_3 = {'execute.return_value': '''     
+        ------------------------------------------------
+        Local Intf: Gi1/0/32
+        Chassis id: FE80::EC22:9A75:BBC7:71AF
+        Port id: 222
+        Port Description: Description
+        System Name - not advertised
+        
+        System Description: 
+        {"SN":"SN-NR","Owner":"OWNER"}
+        
+        Time remaining: 92 seconds
+        System Capabilities - not advertised
+        Enabled Capabilities - not advertised
+        Management Addresses:
+            IPV6: 0000:0000:0000:0000:0000:ffff:7f00:0001
+        Auto Negotiation - not supported
+        Physical media capabilities - not advertised
+        Media Attachment Unit type - not advertised
+        Vlan ID: - not advertised
+        
+        
+        Total entries displayed: 1
+    '''}
+
+    golden_parsed_output_3 = {
+        'interfaces': {
+            'GigabitEthernet1/0/32': {
+                'if_name': 'GigabitEthernet1/0/32',
+                'port_id': {
+                    '222': {
+                        'neighbors': {
+                            'not advertised': {
+                                'neighbor_id': 'not advertised',
+                                'chassis_id': 'FE80::EC22:9A75:BBC7:71AF',
+                                'port_id': '222',
+                                'port_description': 'Description',
+                                'system_name': 'not advertised',
+                                'system_description': '{"SN":"SN-NR","Owner":"OWNER"}',
+                                'time_remaining': 92,
+                                'management_address': '0000:0000:0000:0000:0000:ffff:7f00:0001',
+                                'auto_negotiation': 'not supported'
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        'total_entries': 1,
+    }
+
+    golden_output_4 = {'execute.return_value': '''     
+        ------------------------------------------------
+        Local Intf: Gi1/0/17
+        Chassis id: 127.0.0.2
+        Port id: c81f.7777.6666
+        Port Description - not advertised
+        System Name: TestName
+        System Description - not advertised
+        
+        Time remaining: 104 seconds
+        System Capabilities: B,T
+        Enabled Capabilities: B,T
+        Management Addresses:
+            IP: 127.0.0.2
+            OID:
+                1.3.6.1.4.1.6889.1.69.2.0.
+        Auto Negotiation - not supported
+        Physical media capabilities - not advertised
+        Media Attachment Unit type: 30
+        Vlan ID: - not advertised
+        
+        MED Information:
+        
+            MED Codes:
+                  (NP) Network Policy, (LI) Location Identification
+                  (PS) Power Source Entity, (PD) Power Device
+                  (IN) Inventory
+        
+            H/W revision: 9611GD02C
+            S/W revision: 6.6604
+            Serial number: 12389WET87
+            Manufacturer: Avaya
+            Model: 9611
+            Capabilities: NP, PD, IN
+            Device type: Endpoint Class III
+            Network Policy(Voice): VLAN 66, tagged, Layer-2 priority: 5, DSCP: 46
+            Power requirements - not advertised
+            Location - not advertised
+        
+        
+        Total entries displayed: 1
+        '''}
+
+    golden_parsed_output_4 = {
+      'interfaces': {
+        'GigabitEthernet1/0/17': {
+          'if_name': 'GigabitEthernet1/0/17',
+          'port_id': {
+            'C81f.7777.6666': {
+              'neighbors': {
+                'TestName': {
+                  'neighbor_id': 'TestName',
+                  'chassis_id': '127.0.0.2',
+                  'port_id': 'C81f.7777.6666',
+                  'system_name': 'TestName',
+                  'time_remaining': 104,
+                  'capabilities': {
+                    'mac_bridge': {
+                      'name': 'mac_bridge',
+                      'system': True,
+                      'enabled': True
+                    },
+                    'telephone': {
+                      'name': 'telephone',
+                      'system': True,
+                      'enabled': True
+                    }
+                  },
+                  'management_address': '127.0.0.2',
+                  'auto_negotiation': 'not supported',
+                  'unit_type': 30
+                }
+              }
+            }
+          }
+        }
+      },
+      'med_information': {
+        'h/w_revision': '9611GD02C',
+        's/w_revision': '6.6604',
+        'serial_number': '12389WET87',
+        'manufacturer': 'Avaya',
+        'model': '9611',
+        'capabilities': [
+          'NP',
+          'PD',
+          'IN'
+        ],
+        'device_type': 'Endpoint Class III',
+        'network_policy': {
+          'voice': {
+            'tagged': True,
+            'layer_2_priority': 5,
+            'dscp': 46,
+            'vlan': 66
+          }
+        },
+        'location': 'not advertised'
+      },
+      'total_entries': 1
+    }
+
+    golden_output_5 = {'execute.return_value': '''     
+        ------------------------------------------------
+        Local Intf: Gi1/0/19
+        Chassis id: 6400.3333.1111
+        Port id: 6400.3333.1111
+        Port Description - not advertised
+        System Name - not advertised
+        System Description - not advertised
+        
+        Time remaining: 3284 seconds
+        System Capabilities - not advertised
+        Enabled Capabilities - not advertised
+        Management Addresses - not advertised
+        Auto Negotiation - supported, enabled
+        Physical media capabilities:
+            1000baseT(FD)
+        Media Attachment Unit type - not advertised
+        Vlan ID: - not advertised
+        
+        MED Information:
+        
+            MED Codes:
+                  (NP) Network Policy, (LI) Location Identification
+                  (PS) Power Source Entity, (PD) Power Device
+                  (IN) Inventory
+        
+            Inventory information - not advertised
+            Capabilities: 
+            Device type: Endpoint Class I
+            Network Policies - not advertised
+            Power requirements - not advertised
+            Location - not advertised
+        
+        
+        Total entries displayed: 1
+        '''}
+
+    golden_parsed_output_5 = {
+        'interfaces': {
+            'GigabitEthernet1/0/19': {
+                'if_name': 'GigabitEthernet1/0/19',
+                'port_id': {
+                    '6400.3333.1111': {
+                        'neighbors': {
+                            'not advertised': {
+                                'neighbor_id': 'not advertised',
+                                'chassis_id': '6400.3333.1111',
+                                'port_id': '6400.3333.1111',
+                                'system_name': 'not advertised',
+                                'time_remaining': 3284,
+                                'management_address': 'not advertised',
+                                'auto_negotiation': 'supported, enabled',
+                                'physical_media_capabilities': [
+                                    '1000baseT(FD)'
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        'med_information': {
+            'capabilities': [],
+            'device_type': 'Endpoint Class I',
+            'location': 'not advertised'
+        },
+        'total_entries': 1
+    }
+
     def test_empty(self):
         self.dev1 = Mock(**self.empty_output)
         obj = ShowLldpNeighborsDetail(device=self.dev1)
@@ -1493,6 +1715,34 @@ class test_show_lldp_neighbor_detail(unittest.TestCase):
         obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
         parsed_output = obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output_2)
+
+    def test_golden_3(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_3)
+        obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_3)
+
+    def test_golden_4(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_4)
+        obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_4)
+
+    def test_golden_5(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_5)
+        obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_5)
+
+    def test_golden_6(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_6)
+        obj = ShowLldpNeighborsDetail(device=self.dev_c3850)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_5)
 
 
 class test_show_lldp_traffic(unittest.TestCase):


### PR DESCRIPTION
Hi,

here I fixed some regexes:

* Fixed regex for chassis id, now also supports ':' and '-'.
* Fixed regex for description, now also supports messages like '{"SN":"SN-NR","Owner":"OWNER"}'.
* Fixed regex for management addresses, now also supports IPv6 addresses.

I made the following keys optional in the 'med_information' part in the schema:

* 'f/w_revision'
* 'power_source'
* 'power_priority'
* 'wattage'
* 'capabilities'

Previously the regex for 'f/w_revision' was used to initialise the 'med_information' dictionary, since this information is now optional, I added a new regex checking for the 'MED Information:' line to initialise the dictionary.

![tests](https://user-images.githubusercontent.com/32892378/81546551-d1994f00-937a-11ea-8f33-69e550bbd3d5.jpg)
