### PR TITLE
Minor enhancements to ci_folder_parsing script

### DIFF
--- a/changelog/changelog_ci_parsing20201008103500.rst
+++ b/changelog/changelog_ci_parsing20201008103500.rst
@@ -1,0 +1,5 @@
+--------------------------------------------------------------------------------
+                                New
+--------------------------------------------------------------------------------
+* Common
+    * Updated ci_parsing_folder script to accept argument '--number' or '-n' to specify which test output to run

--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -1,19 +1,24 @@
 """Testing strategy for dynamic testing via folder structure."""
 
-import importlib
-import inspect
+# Python
 import os
+import re
 import glob
 import json
+import inspect
 import argparse
+import importlib
 from unittest.mock import Mock
+
+# pyATS
 from pyats import aetest
+from pyats.topology import Device
 from pyats.aetest.steps import Steps
 
+# Genie
 from genie.libs import parser as _parser
 from genie.metaparser.util.exceptions import SchemaEmptyParserError
 
-from pyats.topology import Device
 
 # Create the parser
 my_parser = argparse.ArgumentParser(description="Optional arguments for 'nose'-like tests")
@@ -29,11 +34,16 @@ my_parser.add_argument('-t', "--token",
                        type=str,
                        help="The Token associated with the class, such as 'asr1k'",
                        default=None)
+my_parser.add_argument('-n', "--number",
+                       type=str,
+                       help="The specific unittest we want to run, such as '25'",
+                       default=None)
 args = my_parser.parse_args()
 
 _os = args.operating_system
 _class = args.class_name
 _token = args.token
+_number = args.number
 
 # This is the list of Classes that currently have no testing. It was found during the process
 # of converting to folder based testing strategy
@@ -186,6 +196,7 @@ def get_tokens(folder):
         tokens.append(path.split('/')[-2])
     return tokens
 
+
 def get_files(folder, token=None):
     files = []
     for parse_file in glob.glob(f"{folder}/*.py"):
@@ -201,7 +212,7 @@ class FileBasedTest(aetest.Testcase):
     OPERATING_SYSTEMS = get_operating_systems()
     @aetest.test
     @aetest.test.loop(operating_system=OPERATING_SYSTEMS)
-    def check_os_folder(self, steps, operating_system):
+    def check_os_folder(self, steps, operating_system, number=_number):
         """Loop through OS's and run appropriate tests."""
         base_folder = f"../src/genie/libs/parser/{operating_system}"
         # Please refer to get_tokens comments for the how, the what is a genie token, such as
@@ -262,7 +273,7 @@ class FileBasedTest(aetest.Testcase):
                             continue_=True,
                         ) as golden_steps:
                             self.test_golden(
-                                golden_steps, local_class, operating_system, token
+                                golden_steps, local_class, operating_system, token, _number
                             )
                         with class_step.start(
                             f"Test Empty -> {operating_system} -> {name}",
@@ -270,13 +281,21 @@ class FileBasedTest(aetest.Testcase):
                         ) as empty_steps:
                             self.test_empty(empty_steps, local_class, operating_system, token)
 
-    def test_golden(self, steps, local_class, operating_system, token=None):
+    def test_golden(self, steps, local_class, operating_system, token=None, number=None):
         """Test step that finds any output named with _output.txt, and compares to similar named .py file."""
         if token:
             folder_root = f"{operating_system}/{token}/{local_class.__name__}/cli/equal"
         else:
             folder_root = f"{operating_system}/{local_class.__name__}/cli/equal"
-        output_glob = glob.glob(f"{folder_root}/*_output.txt")
+
+        # Get list of output files to parse and sort
+        convert = lambda text: int(text) if text.isdigit() else text
+        aph_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+        if number:
+            output_glob = sorted(glob.glob(f"{folder_root}/golden_output{number}_output.txt"), key=aph_key)
+        else:
+            output_glob = sorted(glob.glob(f"{folder_root}/*_output.txt"), key=aph_key)
+
         if len(output_glob) == 0:
             self.failed(f"No files found in appropriate directory for {local_class}")
 

--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -3,6 +3,7 @@
 # Python
 import os
 import re
+import sys
 import glob
 import json
 import inspect
@@ -35,7 +36,7 @@ my_parser.add_argument('-t', "--token",
                        help="The Token associated with the class, such as 'asr1k'",
                        default=None)
 my_parser.add_argument('-n', "--number",
-                       type=str,
+                       type=int,
                        help="The specific unittest we want to run, such as '25'",
                        default=None)
 args = my_parser.parse_args()
@@ -179,7 +180,8 @@ def get_operating_systems():
     # Update and fix as more OS's converted to folder baed tests
     if _os:
         return [_os]
-    return ["asa", "ios", "iosxe"]
+    sys.exit("Argument '-o' or '--operating_system' for operating system not provided")
+    # return ["asa", "ios", "iosxe"]
     # operating_system = []
     # for folder in os.listdir("./"):
     #    if os.path.islink("./" + folder):

--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -46,6 +46,9 @@ _class = args.class_name
 _token = args.token
 _number = args.number
 
+if _number and not _class:
+    sys.exit("Unittest number provided without specifying argument '-c' or '--class_name' for the parser class")
+
 # This is the list of Classes that currently have no testing. It was found during the process
 # of converting to folder based testing strategy
 CLASS_SKIP = {

--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -46,8 +46,8 @@ _class = args.class_name
 _token = args.token
 _number = args.number
 
-if _number and not _class or not _os:
-    sys.exit("Unittest number provided without specifying supporting arguments:"
+if _number and not _class or _number and not _os:
+    sys.exit("Unittest number provided but missing supporting arguments:"
              "\n* '-c' or '--class_name' for the parser class"
              "\n* '-o' or '--operating_system' for operating system")
 
@@ -297,7 +297,7 @@ class FileBasedTest(aetest.Testcase):
         # Get list of output files to parse and sort
         convert = lambda text: int(text) if text.isdigit() else text
         aph_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
-        if number:
+        if number and not operating_system or not local_class:
             output_glob = sorted(glob.glob(f"{folder_root}/golden_output{number}_output.txt"), key=aph_key)
         else:
             output_glob = sorted(glob.glob(f"{folder_root}/*_output.txt"), key=aph_key)

--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -46,7 +46,7 @@ _class = args.class_name
 _token = args.token
 _number = args.number
 
-if _number and not _class or _number and not _os:
+if _number and (not _class or not _number):
     sys.exit("Unittest number provided but missing supporting arguments:"
              "\n* '-c' or '--class_name' for the parser class"
              "\n* '-o' or '--operating_system' for operating system")

--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -46,8 +46,10 @@ _class = args.class_name
 _token = args.token
 _number = args.number
 
-if _number and not _class:
-    sys.exit("Unittest number provided without specifying argument '-c' or '--class_name' for the parser class")
+if _number and not _class or not _os:
+    sys.exit("Unittest number provided without specifying supporting arguments:"
+             "\n* '-c' or '--class_name' for the parser class"
+             "\n* '-o' or '--operating_system' for operating system")
 
 # This is the list of Classes that currently have no testing. It was found during the process
 # of converting to folder based testing strategy
@@ -183,8 +185,7 @@ def get_operating_systems():
     # Update and fix as more OS's converted to folder baed tests
     if _os:
         return [_os]
-    sys.exit("Argument '-o' or '--operating_system' for operating system not provided")
-    # return ["asa", "ios", "iosxe"]
+    return ["asa", "ios", "iosxe"]
     # operating_system = []
     # for folder in os.listdir("./"):
     #    if os.path.islink("./" + folder):


### PR DESCRIPTION
## Description
Updated ci_parsing_folder script to accept argument '--number' or '-n' to specify which test output to run

## Motivation and Context
Updated ci_parsing_folder script to accept argument '--number' or '-n' to specify which test output to run

## Impact (If any)
N/A

## Screenshots:
![image](https://user-images.githubusercontent.com/30269622/95623471-5203cf00-0a43-11eb-8914-402a8ccbb23d.png)


```
(py381) LRASHEED-M-43JH:tests lrasheed$ python ci_folder_parsing.py -o iosxe -c ShowPolicyMapInterface -n 8
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: |                       Starting testcase FileBasedTest                        |
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: |           Starting section check_os_folder[operating_system=iosxe]           |
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: :               Starting STEP 1: iosxe -> ShowPolicyMapInterface               :
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: :      Starting STEP 1.1: Test Golden -> iosxe -> ShowPolicyMapInterface       :
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: :    Starting STEP 1.1.1: ('Gold -> iosxe -> ShowPolicyMapInterface -> gold    :
2020-10-08T10:40:06: %AETEST-INFO: :                                en_output8',)                                 :
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: The result of STEP 1.1.1: ('Gold -> iosxe -> ShowPolicyMapInterface -> golden_output8',) is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowPolicyMapInterface is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: :       Starting STEP 1.2: Test Empty -> iosxe -> ShowPolicyMapInterface       :
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: :    Starting STEP 1.2.1: Empty -> iosxe -> ShowPolicyMapInterface -> empty    :
2020-10-08T10:40:06: %AETEST-INFO: :                                   _output                                    :
2020-10-08T10:40:06: %AETEST-INFO: +..............................................................................+
2020-10-08T10:40:06: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowPolicyMapInterface -> empty_output is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowPolicyMapInterface is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: The result of STEP 1: iosxe -> ShowPolicyMapInterface is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: +----------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: |                       STEPS Report                       |
2020-10-08T10:40:06: %AETEST-INFO: +----------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: STEP 1 - iosxe -> ShowPolicyMapInterface              Passed
2020-10-08T10:40:06: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowPolicyMapInterface    Passed
2020-10-08T10:40:06: %AETEST-INFO: STEP 1.1.1 - ('Gold -> iosxe -> ShowPolicyMapInterface -> golden_output8',)    Passed
2020-10-08T10:40:06: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowPolicyMapInterface    Passed
2020-10-08T10:40:06: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowPolicyMapInterface -> empty_output    Passed
2020-10-08T10:40:06: %AETEST-INFO: ------------------------------------------------------------
2020-10-08T10:40:06: %AETEST-INFO: The result of section check_os_folder[operating_system=iosxe] is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: The result of testcase FileBasedTest is => PASSED
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: |                               Detailed Results                               |
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO:  SECTIONS/TESTCASES                                                      RESULT
2020-10-08T10:40:06: %AETEST-INFO: --------------------------------------------------------------------------------
2020-10-08T10:40:06: %AETEST-INFO: .
2020-10-08T10:40:06: %AETEST-INFO: `-- FileBasedTest                                                         PASSED
2020-10-08T10:40:06: %AETEST-INFO:     `-- check_os_folder[operating_system=iosxe]                           PASSED
2020-10-08T10:40:06: %AETEST-INFO:         |-- Step 1: iosxe -> ShowPolicyMapInterface                       PASSED
2020-10-08T10:40:06: %AETEST-INFO:         |-- Step 1.1: Test Golden -> iosxe -> ShowPolicyMapInterface      PASSED
2020-10-08T10:40:06: %AETEST-INFO:         |-- Step 1.1.1: ('Gold -> iosxe -> ShowPolicyMapInterface -...    PASSED
2020-10-08T10:40:06: %AETEST-INFO:         |-- Step 1.2: Test Empty -> iosxe -> ShowPolicyMapInterface       PASSED
2020-10-08T10:40:06: %AETEST-INFO:         `-- Step 1.2.1: Empty -> iosxe -> ShowPolicyMapInterface ->...    PASSED
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO: |                                   Summary                                    |
2020-10-08T10:40:06: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-08T10:40:06: %AETEST-INFO:  Number of ABORTED                                                            0
2020-10-08T10:40:06: %AETEST-INFO:  Number of BLOCKED                                                            0
2020-10-08T10:40:06: %AETEST-INFO:  Number of ERRORED                                                            0
2020-10-08T10:40:06: %AETEST-INFO:  Number of FAILED                                                             0
2020-10-08T10:40:06: %AETEST-INFO:  Number of PASSED                                                             1
2020-10-08T10:40:06: %AETEST-INFO:  Number of PASSX                                                              0
2020-10-08T10:40:06: %AETEST-INFO:  Number of SKIPPED                                                            0
2020-10-08T10:40:06: %AETEST-INFO:  Total Number                                                                 1
2020-10-08T10:40:06: %AETEST-INFO:  Success Rate                                                            100.0%
2020-10-08T10:40:06: %AETEST-INFO: --------------------------------------------------------------------------------
(py381) LRASHEED-M-43JH:tests lrasheed$
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
