### PR TITLE
Fix show cdp for subinterfaces

### DIFF
--- a/src/genie/libs/parser/iosxe/show_cdp.py
+++ b/src/genie/libs/parser/iosxe/show_cdp.py
@@ -82,7 +82,7 @@ class ShowCdpNeighbors(ShowCdpNeighborsSchema):
         p4 = re.compile(r'^(?P<device_id>\S+)$')
         p5 = re.compile(r'(?P<local_interface>[a-zA-Z]+[\s]*[\d/.]+) +'
                         r'(?P<hold_time>\d+) +(?P<capability>[RTBSHIrPDCM\s]+) +'
-                        r'(?P<platform>\S+) (?P<port_id>[a-zA-Z0-9/\s]+)$')
+                        r'(?P<platform>\S+) (?P<port_id>[\.a-zA-Z0-9/\s]+)$')
 
         device_id_index = 0
         parsed_dict = {}


### PR DESCRIPTION
allowed for . in port_id to support cdp neighbor subinterfaces e.g  GigabitEthernet0/1.1

Test data:
abcdefgs01c37#show cdp neighbors
Capability Codes: R - Router, T - Trans Bridge, B - Source Route Bridge
                  S - Switch, H - Host, I - IGMP, r - Repeater, P - Phone,
                  D - Remote, C - CVTA, M - Two-port Mac Relay
 
Device ID        Local Intrfce     Holdtme    Capability  Platform  Port ID
abcdefgr01c39.abc.defghi.klm.no
                 Gig 1/0/1         150            R B S I CISCO3945 Gig 0/1.1
 
Total cdp entries displayed : 1
