### PR TITLE
[Fix] - Bug on "show isis neighbor commad"

### DIFF
--- a/src/genie/libs/parser/iosxe/show_isis.py
+++ b/src/genie/libs/parser/iosxe/show_isis.py
@@ -15,6 +15,7 @@ import re
 # Metaparser
 from genie.metaparser import MetaParser
 from genie.metaparser.util.schemaengine import Schema, Any, Optional
+from genie.libs.parser.utils.common import Common
 
 
 class ShowIsisNeighborsSchema(MetaParser):
@@ -80,14 +81,15 @@ class ShowIsisNeighbors(ShowIsisNeighborsSchema):
                                               setdefault('neighbors', {}).setdefault(system_id, {})
                 else:
                     neighbour_dict = isis_dict.setdefault('neighbors', {}).setdefault(system_id, {})
-
+                
                 type_dict = neighbour_dict.setdefault('type', {}).setdefault(isis_type, {})
-
-                type_dict['interface'] = m.groupdict()['interface']
-                type_dict['ip_address'] = m.groupdict()['ip_address']
-                type_dict['state'] = m.groupdict()['state']
-                type_dict['holdtime'] = m.groupdict()['holdtime']
-                type_dict['circuit_id'] = m.groupdict()['circuit_id']
+                  
+                interface_name = Common.convert_intf_name(m.groupdict()['interface'])
+                interfaces_dict = type_dict.setdefault('interfaces', {}).setdefault(interface_name, {})
+                interfaces_dict['ip_address'] = m.groupdict()['ip_address']
+                interfaces_dict['state'] = m.groupdict()['state']
+                interfaces_dict['holdtime'] = m.groupdict()['holdtime']
+                interfaces_dict['circuit_id'] = m.groupdict()['circuit_id']
                 continue
 
         return ret_dict


### PR DESCRIPTION
Hi Team,

Thanks in advance for taking the time to review my proposed changes to this code. I have encountered a bug parsing the commad "show isis neighbors" on a IOS-XE platform (The bug relies on the "ShowIsisNeighbors" class becuase it just replacing the values of keys on the final nested dictionary). The behavior of the parser is that it is only getting the last neighbor from the command output.

e.g.
```
device.parse('show isis neighbors')
2020-11-27 11:20:58,553: %UNICON-INFO: +++ CSR1000v_0: executing command 'show isis neighbors' +++
show isis neighbors
Tag LAB:
System Id Type Interface IP Address State Holdtime Circuit Id
xrv-0 L2 Gi2 172.16.10.1 UP 21 00
xrv-0 L2 Gi3 172.16.20.1 UP 25 00
CSR1000v_0#
{'isis': {'LAB': {'neighbors': {'xrv-0': {'type': {'L2': {'interface': 'Gi3', 'ip_address': '172.16.20.1', 'state': 'UP', 'holdtime': '25', 'circuit_id': '00'}}}}}}}
```

Best Regards.
Ernesto Wilson

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Impact (If any)
<!--- If there is any negative impact - what is it? -->

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
