### PR TITLE
fixed make json issue

### DIFF
--- a/src/genie/libs/parser/iosxe/show_wireless.py
+++ b/src/genie/libs/parser/iosxe/show_wireless.py
@@ -1167,7 +1167,6 @@ class ShowWirelessCtsSummary(ShowWirelessCtsSummarySchema):
 
         return wireless_cts_summary_dict
 
-=======
 # ========================================
 # Schema for:
 #  * 'show wireless fabric client summary'
@@ -1537,7 +1536,7 @@ class ShowWirelessClientSummary(ShowWirelessClientSummarySchema):
         include_index = 0
         exclude_index = 0
 
-        for line in out.splitlines():
+        for line in output.splitlines():
             line = line.strip()
             # Number of Clients: 13
             if wireless_client_count_capture.match(line):
@@ -1875,7 +1874,12 @@ class ShowWirelessProfilePolicySummarySchema(MetaParser):
     schema = {
         "policy_count": int,
         "policy_name": {
-            Any(): {"description": str, "status": str},
+            Any(): {
+              "description": str,
+              "status": str
+            },
+        }
+    }
 
 # =========================================
 # Parser for:
@@ -2026,31 +2030,26 @@ class ShowWirelessStatsApJoinSummary(ShowWirelessStatsApJoinSummarySchema):
         )
 
         wireless_info_obj = {}
-          
-          if ap_count_capture.match(line):
 
-              # only grab the first entry from output
-              if not wireless_info_obj.get("ap_count"):
-                  ap_count_match = ap_count_capture.match(line)
-                  group = ap_count_match.groupdict()
-
-                  # convert value from str to int
-                  ap_count_dict = {"ap_count": int(group["ap_count"])}
-
-                  wireless_info_obj.update(ap_count_dict)
-
+        for line in output.splitlines():
+            line = line.strip()
+            if ap_count_capture.match(line):
+                # only grab the first entry from output
+                if not wireless_info_obj.get("ap_count"):
+                    ap_count_match = ap_count_capture.match(line)
+                    group = ap_count_match.groupdict()
+                    # convert value from str to int
+                    ap_count_dict = {"ap_count": int(group["ap_count"])}
+                    wireless_info_obj.update(ap_count_dict)
             if ap_join_capture.match(line):
                 ap_join_match = ap_join_capture.match(line)
                 group = ap_join_match.groupdict()
-
                 # pull the base_mac to use as key then pop it from the dict
                 ap_info_dict = {group["base_mac"]: {}}
                 ap_info_dict[group["base_mac"]].update(group)
                 ap_info_dict[group["base_mac"]].pop("base_mac")
-
                 if not wireless_info_obj.get("base_mac"):
                     wireless_info_obj["base_mac"] = {}
-
                 wireless_info_obj["base_mac"].update(ap_info_dict)
 
         return wireless_info_obj

--- a/src/genie/libs/parser/iosxe/show_wireless.py
+++ b/src/genie/libs/parser/iosxe/show_wireless.py
@@ -1990,6 +1990,8 @@ class ShowWirelessStatsApJoinSummary(ShowWirelessStatsApJoinSummarySchema):
     def cli(self, output=None):
         if output is None:
             out = self.device.execute(self.cli_command[0])
+        else:
+            out = output
 
         # Number of APs: 61
 

--- a/src/genie/libs/parser/iosxe/show_wireless.py
+++ b/src/genie/libs/parser/iosxe/show_wireless.py
@@ -1990,8 +1990,6 @@ class ShowWirelessStatsApJoinSummary(ShowWirelessStatsApJoinSummarySchema):
     def cli(self, output=None):
         if output is None:
             out = self.device.execute(self.cli_command[0])
-        else:
-            out = self.device.execute(self.cli_command[0], output=output)
 
         # Number of APs: 61
 

--- a/src/genie/libs/parser/iosxe/show_wireless.py
+++ b/src/genie/libs/parser/iosxe/show_wireless.py
@@ -1989,9 +1989,9 @@ class ShowWirelessStatsApJoinSummary(ShowWirelessStatsApJoinSummarySchema):
           
     def cli(self, output=None):
         if output is None:
-            output = self.device.execute(self.cli_command[0])
+            out = self.device.execute(self.cli_command[0])
         else:
-            output = output
+            out = self.device.execute(self.cli_command[0], output=output)
 
         # Number of APs: 61
 
@@ -2031,7 +2031,7 @@ class ShowWirelessStatsApJoinSummary(ShowWirelessStatsApJoinSummarySchema):
 
         wireless_info_obj = {}
 
-        for line in output.splitlines():
+        for line in out.splitlines():
             line = line.strip()
             if ap_count_capture.match(line):
                 # only grab the first entry from output


### PR DESCRIPTION
## Description
fixed reported issue https://github.com/CiscoTestAutomation/genieparser/issues/299 which user couldn't run `make json`

## Motivation and Context
Fixed a bug

## Impact (If any)
No impact

## Screenshots:
```
2020-10-16T09:44:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-16T09:44:14: %AETEST-INFO: |                               Detailed Results                               |
2020-10-16T09:44:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2020-10-16T09:44:14: %AETEST-INFO:  SECTIONS/TESTCASES                                                      RESULT
2020-10-16T09:44:14: %AETEST-INFO: --------------------------------------------------------------------------------
2020-10-16T09:44:14: %AETEST-INFO: .
2020-10-16T09:44:14: %AETEST-INFO: `-- FileBasedTest                                                         PASSED
2020-10-16T09:44:14: %AETEST-INFO:     `-- check_os_folder[operating_system=iosxe]                           PASSED
2020-10-16T09:44:14: %AETEST-INFO:         |-- Step 1: iosxe -> ShowWirelessStatsApJoinSummary               PASSED
2020-10-16T09:44:14: %AETEST-INFO:         |-- Step 1.1: Test Golden -> iosxe -> ShowWirelessStatsApJo...    PASSED
2020-10-16T09:44:14: %AETEST-INFO:         |-- Step 1.1.1: ('Gold -> iosxe -> ShowWirelessStatsApJoinS...    PASSED
2020-10-16T09:44:14: %AETEST-INFO:         |-- Step 1.2: Test Empty -> iosxe -> ShowWirelessStatsApJoi...    PASSED
2020-10-16T09:44:14: %AETEST-INFO:         `-- Step 1.2.1: Empty -> iosxe -> ShowWirelessStatsApJoinSu...    PASSED
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
