### PR TITLE
show interface status fix

### DIFF
--- a/src/genie/libs/parser/nxos/show_interface.py
+++ b/src/genie/libs/parser/nxos/show_interface.py
@@ -3397,13 +3397,14 @@ class ShowInterfaceStatus(ShowInterfaceStatusSchema):
 
         # Eth1/5 *** L2 L3-CIS-N connected trunk full a-1000 1000base-T
         # Eth1/4 *** FEX 2248TP  connected 1     full a-10G  Fabric Exte
-        p1_1 = re.compile(r'^(?P<interface>(\S+)) '
-                          r'+(?P<name>(\*\*\*\s)([\S\s]+)) '
-                          r'+(?P<status>\S+) '
-                          r'+(?P<vlan>\S+) '
-                          r'+(?P<duplex_code>([a-z]+)) '
-                          r'+(?P<port_speed>(\S+)) '
-                          r'+(?P<type>([\S\s]+))$')
+        p1_1 = re.compile(r'(?P<interface>(\S+)) +'
+                        r'(?P<name>([\S\s]+))(?<! ) +'
+                        r'(?P<status>(\S+)) +'
+                        r'(?P<vlan>(\S+)) +'
+                        r'(?P<duplex_code>([a-z]+)) +'
+                        r'(?P<port_speed>(\S+)) +'
+                        r'(?P<type>([\S\s]+))$')
+
 
         for line in out.splitlines():
             line = line.strip()

--- a/src/genie/libs/parser/nxos/tests/test_show_interface.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_interface.py
@@ -7028,7 +7028,7 @@ class test_show_interface_status(unittest.TestCase):
             },
             'Ethernet1/4': {
                 'duplex_code': 'full',
-                'name': '*** FEX 2248TP ',
+                'name': '*** FEX 2248TP',
                 'port_speed': 'a-10G',
                 'status': 'connected',
                 'type': 'Fabric Exte',


### PR DESCRIPTION
A couple of fixes.

in test  file, removed additional white space. not needed?

In :show interface status" block, added a generic regex so 'name' can be any string, including white spaces