### PR TITLE
update iosxe show lldp neighbor to allow space in deviceid

### DIFF
--- a/changelog/changelog_show_lldp_neighbor20201125051828
+++ b/changelog/changelog_show_lldp_neighbor20201125051828
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                                New
+--------------------------------------------------------------------------------
+* IOSXE
+    * Updated Show lldp neigh:
+      * show lldp neighbor
+        updated to allow Device ID with space and 20 characters

--- a/changelog/changelog_show_lldp_neighbor20201125051828
+++ b/changelog/changelog_show_lldp_neighbor20201125051828
@@ -3,5 +3,4 @@
 --------------------------------------------------------------------------------
 * IOSXE
     * Updated Show lldp neigh:
-      * show lldp neighbor
-        updated to allow Device ID with space and 20 characters
+        * show lldp neighbor updated to allow Device ID with space and 20 characters

--- a/src/genie/libs/parser/iosxe/show_lldp.py
+++ b/src/genie/libs/parser/iosxe/show_lldp.py
@@ -698,7 +698,9 @@ class ShowLldpNeighbors(ShowLldpNeighborsSchema):
         # router               Gi1/0/52       117        R               Gi0/0/0
         # 10.10.191.107       Gi1/0/14       155        B,T             7038.eeff.572d
         # d89e.f3ff.58fe      Gi1/0/33       3070                       d89e.f3ff.58fe
-        p2 = re.compile(r'(?P<device_id>\S+)\s+(?P<interfaces>\S+)'
+        # Polycom Trio Visual+Gi2/0/28       120        T               6416.7f1e.ff12
+
+        p2 = re.compile(r'(?P<device_id>.{20})(?P<interfaces>\S+)'
                         r'\s+(?P<hold_time>\d+)\s+(?P<capabilities>[A-Z,]+)?'
                         r'\s+(?P<port_id>\S+)')
 


### PR DESCRIPTION
## Description
updates show lldp neighbor to allow for space in device id and 20 characters

## Motivation and Context
wasn't correctly parsing lldp neighbor with space in device id and 20 characters long

## Impact (If any)
no negative impact

## Screenshots:
 python -m unittest
..................................................................................................................................................................................................................................................../home/mike/pydev/genieparser/src/genie/libs/parser/iosxr/show_controllers.py:78: FutureWarning: Possible nested set at position 74
  p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
/home/mike/pydev/genieparser/src/genie/libs/parser/iosxr/show_controllers.py:78: FutureWarning: Possible nested set at position 176
  p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................../home/mike/pydev/genieparser/src/genie/libs/parser/utils/common.py:607: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  cmd_node = root.getchildren()[0]
/home/mike/pydev/genieparser/src/genie/libs/parser/utils/common.py:620: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  cmd_node = cmd_node.getchildren()
....................................................................../home/mike/pydev/genieparser/src/genie/libs/parser/nxos/show_bgp.py:8976: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  for item in nei.getchildren():
/home/mike/pydev/genieparser/src/genie/libs/parser/nxos/show_bgp.py:8984: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  root = item.getchildren()[0]
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 1825 tests in 64.988s

OK


## Checklist:

- [x ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x ] All new and existing tests passed.
- [x ] All new code passed compilation.
