### PR TITLE
show power inline

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -69,6 +69,10 @@
         * Fixed regex for vlan name, now also supports multiple white spaces.
         * Added regex for toking ring table.
         * Added the following keys: 'token_ring', 'are_hops', 'ste_hops' and 'backup_crf'.
+    * Renamed ShowPowerInlineInterface to ShowPowerInline
+        * Added 'watts' information the schema, containing available, used and remaining watts.
+        * Added regex to parse watts information
+        * Changed the regex to also support white spaces in device names
 
 * NXOS
     * Updated ShowIpStaticRouteMulticast:

--- a/src/genie/libs/parser/ios/show_power.py
+++ b/src/genie/libs/parser/ios/show_power.py
@@ -2,7 +2,7 @@
 
 """
 from genie.libs.parser.iosxe.show_power import ShowStackPower as ShowStackPower_iosxe,\
-                                               ShowPowerInlineInterface as ShowPowerInlineInterface_iosxe
+                                               ShowPowerInline as ShowPowerInlineInterface_iosxe
 
 
 class ShowStackPower(ShowStackPower_iosxe):

--- a/src/genie/libs/parser/ios/show_power.py
+++ b/src/genie/libs/parser/ios/show_power.py
@@ -2,7 +2,7 @@
 
 """
 from genie.libs.parser.iosxe.show_power import ShowStackPower as ShowStackPower_iosxe,\
-                                               ShowPowerInline as ShowPowerInlineInterface_iosxe
+                                               ShowPowerInline as ShowPowerInline_iosxe
 
 
 class ShowStackPower(ShowStackPower_iosxe):
@@ -10,6 +10,7 @@ class ShowStackPower(ShowStackPower_iosxe):
     pass
 
 
-class ShowPowerInlineInterface(ShowPowerInlineInterface_iosxe):
-    """Parser for show power inline <interface>"""
+class ShowPowerInline(ShowPowerInline_iosxe):
+    """Parser for show power inline
+                  show power inline <interface>"""
     pass

--- a/src/genie/libs/parser/ios/tests/test_show_power.py
+++ b/src/genie/libs/parser/ios/tests/test_show_power.py
@@ -5,7 +5,7 @@ from pyats.topology import Device
 
 from genie.metaparser.util.exceptions import SchemaEmptyParserError, SchemaMissingKeyError
 
-from genie.libs.parser.ios.show_power import ShowStackPower, ShowPowerInlineInterface
+from genie.libs.parser.ios.show_power import ShowStackPower, ShowPowerInline
 
 from genie.libs.parser.iosxe.tests.test_show_power import \
                 test_show_stack_power as test_show_stack_power_iosxe,\
@@ -32,14 +32,14 @@ class test_show_power_inline_interface(test_show_power_inline_interface_iosxe):
 
     def test_empty(self):
         self.dev1 = Mock(**self.empty_output)
-        platform_obj = ShowPowerInlineInterface(device=self.dev1)
+        platform_obj = ShowPowerInline(device=self.dev1)
         with self.assertRaises(SchemaEmptyParserError):
             parsed_output = platform_obj.parse(interface='Gi1/0/13')
 
     def test_golden(self):
         self.maxDiff = None
         self.dev_c3850 = Mock(**self.golden_output_c3850)
-        platform_obj = ShowPowerInlineInterface(device=self.dev_c3850)
+        platform_obj = ShowPowerInline(device=self.dev_c3850)
         parsed_output = platform_obj.parse(interface='Gi1/0/13')
         self.assertEqual(parsed_output,self.golden_parsed_output_c3850)
 

--- a/src/genie/libs/parser/iosxe/show_power.py
+++ b/src/genie/libs/parser/iosxe/show_power.py
@@ -105,7 +105,8 @@ class ShowPowerInlineSchema(MetaParser):
 
 
 class ShowPowerInline(ShowPowerInlineSchema):
-    """Parser for show power inline """
+    """Parser for show power inline
+                  show power inline <interface>"""
 
     cli_command = ['show power inline', 'show power inline {interface}']
 

--- a/src/genie/libs/parser/iosxe/show_power.py
+++ b/src/genie/libs/parser/iosxe/show_power.py
@@ -80,8 +80,8 @@ class ShowStackPower(ShowStackPowerSchema):
         return ret_dict
 
 
-class ShowPowerInlineInterfaceSchema(MetaParser):
-    """Schema for show power inline <interface>"""
+class ShowPowerInlineSchema(MetaParser):
+    """Schema for show power inline """
     schema = {
         'interface': {
             Any(): {
@@ -92,19 +92,32 @@ class ShowPowerInlineInterfaceSchema(MetaParser):
                 Optional('class'): str,
                 'max': float
             },
+        },
+        Optional('watts'): {
+            Any(): {
+                'module': str,
+                'available': float,
+                'used': float,
+                'remaining': float
+            }
         }
     }
 
 
-class ShowPowerInlineInterface(ShowPowerInlineInterfaceSchema):
-    """Parser for show power inline <interface>"""
+class ShowPowerInline(ShowPowerInlineSchema):
+    """Parser for show power inline """
 
-    cli_command = 'show power inline {interface}'
+    cli_command = ['show power inline', 'show power inline {interface}']
 
-    def cli(self, interface,output=None):
+    def cli(self, interface='', output=None):
         if output is None:
+            if interface:
+                cmd = self.cli_command[1].format(interface=interface)
+            else:
+                cmd = self.cli_command[0]
+
             # get output from device
-            out = self.device.execute(self.cli_command.format(interface=interface))
+            out = self.device.execute(cmd)
         else:
             out = output
 
@@ -112,13 +125,27 @@ class ShowPowerInlineInterface(ShowPowerInlineInterfaceSchema):
         ret_dict = {}
 
         # initial regexp pattern
-        p1 = re.compile(r'^(?P<intf>[\w\-\/\.]+) *'
-                         '(?P<admin_state>\w+) +'
-                         '(?P<oper_state>\w+) +'
-                         '(?P<power>[\d\.]+) +'
-                         '(?P<device>[\w\-\/]+) +'
-                         '(?P<class>[\w\/]+) +'
+        p1 = re.compile(r'^(?P<intf>[\w\-\/\.]+)\s*'
+                         '(?P<admin_state>\w+)\s+'
+                         '(?P<oper_state>\w+)\s+'
+                         '(?P<power>[\d\.]+)\s+'
+                         '(?P<device>(?=\S).*(?<=\S))\s+'
+                         '(?P<class>[\w\/]+)\s+'
                          '(?P<max>[\d\.]+)$')
+
+        # Module   Available     Used     Remaining
+        #          (Watts)     (Watts)    (Watts)
+        # ------   ---------   --------   ---------
+        # 1          1550.0      147.0      1403.0
+        p2 = re.compile(r'^(?P<module>\d+)\s+'
+                         '(?P<available>[\d\.]+)\s+'
+                         '(?P<used>[\d\.]+)\s+'
+                         '(?P<remaining>[\d\.]+)\s*$')
+
+        # Available:1170.0(w)  Used:212.2(w)  Remaining:957.8(w)
+        p3 = re.compile(r'^\s*[Aa]vailable\:(?P<available>[\d\.]+)\(\w+\)\s+'
+                         '[Uu]sed\:(?P<used>[\d\.]+)\(\w+\)\s+'
+                         '[Rr]emaining\:(?P<remaining>[\d\.]+)\(\w+\)\s*$')
 
         for line in out.splitlines():
             line = line.strip()
@@ -134,7 +161,42 @@ class ShowPowerInlineInterface(ShowPowerInlineInterfaceSchema):
                 intf_dict = ret_dict.setdefault('interface', {}).setdefault(intf, {})
                 intf_dict['power'] = float(group.pop('power'))
                 intf_dict['max'] = float(group.pop('max'))
-                intf_dict.update(
-                       {k:v for k, v in group.items() if 'n/a' not in v})
+                intf_dict.update({k: v for k, v in group.items() if 'n/a' not in v})
+
                 continue
+
+            # Module   Available     Used     Remaining
+            #          (Watts)     (Watts)    (Watts)
+            # ------   ---------   --------   ---------
+            # 1          1550.0      147.0      1403.0
+            m = p2.match(line)
+            if m:
+                group = m.groupdict()
+
+                module = group.pop('module')
+                stat_dict = ret_dict.setdefault('watts', {}).setdefault(module, {})
+
+                stat_dict['module'] = module
+                stat_dict['available'] = float(group.pop('available'))
+                stat_dict['used'] = float(group.pop('used'))
+                stat_dict['remaining'] = float(group.pop('remaining'))
+
+                continue
+
+            # Available:1170.0(w)  Used:212.2(w)  Remaining:957.8(w)
+            m = p3.match(line)
+            if m:
+                group = m.groupdict()
+
+                stat_dict = ret_dict.setdefault('watts', {}).setdefault('0', {})
+
+                stat_dict['module'] = '0'
+                stat_dict['available'] = float(group.pop('available'))
+                stat_dict['used'] = float(group.pop('used'))
+                stat_dict['remaining'] = float(group.pop('remaining'))
+
+        # Remove statistics if we don't have any interfaces
+        if 'interface' not in ret_dict and 'watts' in ret_dict:
+            ret_dict.pop('watts', None)
+
         return ret_dict

--- a/src/genie/libs/parser/iosxe/tests/test_show_power.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_power.py
@@ -5,7 +5,7 @@ from pyats.topology import Device
 
 from genie.metaparser.util.exceptions import SchemaEmptyParserError,\
                                        SchemaMissingKeyError
-from genie.libs.parser.iosxe.show_power import ShowStackPower, ShowPowerInlineInterface
+from genie.libs.parser.iosxe.show_power import ShowStackPower, ShowPowerInline
 
 
 class test_show_stack_power(unittest.TestCase):
@@ -98,18 +98,373 @@ class test_show_power_inline_interface(unittest.TestCase):
     '''
     }
 
+    golden_output_1 = {'execute.return_value': '''\
+        Module   Available     Used     Remaining
+                  (Watts)     (Watts)    (Watts) 
+        ------   ---------   --------   ---------
+        1          1550.0      147.0      1403.0
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi1/0/1   auto   off        0.0     n/a                 n/a   30.0 
+        Gi1/0/2   auto   off        0.0     n/a                 n/a   30.0 
+        Gi1/0/3   auto   off        0.0     n/a                 n/a   30.0 
+        
+        Module   Available     Used     Remaining
+                  (Watts)     (Watts)    (Watts) 
+        ------   ---------   --------   ---------
+        2          1550.0      424.7      1125.3
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi2/0/1   auto   on         7.1     IP Phone 8845       2     30.0 
+        Gi2/0/2   auto   off        0.0     n/a                 n/a   30.0 
+        Gi2/0/3   auto   on         26.1    AIR-AP2802I-E-K9    4     30.0 
+        
+        Module   Available     Used     Remaining
+                  (Watts)     (Watts)    (Watts) 
+        ------   ---------   --------   ---------
+        3          1550.0      397.4      1152.6
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi3/0/1   auto   on         26.1    AIR-AP2802I-E-K9    4     30.0 
+        Gi3/0/2   auto   on         26.1    AIR-AP2802I-E-K9    4     30.0 
+        
+        Module   Available     Used     Remaining
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+                  (Watts)     (Watts)    (Watts) 
+        ------   ---------   --------   ---------
+        4          1550.0      267.0      1283.0
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi4/0/1   auto   off        0.0     n/a                 n/a   30.0 
+        Gi4/0/2   auto   off        0.0     n/a                 n/a   30.0 
+        Gi4/0/3   auto   off        0.0     n/a                 n/a   30.0 
+        Gi4/0/4   auto   on         14.8    IP Phone 8865       4     30.0 
+        
+        Module   Available     Used     Remaining
+                  (Watts)     (Watts)    (Watts) 
+        ------   ---------   --------   ---------
+        5          1550.0       80.6      1469.4
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi5/0/1   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/2   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/3   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/4   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/5   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/6   auto   off        0.0     n/a                 n/a   30.0 
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi5/0/7   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/8   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/9   auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/10  auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/11  auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/12  auto   off        0.0     n/a                 n/a   30.0 
+        Gi5/0/13  auto   on         15.2    IP Phone 8865       4     30.0 
+       '''}
+
+    golden_parsed_output_1 = {
+        'watts': {
+            '1': {
+              'module': '1',
+              'available': 1550.0,
+              'used': 147.0,
+              'remaining': 1403.0
+            },
+            '2': {
+              'module': '2',
+              'available': 1550.0,
+              'used': 424.7,
+              'remaining': 1125.3
+            },
+            '3': {
+              'module': '3',
+              'available': 1550.0,
+              'used': 397.4,
+              'remaining': 1152.6
+            },
+            '4': {
+              'module': '4',
+              'available': 1550.0,
+              'used': 267.0,
+              'remaining': 1283.0
+            },
+            '5': {
+              'module': '5',
+              'available': 1550.0,
+              'used': 80.6,
+              'remaining': 1469.4
+            }
+        },
+        'interface': {
+            'GigabitEthernet1/0/1': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet1/0/2': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet1/0/3': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet2/0/1': {
+              'power': 7.1,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'IP Phone 8845',
+              'class': '2'
+            },
+            'GigabitEthernet2/0/2': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet2/0/3': {
+              'power': 26.1,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'AIR-AP2802I-E-K9',
+              'class': '4'
+            },
+            'GigabitEthernet3/0/1': {
+              'power': 26.1,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'AIR-AP2802I-E-K9',
+              'class': '4'
+            },
+            'GigabitEthernet3/0/2': {
+              'power': 26.1,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'AIR-AP2802I-E-K9',
+              'class': '4'
+            },
+            'GigabitEthernet4/0/1': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet4/0/2': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet4/0/3': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet4/0/4': {
+              'power': 14.8,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'IP Phone 8865',
+              'class': '4'
+            },
+            'GigabitEthernet5/0/1': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/2': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/3': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/4': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/5': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/6': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/7': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/8': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/9': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/10': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/11': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/12': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet5/0/13': {
+              'power': 15.2,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'IP Phone 8865',
+              'class': '4'
+            }
+        }
+    }
+
+    golden_output_2 = {'execute.return_value': '''\
+        Available:1170.0(w)  Used:212.2(w)  Remaining:957.8(w)
+        
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+        Gi0/1     auto   off        0.0     n/a                 n/a   30.0 
+        Gi0/2     auto   on         6.4     IP Phone 8945       2     30.0 
+        Gi0/3     auto   on         6.4     IP Phone 8845       2     30.0 
+        Gi0/4     auto   off        0.0     n/a                 n/a   30.0 
+    '''}
+
+    golden_parsed_output_2 = {
+        'watts': {
+            '0': {
+              'module': '0',
+              'available': 1170.0,
+              'used': 212.2,
+              'remaining': 957.8
+            }
+        },
+        'interface': {
+            'GigabitEthernet0/1': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            },
+            'GigabitEthernet0/2': {
+              'power': 6.4,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'IP Phone 8945',
+              'class': '2'
+            },
+            'GigabitEthernet0/3': {
+              'power': 6.4,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'on',
+              'device': 'IP Phone 8845',
+              'class': '2'
+            },
+            'GigabitEthernet0/4': {
+              'power': 0.0,
+              'max': 30.0,
+              'admin_state': 'auto',
+              'oper_state': 'off'
+            }
+        }
+    }
+
+    golden_output_3 = {'execute.return_value': '''\
+        Available:0.0(w)  Used:0.0(w)  Remaining:0.0(w)
+
+        Interface Admin  Oper       Power   Device              Class Max
+                                    (Watts)                            
+        --------- ------ ---------- ------- ------------------- ----- ----
+    '''}
+
     def test_empty(self):
         self.dev1 = Mock(**self.empty_output)
-        platform_obj = ShowPowerInlineInterface(device=self.dev1)
+        platform_obj = ShowPowerInline(device=self.dev1)
         with self.assertRaises(SchemaEmptyParserError):
             parsed_output = platform_obj.parse(interface='Gi1/0/13')    
 
     def test_golden(self):
         self.maxDiff = None
         self.dev_c3850 = Mock(**self.golden_output_c3850)
-        platform_obj = ShowPowerInlineInterface(device=self.dev_c3850)
+        platform_obj = ShowPowerInline(device=self.dev_c3850)
         parsed_output = platform_obj.parse(interface='Gi1/0/13')
         self.assertEqual(parsed_output,self.golden_parsed_output_c3850)
+
+    def test_golden_1(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_1)
+        platform_obj = ShowPowerInline(device=self.dev_c3850)
+        parsed_output = platform_obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_1)
+
+    def test_golden_2(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_2)
+        platform_obj = ShowPowerInline(device=self.dev_c3850)
+        parsed_output = platform_obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output_2)
+
+    def test_golden_3(self):
+        self.maxDiff = None
+        self.dev_c3850 = Mock(**self.golden_output_3)
+        platform_obj = ShowPowerInline(device=self.dev_c3850)
+        with self.assertRaises(SchemaEmptyParserError):
+            parsed_output = platform_obj.parse()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,

we also wanted to be able to parse the output of `show power inline`. 
Therefore I changed the names from 'ShowPowerInlineInterface' to 'ShowPowerInline' (I copied that from 'ShowInterfaces').

I also added a new key to schema named 'watts' containing the available, used and remaining watts.
I changed the regex to also support white spaces in the device names.

Is there anything else I have to do because of renaming?

![tests](https://user-images.githubusercontent.com/32892378/81693913-f2d46b00-9460-11ea-8399-873049c9ddab.jpg)
