### PR TITLE
Genieparser Issue - regex for VRF

### DIFF
--- a/src/genie/libs/parser/nxos/show_cdp.py
+++ b/src/genie/libs/parser/nxos/show_cdp.py
@@ -29,7 +29,7 @@ class ShowCdpNeighborsSchema(MetaParser):
                     {'device_id': str,
                      'local_interface': str,
                      'hold_time': int,
-                     Optional('capability'): str,
+                     'capability': str,
                      'platform': str,
                      'port_id': str, }, }, },
     }

--- a/src/genie/libs/parser/nxos/show_cdp.py
+++ b/src/genie/libs/parser/nxos/show_cdp.py
@@ -27,9 +27,6 @@ class ShowCdpNeighborsSchema(MetaParser):
             {Optional('index'):
                 {Any():
                     {'device_id': str,
-                     'local_interface': str,
-                     'hold_time': int,
-                     'capability': str,
                      'platform': str,
                      'port_id': str, }, }, },
     }


### PR DESCRIPTION
In our VRF naming convention we use AAA:123 format. VRFs containing the ‘:’ character seem to be missed by the genie parser.  As a quick test I changed the regex value in one of the pyATS parser files to this value - (?P<vrf_name>[A-Za-z0-9:]+) - Previously the pattern was - (?P<vrf_name>[A-Za-z0-9]+) 
 
This then corrected the problem, so looks like the RegEx in genie parser is not currently setup to allow non alpha numeric characters. 



 
