### PR TITLE
Additional parsed attributes for show running-config interface

### DIFF
--- a/changelog/undistributed.rst
+++ b/changelog/undistributed.rst
@@ -85,6 +85,11 @@
         * Added regex to support interfaces down for SFP Not Inserted
         * Added regex to support interfaces down for ErrDisabled
         * Added regex to support interfaces down due to being suspended (LACP)
+    * Updated ShowRunningConfigInterface:
+        * Added regex to support vpc
+        * Added regex to support native vlan
+        * Added regex to support switchport_mode access
+        * Fixed regex to allow white spaces in description
 
 * IOSXR
     * Updated ShowBgpSessions:

--- a/src/genie/libs/parser/nxos/show_interface.py
+++ b/src/genie/libs/parser/nxos/show_interface.py
@@ -2887,10 +2887,12 @@ class ShowRunningConfigInterfaceSchema(MetaParser):
                      Optional('switchport'): bool,
                      Optional('switchport_mode'): str,
                      Optional('trunk_vlans'): str,
+                     Optional('trunk_native_vlan'): str,
                      Optional('description'): str,
                      Optional('access_vlan'): str,
                      Optional('speed'): int,
                      Optional('duplex'): str,
+                     Optional('vpc'): str,
                      Optional('port_channel'):{
                         Optional('port_channel_mode'): str,
                         Optional('port_channel_int'): str,
@@ -3043,12 +3045,21 @@ class ShowRunningConfigInterface(ShowRunningConfigInterfaceSchema):
                 group = m.groupdict()
                 interface_dict.update({'trunk_vlans': group['trunk_vlans']})
                 continue
-
-            # switchport access vlan x
-            p10_1 = re.compile(r'^switchport +access +vlan +(?P<access_vlan>\S+)$')
+            
+            # switchport trunk native vlan x
+            p10_1 = re.compile(r'^switchport +trunk +native +vlan +(?P<trunk_native_vlan>\S+)$')
             m = p10_1.match(line)
             if m:
                 group = m.groupdict()
+                interface_dict.update({'trunk_native_vlan': group['trunk_native_vlan']})
+                continue
+
+            # switchport access vlan x
+            p10_2 = re.compile(r'^switchport +access +vlan +(?P<access_vlan>\S+)$')
+            m = p10_2.match(line)
+            if m:
+                group = m.groupdict()
+                interface_dict.update({'switchport_mode': 'access'})
                 interface_dict.update({'access_vlan': group['access_vlan']})
                 continue
 
@@ -3077,10 +3088,18 @@ class ShowRunningConfigInterface(ShowRunningConfigInterfaceSchema):
                 continue
 
             # description DeviceA-description
-            p14 = re.compile(r'^description +(?P<description>\S+)$')
+            p14 = re.compile(r'^description +(?P<description>.+)$')
             m = p14.match(line)
             if m:
                 interface_dict.update({'description': m.groupdict()['description']})
+                continue
+
+            # vpc
+            p15 = re.compile(r'^vpc +(?P<vpc>\S+)$')
+            m = p15.match(line)
+            if m:
+                group = m.groupdict()
+                interface_dict.update({'vpc': group['vpc']})
                 continue
 
         return ret_dict

--- a/src/genie/libs/parser/nxos/tests/test_show_interface.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_interface.py
@@ -6388,9 +6388,11 @@ class TestShowRunInterface(unittest.TestCase):
     golden_parsed_output_2 = {
         'interface': {
             'Ethernet1/1': {
+                'description': '*** Peer Link ***',
                 'switchport': True,
                 'switchport_mode': 'trunk',
                 'trunk_vlans': '1-99,101-199,201-1399,1401-4094',
+                'trunk_native_vlan': '330',
                 'port_channel':{
                     'port_channel_mode': 'active',
                     'port_channel_int': '1',
@@ -6411,6 +6413,7 @@ class TestShowRunInterface(unittest.TestCase):
           description *** Peer Link ***
           switchport
           switchport mode trunk
+          switchport trunk native vlan 330
           switchport trunk allowed vlan 1-99,101-199,201-1399,1401-4094
           channel-group 1 mode active
           no shutdown
@@ -6433,11 +6436,36 @@ class TestShowRunInterface(unittest.TestCase):
             'Ethernet1/4': {
                 'duplex': 'full',
                 'access_vlan': 'x',
+                'switchport_mode': 'access',
                 'speed': 1000,
                 'description': 'DeviceA-description',
             },
         },
     }
+
+    golden_output_4 = {'execute.return_value': '''
+    interface port-channel5
+      description Port Channel Config Tst
+      switchport mode trunk
+      switchport trunk native vlan 2253
+      switchport trunk allowed vlan 2253
+      speed 10000
+      vpc 5
+    '''}
+
+    golden_parsed_output_4 = {
+        'interface': {
+            'port-channel5': {
+                'description': 'Port Channel Config Tst',
+                'switchport_mode': 'trunk',
+                'trunk_native_vlan': '2253',
+                'trunk_vlans': '2253',
+                'speed': 10000,
+                'vpc': '5'
+            },
+        },
+    }
+
 
     def test_golden(self):
         self.device = Mock(**self.golden_output)
@@ -6468,6 +6496,12 @@ class TestShowRunInterface(unittest.TestCase):
         intf_obj = ShowRunningConfigInterface(device=self.device)
         parsed_output = intf_obj.parse(interface='Ethernet1/4')
         self.assertEqual(parsed_output,self.golden_parsed_output_3)
+
+    def test_golden_4(self):
+        self.device = Mock(**self.golden_output_4)
+        intf_obj = ShowRunningConfigInterface(device=self.device)
+        parsed_output = intf_obj.parse(interface='port-channel10')
+        self.assertEqual(parsed_output,self.golden_parsed_output_4)
 
 
 class TestShowNveInterface(unittest.TestCase):


### PR DESCRIPTION
Additional parsed attributes:
trunk_native_vlan
vpc
swtichport_mode  --> Value 'access'

'description' field must be able to take strings with white space

Also modified test script to take into account these changes