### PR TITLE
show access-lists parser enhancements

### DIFF
--- a/changelog/undistributed/changelog_show_acl_parser_20201203193221.rst
+++ b/changelog/undistributed/changelog_show_acl_parser_20201203193221.rst
@@ -1,0 +1,14 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* IOSXE
+	* Modified ShowAccessLists:
+        * Fixed an issue in p_ip_acl where the address of the destination 
+          network was being captured as part of the source_port capture group.
+        * Fixed an issue in p_ip_acl where the destination port was being
+          captured as part of the left capture group.
+    * Modified golden_output_output.txt
+        * Additional access-list 'test33' that includes two entries that would
+          fail on the previous parser.
+    * Modified golden_output_expected.py
+        * Matched correct output.

--- a/src/genie/libs/parser/iosxe/show_acl.py
+++ b/src/genie/libs/parser/iosxe/show_acl.py
@@ -291,14 +291,17 @@ class ShowAccessLists(ShowAccessListsSchema):
         # 10 permit tcp any any eq www
         # 20 permit tcp any any eq 22
         # 30 permit icmp any any ttl-exceeded
+        # 10 permit icmp any 10.120.194.64 0.0.0.63
+        # 20 permit tcp any eq 443 10.120.194.64 0.0.0.63
         p_ip_acl = re.compile(
             r'^(?P<seq>\d+) +(?P<actions_forwarding>permit|deny) +(?P<protocol>\w+) '
-            r'+(?P<src>(?:any|host|\d+\.\d+\.\d+\.\d+)(?: '
-            r'+\d+\.\d+\.\d+\.\d+)?)(?: +(?P<src_operator>eq|gt|lt|neq|range) '
-            r'+(?P<src_port>[\S ]+\S))? +(?P<dst>(?:any|host|\d+\.\d+\.\d+\.\d+)'
-            r'(?: +\d+\.\d+\.\d+\.\d+)?)(?: +(?P<dst_operator>eq|gt|lt|neq|range) '
-            r'+(?P<dst_port>(?:\S?)+\S))?(?: +(?P<msg_type>ttl-exceeded|unreachable|'
-            r'packet-too-big|echo-reply|echo|router-advertisement|mld-query+))?(?P<left>.+)?$')
+            r'+(?P<src>(?:any|host +\d+.\d+.\d+.\d+|\d+.\d+.\d+.\d+ +\d+.\d+.\d+.\d+)?)'
+            r'(?: +(?P<src_operator>eq|gt|lt|neq|range) '
+            r'+(?P<src_port>.*?(?=(?: +any| +host +\d+.\d+.\d+.\d+| +\d+.\d+.\d+.\d+ +\d+.\d+.\d+.\d+)|$)))? '
+            r'+(?P<dst>(?:any|host +\d+.\d+.\d+.\d+|\d+.\d+.\d+.\d+ +\d+.\d+.\d+.\d+)?)'
+            r'(?: +(?P<dst_operator>eq|gt|lt|neq|range) +(?P<dst_port>(?:\S?)+\S))?(?: '
+            r'+(?P<msg_type>ttl-exceeded|unreachable|packet-too-big|echo-reply|echo|'
+            r'router-advertisement|mld-query+))?(?P<left>.+)?$')
 
         # permit tcp host 2001: DB8: 1: : 32 eq bgp host 2001: DB8: 2: : 32 eq 11000 sequence 1
         # permit tcp host 2001: DB8: 1: : 32 eq telnet host 2001: DB8: 2: : 32 eq 11001 sequence 2

--- a/src/genie/libs/parser/iosxe/tests/ShowAccessLists/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowAccessLists/cli/equal/golden_output_expected.py
@@ -83,12 +83,12 @@ expected_output = {
                         "ipv6": {
                             "destination_network": {
                                 "host 2001:1::2": {
-                                    "destination_network": "host " "2001:1::2"
+                                    "destination_network": "host 2001:1::2"
                                 }
                             },
                             "protocol": "ipv6",
                             "source_network": {
-                                "host 2001::1": {"source_network": "host " "2001::1"}
+                                "host 2001::1": {"source_network": "host 2001::1"}
                             },
                         }
                     },
@@ -103,7 +103,7 @@ expected_output = {
                         "ipv6": {
                             "destination_network": {
                                 "host 2001:2::2": {
-                                    "destination_network": "host " "2001:2::2"
+                                    "destination_network": "host 2001:2::2"
                                 }
                             },
                             "protocol": "tcp",
@@ -114,7 +114,7 @@ expected_output = {
                         "tcp": {
                             "established": False,
                             "source_port": {
-                                "operator": {"operator": "eq", "port": "www " "8443"}
+                                "operator": {"operator": "eq", "port": "www 8443"}
                             },
                         }
                     },
@@ -128,15 +128,13 @@ expected_output = {
                         "ipv6": {
                             "destination_network": {
                                 "2001:db8:1:1::1 2001:db8:24:24::6": {
-                                    "destination_network": "2001:db8:1:1::1 "
-                                    "2001:db8:24:24::6"
+                                    "destination_network": "2001:db8:1:1::1 2001:db8:24:24::6"
                                 }
                             },
                             "protocol": "ipv6",
                             "source_network": {
                                 "2001:db8:9:9::3 2001:db8:10:10::4": {
-                                    "source_network": "2001:db8:9:9::3 "
-                                    "2001:db8:10:10::4"
+                                    "source_network": "2001:db8:9:9::3 2001:db8:10:10::4"
                                 }
                             },
                         }
@@ -194,9 +192,9 @@ expected_output = {
                 "matches": {
                     "l2": {
                         "eth": {
-                            "destination_mac_address": "host " "0003.00ff.0306",
+                            "destination_mac_address": "host 0003.00ff.0306",
                             "lsap": "0x1 0xD8FE",
-                            "source_mac_address": "host " "0001.00ff.0235",
+                            "source_mac_address": "host 0001.00ff.0235",
                         }
                     }
                 },
@@ -314,7 +312,7 @@ expected_output = {
                             "protocol": "icmp",
                             "source_network": {
                                 "0.1.1.1 255.0.0.0": {
-                                    "source_network": "0.1.1.1 " "255.0.0.0"
+                                    "source_network": "0.1.1.1 255.0.0.0"
                                 }
                             },
                         }
@@ -336,13 +334,13 @@ expected_output = {
                         "ipv4": {
                             "destination_network": {
                                 "host 10.4.1.1": {
-                                    "destination_network": "host " "10.4.1.1"
+                                    "destination_network": "host 10.4.1.1"
                                 }
                             },
                             "protocol": "tcp",
                             "source_network": {
                                 "192.168.1.0 0.0.0.255": {
-                                    "source_network": "192.168.1.0 " "0.0.0.255"
+                                    "source_network": "192.168.1.0 0.0.0.255"
                                 }
                             },
                         }
@@ -363,7 +361,7 @@ expected_output = {
                             "protocol": "tcp",
                             "source_network": {
                                 "host 10.16.2.2": {
-                                    "source_network": "host " "10.16.2.2"
+                                    "source_network": "host 10.16.2.2"
                                 }
                             },
                             "ttl": 255,
@@ -376,7 +374,7 @@ expected_output = {
                             "source_port": {
                                 "operator": {
                                     "operator": "eq",
-                                    "port": "www " "telnet " "443",
+                                    "port": "www telnet 443",
                                 }
                             },
                         }
@@ -436,7 +434,7 @@ expected_output = {
                         "ipv4": {
                             "destination_network": {
                                 "10.120.194.64 0.0.0.63": {
-                                    "destination_network": "10.120.194.64 " "0.0.0.63"
+                                    "destination_network": "10.120.194.64 0.0.0.63"
                                 }
                             },
                             "protocol": "icmp",
@@ -454,7 +452,7 @@ expected_output = {
                         "ipv4": {
                             "destination_network": {
                                 "10.120.194.64 0.0.0.63": {
-                                    "destination_network": "10.120.194.64 " "0.0.0.63"
+                                    "destination_network": "10.120.194.64 0.0.0.63"
                                 }
                             },
                             "protocol": "tcp",

--- a/src/genie/libs/parser/iosxe/tests/ShowAccessLists/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowAccessLists/cli/equal/golden_output_expected.py
@@ -74,144 +74,6 @@ expected_output = {
         "name": "ipv4_acl",
         "type": "ipv4-acl-type",
     },
-    "test1": {
-        "aces": {
-            "10": {
-                "actions": {"forwarding": "permit", "logging": "log-syslog"},
-                "matches": {
-                    "l3": {
-                        "ipv4": {
-                            "destination_network": {
-                                "any": {"destination_network": "any"}
-                            },
-                            "dscp": "default",
-                            "protocol": "pim",
-                            "source_network": {"any": {"source_network": "any"}},
-                        }
-                    },
-                    "l4": {"pim": {"established": False}},
-                },
-                "name": "10",
-            },
-            "20": {
-                "actions": {"forwarding": "permit", "logging": "log-none"},
-                "matches": {
-                    "l3": {
-                        "ipv4": {
-                            "source_network": {
-                                "0.1.1.1 255.0.0.0": {
-                                    "source_network": "0.1.1.1 255.0.0.0"
-                                }
-                            },
-                            "protocol": "icmp",
-                            "destination_network": {
-                                "any": {"destination_network": "any"}
-                            },
-                        }
-                    },
-                    "l4": {"icmp": {"code": 66, "established": False, "type": 10}},
-                },
-                "name": "20",
-            },
-        },
-        "name": "test1",
-        "type": "ipv4-acl-type",
-    },
-    "test22": {
-        "aces": {
-            "10": {
-                "actions": {"forwarding": "permit", "logging": "log-syslog"},
-                "matches": {
-                    "l3": {
-                        "ipv4": {
-                            "source_network": {
-                                "192.168.1.0 0.0.0.255": {
-                                    "source_network": "192.168.1.0 0.0.0.255"
-                                }
-                            },
-                            "protocol": "tcp",
-                            "destination_network": {
-                                "host 10.4.1.1": {
-                                    "destination_network": "host 10.4.1.1"
-                                }
-                            },
-                        }
-                    },
-                    "l4": {"tcp": {"established": True}},
-                },
-                "name": "10",
-            },
-            "20": {
-                "actions": {"forwarding": "permit", "logging": "log-none"},
-                "matches": {
-                    "l3": {
-                        "ipv4": {
-                            "destination_network": {
-                                "any": {"destination_network": "any"}
-                            },
-                            "precedence": "network",
-                            "protocol": "tcp",
-                            "source_network": {
-                                "host 10.16.2.2": {"source_network": "host 10.16.2.2"}
-                            },
-                            "ttl": 255,
-                            "ttl_operator": "eq",
-                        }
-                    },
-                    "l4": {
-                        "tcp": {
-                            "established": False,
-                            "source_port": {
-                                "operator": {"operator": "eq", "port": "www telnet 443"}
-                            },
-                        }
-                    },
-                },
-                "name": "20",
-            },
-            "30": {
-                "actions": {"forwarding": "deny", "logging": "log-none"},
-                "matches": {
-                    "l3": {
-                        "ipv4": {
-                            "destination_network": {
-                                "any": {"destination_network": "any"}
-                            },
-                            "protocol": "ipv4",
-                            "source_network": {"any": {"source_network": "any"}},
-                        }
-                    },
-                    "l4": {"ipv4": {"established": False}},
-                },
-                "name": "30",
-            },
-            "40": {
-                "actions": {"forwarding": "permit", "logging": "log-none"},
-                "matches": {
-                    "l3": {
-                        "ipv4": {
-                            "destination_network": {
-                                "any": {"destination_network": "any"}
-                            },
-                            "protocol": "tcp",
-                            "source_network": {"any": {"source_network": "any"}},
-                        }
-                    },
-                    "l4": {
-                        "tcp": {
-                            "established": False,
-                            "source_port": {
-                                "range": {"lower_port": 20, "upper_port": 179}
-                            },
-                        }
-                    },
-                },
-                "name": "40",
-            },
-        },
-        "name": "test22",
-        "type": "ipv4-acl-type",
-    },
     "ipv6_acl": {
         "aces": {
             "20": {
@@ -221,12 +83,12 @@ expected_output = {
                         "ipv6": {
                             "destination_network": {
                                 "host 2001:1::2": {
-                                    "destination_network": "host 2001:1::2"
+                                    "destination_network": "host " "2001:1::2"
                                 }
                             },
                             "protocol": "ipv6",
                             "source_network": {
-                                "host 2001::1": {"source_network": "host 2001::1"}
+                                "host 2001::1": {"source_network": "host " "2001::1"}
                             },
                         }
                     },
@@ -241,7 +103,7 @@ expected_output = {
                         "ipv6": {
                             "destination_network": {
                                 "host 2001:2::2": {
-                                    "destination_network": "host 2001:2::2"
+                                    "destination_network": "host " "2001:2::2"
                                 }
                             },
                             "protocol": "tcp",
@@ -252,7 +114,7 @@ expected_output = {
                         "tcp": {
                             "established": False,
                             "source_port": {
-                                "operator": {"operator": "eq", "port": "www 8443"}
+                                "operator": {"operator": "eq", "port": "www " "8443"}
                             },
                         }
                     },
@@ -266,13 +128,15 @@ expected_output = {
                         "ipv6": {
                             "destination_network": {
                                 "2001:db8:1:1::1 2001:db8:24:24::6": {
-                                    "destination_network": "2001:db8:1:1::1 2001:db8:24:24::6"
+                                    "destination_network": "2001:db8:1:1::1 "
+                                    "2001:db8:24:24::6"
                                 }
                             },
                             "protocol": "ipv6",
                             "source_network": {
                                 "2001:db8:9:9::3 2001:db8:10:10::4": {
-                                    "source_network": "2001:db8:9:9::3 2001:db8:10:10::4"
+                                    "source_network": "2001:db8:9:9::3 "
+                                    "2001:db8:10:10::4"
                                 }
                             },
                         }
@@ -284,6 +148,78 @@ expected_output = {
         },
         "name": "ipv6_acl",
         "type": "ipv6-acl-type",
+    },
+    "mac_acl": {
+        "aces": {
+            "10": {
+                "actions": {"forwarding": "permit", "logging": "log-none"},
+                "matches": {
+                    "l2": {
+                        "eth": {
+                            "destination_mac_address": "any",
+                            "source_mac_address": "any",
+                        }
+                    }
+                },
+                "name": "10",
+            },
+            "20": {
+                "actions": {"forwarding": "deny", "logging": "log-none"},
+                "matches": {
+                    "l2": {
+                        "eth": {
+                            "destination_mac_address": "any",
+                            "ether_type": "msdos",
+                            "source_mac_address": "any",
+                        }
+                    }
+                },
+                "name": "20",
+            },
+            "30": {
+                "actions": {"forwarding": "deny", "logging": "log-none"},
+                "matches": {
+                    "l2": {
+                        "eth": {
+                            "destination_mac_address": "any",
+                            "source_mac_address": "any",
+                            "vlan": 10,
+                        }
+                    }
+                },
+                "name": "30",
+            },
+            "40": {
+                "actions": {"forwarding": "permit", "logging": "log-none"},
+                "matches": {
+                    "l2": {
+                        "eth": {
+                            "destination_mac_address": "host " "0003.00ff.0306",
+                            "lsap": "0x1 0xD8FE",
+                            "source_mac_address": "host " "0001.00ff.0235",
+                        }
+                    }
+                },
+                "name": "40",
+            },
+            "50": {
+                "actions": {"forwarding": "permit", "logging": "log-none"},
+                "matches": {
+                    "l2": {
+                        "eth": {
+                            "cos": 4,
+                            "destination_mac_address": "any",
+                            "ether_type": "aarp",
+                            "source_mac_address": "any",
+                            "vlan": 20,
+                        }
+                    }
+                },
+                "name": "50",
+            },
+        },
+        "name": "mac_acl",
+        "type": "eth-acl-type",
     },
     "preauth_v6": {
         "aces": {
@@ -348,76 +284,196 @@ expected_output = {
         "per_user": True,
         "type": "ipv6-acl-type",
     },
-    "mac_acl": {
+    "test1": {
         "aces": {
             "10": {
-                "actions": {"forwarding": "permit", "logging": "log-none"},
+                "actions": {"forwarding": "permit", "logging": "log-syslog"},
                 "matches": {
-                    "l2": {
-                        "eth": {
-                            "destination_mac_address": "any",
-                            "source_mac_address": "any",
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "any": {"destination_network": "any"}
+                            },
+                            "dscp": "default",
+                            "protocol": "pim",
+                            "source_network": {"any": {"source_network": "any"}},
                         }
-                    }
+                    },
+                    "l4": {"pim": {"established": False}},
                 },
                 "name": "10",
             },
             "20": {
-                "actions": {"forwarding": "deny", "logging": "log-none"},
+                "actions": {"forwarding": "permit", "logging": "log-none"},
                 "matches": {
-                    "l2": {
-                        "eth": {
-                            "destination_mac_address": "any",
-                            "ether_type": "msdos",
-                            "source_mac_address": "any",
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "any": {"destination_network": "any"}
+                            },
+                            "protocol": "icmp",
+                            "source_network": {
+                                "0.1.1.1 255.0.0.0": {
+                                    "source_network": "0.1.1.1 " "255.0.0.0"
+                                }
+                            },
                         }
-                    }
+                    },
+                    "l4": {"icmp": {"code": 66, "established": False, "type": 10}},
+                },
+                "name": "20",
+            },
+        },
+        "name": "test1",
+        "type": "ipv4-acl-type",
+    },
+    "test22": {
+        "aces": {
+            "10": {
+                "actions": {"forwarding": "permit", "logging": "log-syslog"},
+                "matches": {
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "host 10.4.1.1": {
+                                    "destination_network": "host " "10.4.1.1"
+                                }
+                            },
+                            "protocol": "tcp",
+                            "source_network": {
+                                "192.168.1.0 0.0.0.255": {
+                                    "source_network": "192.168.1.0 " "0.0.0.255"
+                                }
+                            },
+                        }
+                    },
+                    "l4": {"tcp": {"established": True}},
+                },
+                "name": "10",
+            },
+            "20": {
+                "actions": {"forwarding": "permit", "logging": "log-none"},
+                "matches": {
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "any": {"destination_network": "any"}
+                            },
+                            "precedence": "network",
+                            "protocol": "tcp",
+                            "source_network": {
+                                "host 10.16.2.2": {
+                                    "source_network": "host " "10.16.2.2"
+                                }
+                            },
+                            "ttl": 255,
+                            "ttl_operator": "eq",
+                        }
+                    },
+                    "l4": {
+                        "tcp": {
+                            "established": False,
+                            "source_port": {
+                                "operator": {
+                                    "operator": "eq",
+                                    "port": "www " "telnet " "443",
+                                }
+                            },
+                        }
+                    },
                 },
                 "name": "20",
             },
             "30": {
                 "actions": {"forwarding": "deny", "logging": "log-none"},
                 "matches": {
-                    "l2": {
-                        "eth": {
-                            "destination_mac_address": "any",
-                            "source_mac_address": "any",
-                            "vlan": 10,
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "any": {"destination_network": "any"}
+                            },
+                            "protocol": "ipv4",
+                            "source_network": {"any": {"source_network": "any"}},
                         }
-                    }
+                    },
+                    "l4": {"ipv4": {"established": False}},
                 },
                 "name": "30",
             },
             "40": {
                 "actions": {"forwarding": "permit", "logging": "log-none"},
                 "matches": {
-                    "l2": {
-                        "eth": {
-                            "destination_mac_address": "host 0003.00ff.0306",
-                            "lsap": "0x1 0xD8FE",
-                            "source_mac_address": "host 0001.00ff.0235",
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "any": {"destination_network": "any"}
+                            },
+                            "protocol": "tcp",
+                            "source_network": {"any": {"source_network": "any"}},
                         }
-                    }
+                    },
+                    "l4": {
+                        "tcp": {
+                            "established": False,
+                            "source_port": {
+                                "range": {"lower_port": 20, "upper_port": 179}
+                            },
+                        }
+                    },
                 },
                 "name": "40",
             },
-            "50": {
+        },
+        "name": "test22",
+        "type": "ipv4-acl-type",
+    },
+    "test33": {
+        "aces": {
+            "10": {
                 "actions": {"forwarding": "permit", "logging": "log-none"},
                 "matches": {
-                    "l2": {
-                        "eth": {
-                            "cos": 4,
-                            "destination_mac_address": "any",
-                            "ether_type": "aarp",
-                            "source_mac_address": "any",
-                            "vlan": 20,
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "10.120.194.64 0.0.0.63": {
+                                    "destination_network": "10.120.194.64 " "0.0.0.63"
+                                }
+                            },
+                            "protocol": "icmp",
+                            "source_network": {"any": {"source_network": "any"}},
                         }
-                    }
+                    },
+                    "l4": {"icmp": {"established": False}},
                 },
-                "name": "50",
+                "name": "10",
+            },
+            "20": {
+                "actions": {"forwarding": "permit", "logging": "log-none"},
+                "matches": {
+                    "l3": {
+                        "ipv4": {
+                            "destination_network": {
+                                "10.120.194.64 0.0.0.63": {
+                                    "destination_network": "10.120.194.64 " "0.0.0.63"
+                                }
+                            },
+                            "protocol": "tcp",
+                            "source_network": {"any": {"source_network": "any"}},
+                        }
+                    },
+                    "l4": {
+                        "tcp": {
+                            "established": False,
+                            "source_port": {
+                                "operator": {"operator": "eq", "port": "443"}
+                            },
+                        }
+                    },
+                },
+                "name": "20",
             },
         },
-        "name": "mac_acl",
-        "type": "eth-acl-type",
+        "name": "test33",
+        "type": "ipv4-acl-type",
     },
 }

--- a/src/genie/libs/parser/iosxe/tests/ShowAccessLists/cli/equal/golden_output_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowAccessLists/cli/equal/golden_output_output.txt
@@ -11,6 +11,9 @@ Extended IP access list test22
     20 permit tcp host 10.16.2.2 eq www telnet 443 any precedence network ttl eq 255
     30 deny ip any any
     40 permit tcp any range ftp-data bgp any
+Extended IP access list test33
+    10 permit icmp any 10.120.194.64 0.0.0.63
+    20 permit tcp any eq 443 10.120.194.64 0.0.0.63
 IPv6 access list ipv6_acl
     permit ipv6 host 2001::1 host 2001:1::2 sequence 20
     permit tcp any eq www 8443 host 2001:2::2 sequence 30
@@ -25,4 +28,3 @@ Extended MAC access list mac_acl
     deny   any any vlan 10
     permit host 0001.00ff.0235 host 0003.00ff.0306 lsap 0x1 0xD8FE
     permit any any aarp cos 4 vlan 20
-    


### PR DESCRIPTION
## Description

Hello Team,

I have encountered the below bugs when parsing an extended access-list on a Cisco IOS platform using the parser for `show access-lists`: 

For some access-entries the parser would:

* capture the destination port operator and port as part of the _left_ capture group.
* capture the destination network as part of the _source_network_ capture group.
* capture the destination network as part of the _source_port_ capture group.

## Motivation and Context

Fixes issues in which the parser is capturing parts of an access-entry in the wrong capture groups.

## Impact (If any)

None.

## Screenshots:

**Current Parser**

![image](https://user-images.githubusercontent.com/17187429/101089865-ad6abd00-35ad-11eb-81e4-f7bcfaa82cc0.png)

**Proposed Parser (_note the last two access-entries_)**

![image](https://user-images.githubusercontent.com/17187429/101090147-1b16e900-35ae-11eb-8dc5-e21488d885ed.png)

**FileBasedTest**

> `python ci_folder_parsing.py -o iosxe -c ShowAccessLists`

![image](https://user-images.githubusercontent.com/17187429/101085847-ebfd7900-35a7-11eb-8525-ba04c11e9aca.png)

**Unit Test**

```
(sdk) root@netauto:/sdk/genieparser/tests (master *%=)# python3 -m unittest discover
...................................................................................................
----------------------------------------------------------------------
Ran 1474 tests in 34.208s

OK
```

**Custom Test**

> `show_acl_sample.py`

```python
import json
from genie.conf.base import Device

dev = Device(name='aName', os='iosxe')
dev.custom.abstraction = {"order":["os"]}
with open('show_acl_sample.txt') as f:
    output = f.read()
print(output)
res=dev.parse("show access-lists", output=output)
print(json.dumps(res,indent=4))
```

> `show_acl_sample.txt`

```
Extended IP access list acl_name
    10 permit ip any any (10031 matches)
Extended IP access list ipv4_acl
    10 permit tcp any any eq www
    20 permit tcp any any eq 22
Extended IP access list test1
    10 permit pim any any dscp default option 222 log
    20 permit icmp 0.1.1.1 255.0.0.0 any 10 66
Extended IP access list test22
    10 permit tcp 192.168.1.0 0.0.0.255 host 10.4.1.1 established log
    20 permit tcp host 10.16.2.2 eq www telnet 443 any precedence network ttl eq 255
    30 deny ip any any
    40 permit tcp any range ftp-data bgp any
Extended IP access list test33
    10 permit icmp any 10.120.194.64 0.0.0.63
    20 permit tcp any eq 443 10.120.194.64 0.0.0.63
IPv6 access list ipv6_acl
    permit ipv6 host 2001::1 host 2001:1::2 sequence 20
    permit tcp any eq www 8443 host 2001:2::2 sequence 30
    permit ipv6 2001:db8:9:9::3 2001:db8:10:10::4 2001:db8:1:1::1 2001:db8:24:24::6 log sequence 80
IPv6 access list preauth_v6 (per-user)
    permit udp any any eq domain sequence 10
    permit esp any any dscp cs7 log sequence 20
    deny ipv6 any any sequence 30
Extended MAC access list mac_acl 
    permit any any
    deny   any any msdos
    deny   any any vlan 10
    permit host 0001.00ff.0235 host 0003.00ff.0306 lsap 0x1 0xD8FE
    permit any any aarp cos 4 vlan 20
```

> OUTPUT

```
(sdk) root@netauto:/gitnet/sdk# python3 show_acl_sample.py 
{
    "acl_name": {
        "name": "acl_name",
        "type": "ipv4-acl-type",
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "statistics": {
                    "matched_packets": 10031
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "ipv4",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "ipv4": {
                            "established": false
                        }
                    }
                }
            }
        }
    },
    "ipv4_acl": {
        "name": "ipv4_acl",
        "type": "ipv4-acl-type",
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "tcp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": false,
                            "destination_port": {
                                "operator": {
                                    "operator": "eq",
                                    "port": 80
                                }
                            }
                        }
                    }
                }
            },
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "tcp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": false,
                            "destination_port": {
                                "operator": {
                                    "operator": "eq",
                                    "port": 22
                                }
                            }
                        }
                    }
                }
            }
        }
    },
    "test1": {
        "name": "test1",
        "type": "ipv4-acl-type",
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-syslog"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "pim",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            },
                            "dscp": "default"
                        }
                    },
                    "l4": {
                        "pim": {
                            "established": false
                        }
                    }
                }
            },
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "icmp",
                            "source_network": {
                                "0.1.1.1 255.0.0.0": {
                                    "source_network": "0.1.1.1 255.0.0.0"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "icmp": {
                            "established": false,
                            "type": 10,
                            "code": 66
                        }
                    }
                }
            }
        }
    },
    "test22": {
        "name": "test22",
        "type": "ipv4-acl-type",
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-syslog"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "tcp",
                            "source_network": {
                                "192.168.1.0 0.0.0.255": {
                                    "source_network": "192.168.1.0 0.0.0.255"
                                }
                            },
                            "destination_network": {
                                "host 10.4.1.1": {
                                    "destination_network": "host 10.4.1.1"
                                }
                            }
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": true
                        }
                    }
                }
            },
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "tcp",
                            "source_network": {
                                "host 10.16.2.2": {
                                    "source_network": "host 10.16.2.2"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            },
                            "ttl_operator": "eq",
                            "ttl": 255,
                            "precedence": "network"
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": false,
                            "source_port": {
                                "operator": {
                                    "operator": "eq",
                                    "port": "www telnet 443"
                                }
                            }
                        }
                    }
                }
            },
            "30": {
                "name": "30",
                "actions": {
                    "forwarding": "deny",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "ipv4",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "ipv4": {
                            "established": false
                        }
                    }
                }
            },
            "40": {
                "name": "40",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "tcp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": false,
                            "source_port": {
                                "range": {
                                    "lower_port": 20,
                                    "upper_port": 179
                                }
                            }
                        }
                    }
                }
            }
        }
    },
    "test33": {
        "name": "test33",
        "type": "ipv4-acl-type",
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "icmp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "10.120.194.64 0.0.0.63": {
                                    "destination_network": "10.120.194.64 0.0.0.63"
                                }
                            }
                        }
                    },
                    "l4": {
                        "icmp": {
                            "established": false
                        }
                    }
                }
            },
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv4": {
                            "protocol": "tcp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "10.120.194.64 0.0.0.63": {
                                    "destination_network": "10.120.194.64 0.0.0.63"
                                }
                            }
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": false,
                            "source_port": {
                                "operator": {
                                    "operator": "eq",
                                    "port": "443"
                                }
                            }
                        }
                    }
                }
            }
        }
    },
    "ipv6_acl": {
        "name": "ipv6_acl",
        "type": "ipv6-acl-type",
        "aces": {
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv6": {
                            "protocol": "ipv6",
                            "source_network": {
                                "host 2001::1": {
                                    "source_network": "host 2001::1"
                                }
                            },
                            "destination_network": {
                                "host 2001:1::2": {
                                    "destination_network": "host 2001:1::2"
                                }
                            }
                        }
                    },
                    "l4": {
                        "ipv6": {
                            "established": false
                        }
                    }
                }
            },
            "30": {
                "name": "30",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv6": {
                            "protocol": "tcp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "host 2001:2::2": {
                                    "destination_network": "host 2001:2::2"
                                }
                            }
                        }
                    },
                    "l4": {
                        "tcp": {
                            "established": false,
                            "source_port": {
                                "operator": {
                                    "operator": "eq",
                                    "port": "www 8443"
                                }
                            }
                        }
                    }
                }
            },
            "80": {
                "name": "80",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-syslog"
                },
                "matches": {
                    "l3": {
                        "ipv6": {
                            "protocol": "ipv6",
                            "source_network": {
                                "2001:db8:9:9::3 2001:db8:10:10::4": {
                                    "source_network": "2001:db8:9:9::3 2001:db8:10:10::4"
                                }
                            },
                            "destination_network": {
                                "2001:db8:1:1::1 2001:db8:24:24::6": {
                                    "destination_network": "2001:db8:1:1::1 2001:db8:24:24::6"
                                }
                            }
                        }
                    },
                    "l4": {
                        "ipv6": {
                            "established": false
                        }
                    }
                }
            }
        }
    },
    "preauth_v6": {
        "name": "preauth_v6",
        "type": "ipv6-acl-type",
        "per_user": true,
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv6": {
                            "protocol": "udp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "udp": {
                            "established": false,
                            "destination_port": {
                                "operator": {
                                    "operator": "eq",
                                    "port": 53
                                }
                            }
                        }
                    }
                }
            },
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-syslog"
                },
                "matches": {
                    "l3": {
                        "ipv6": {
                            "protocol": "esp",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            },
                            "dscp": "cs7"
                        }
                    },
                    "l4": {
                        "esp": {
                            "established": false
                        }
                    }
                }
            },
            "30": {
                "name": "30",
                "actions": {
                    "forwarding": "deny",
                    "logging": "log-none"
                },
                "matches": {
                    "l3": {
                        "ipv6": {
                            "protocol": "ipv6",
                            "source_network": {
                                "any": {
                                    "source_network": "any"
                                }
                            },
                            "destination_network": {
                                "any": {
                                    "destination_network": "any"
                                }
                            }
                        }
                    },
                    "l4": {
                        "ipv6": {
                            "established": false
                        }
                    }
                }
            }
        }
    },
    "mac_acl": {
        "name": "mac_acl",
        "type": "eth-acl-type",
        "aces": {
            "10": {
                "name": "10",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l2": {
                        "eth": {
                            "destination_mac_address": "any",
                            "source_mac_address": "any"
                        }
                    }
                }
            },
            "20": {
                "name": "20",
                "actions": {
                    "forwarding": "deny",
                    "logging": "log-none"
                },
                "matches": {
                    "l2": {
                        "eth": {
                            "destination_mac_address": "any",
                            "source_mac_address": "any",
                            "ether_type": "msdos"
                        }
                    }
                }
            },
            "30": {
                "name": "30",
                "actions": {
                    "forwarding": "deny",
                    "logging": "log-none"
                },
                "matches": {
                    "l2": {
                        "eth": {
                            "destination_mac_address": "any",
                            "source_mac_address": "any",
                            "vlan": 10
                        }
                    }
                }
            },
            "40": {
                "name": "40",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l2": {
                        "eth": {
                            "destination_mac_address": "host 0003.00ff.0306",
                            "source_mac_address": "host 0001.00ff.0235",
                            "lsap": "0x1 0xD8FE"
                        }
                    }
                }
            },
            "50": {
                "name": "50",
                "actions": {
                    "forwarding": "permit",
                    "logging": "log-none"
                },
                "matches": {
                    "l2": {
                        "eth": {
                            "destination_mac_address": "any",
                            "source_mac_address": "any",
                            "cos": 4,
                            "vlan": 20,
                            "ether_type": "aarp"
                        }
                    }
                }
            }
        }
    }
}
```

## Checklist:

- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
