### PR TITLE
Issue374 - Fix for double-quote character in Platform section of `show cdp neighbors detail` output (ios/iosxe)

### DIFF
--- a/changelog/undistributed/changelog_show_cdp_neighbors_detail_20210107.rst
+++ b/changelog/undistributed/changelog_show_cdp_neighbors_detail_20210107.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowCdpNeighborsDetail:
+        * Added double quote (") character to the regex for `platform`.

--- a/src/genie/libs/parser/ios/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_expected.py
+++ b/src/genie/libs/parser/ios/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_expected.py
@@ -1,0 +1,20 @@
+expected_output = {
+    "total_entries_displayed": 1,
+    "index": {
+        1: {
+            "device_id": "SEP009E2E69AC48",
+            "duplex_mode": "",
+            "vtp_management_domain": "",
+            "native_vlan": "",
+            "management_addresses": {},
+            "entry_addresses": {"10.0.0.8": {}},
+            "capabilities": "Host Phone",
+            "platform": '"CTS-CODEC-SX80"',
+            "port_id": "gbe0",
+            "local_interface": "GigabitEthernet3/0/38",
+            "hold_time": 166,
+            "software_version": '"ce9.1.3 75ff735 2017-07-10"',
+            "advertisement_ver": 2,
+        }
+    },
+}

--- a/src/genie/libs/parser/ios/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_output.txt
+++ b/src/genie/libs/parser/ios/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_output.txt
@@ -1,0 +1,16 @@
+
+Device ID: SEP009E2E69AC48
+Entry address(es):
+  IP address: 10.0.0.8
+Platform: "CTS-CODEC-SX80",  Capabilities: Host Phone
+Interface: GigabitEthernet3/0/38,  Port ID (outgoing port): gbe0
+Holdtime : 166 sec
+
+Version :
+"ce9.1.3 75ff735 2017-07-10"
+
+advertisement version: 2
+
+
+Total cdp entries displayed : 1
+

--- a/src/genie/libs/parser/iosxe/show_cdp.py
+++ b/src/genie/libs/parser/iosxe/show_cdp.py
@@ -214,7 +214,8 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
         # Platform: cisco WS-C6506-E,  Capabilities: Router Switch_6506 IGMP
         # Platform: Meraki MV21 Cloud Managed Indoor HD Dom
         # Platform: Mitel 5320e,DN 2142      ,  Capabilities: Host Phone
-        platf_cap_re = re.compile(r'Platform:\s+(?P<platform>[\w +(\-|\_\/:)]+'
+        # Platform: "CTS-CODEC-SX80",  Capabilities: Host Phone
+        platf_cap_re = re.compile(r'Platform:\s+(?P<platform>[\w +(\-|\_\/:)\"]+'
                                   r'(?:,[\w ]+)?)(\,\s*Capabilities:\s+'
                                   r'(?P<capabilities>[\w\s\-]+))?$')
 

--- a/src/genie/libs/parser/iosxe/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_expected.py
@@ -1,0 +1,20 @@
+expected_output = {
+    "total_entries_displayed": 1,
+    "index": {
+        1: {
+            "device_id": "SEP009E2E69AC48",
+            "duplex_mode": "",
+            "vtp_management_domain": "",
+            "native_vlan": "",
+            "management_addresses": {},
+            "entry_addresses": {"10.0.0.8": {}},
+            "capabilities": "Host Phone",
+            "platform": '"CTS-CODEC-SX80"',
+            "port_id": "gbe0",
+            "local_interface": "GigabitEthernet3/0/38",
+            "hold_time": 166,
+            "software_version": '"ce9.1.3 75ff735 2017-07-10"',
+            "advertisement_ver": 2,
+        }
+    },
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowCdpNeighborsDetail/cli/equal/device_output_9_output.txt
@@ -1,0 +1,16 @@
+
+Device ID: SEP009E2E69AC48
+Entry address(es):
+  IP address: 10.0.0.8
+Platform: "CTS-CODEC-SX80",  Capabilities: Host Phone
+Interface: GigabitEthernet3/0/38,  Port ID (outgoing port): gbe0
+Holdtime : 166 sec
+
+Version :
+"ce9.1.3 75ff735 2017-07-10"
+
+advertisement version: 2
+
+
+Total cdp entries displayed : 1
+


### PR DESCRIPTION
## Description
The ios/iosxe parser for `show cdp neighbors detail` errors when there is a double quote in the platform string - certain devices report their platform in double quotes.

This PR adds double-quote to the regex for platform and adds IOS and IOSXE test cases for this particular case.

## Motivation and Context
To solve a CDP parsing error that occurs when certain devices are connected to the IOS/IOSXE device.

## Impact (If any)
Should not be any impact -- only added 1 character to the Regex matching and added a test case for the device output that causes the error.

## Screenshots:
```
python ci_folder_parsing.py -o iosxe -c ShowCdpNeighborsDetail -n 9
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: |                       Starting testcase FileBasedTest                        |
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: |                            Starting section setup                            |
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: The result of section setup is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: |                Starting section test[operating_system=iosxe]                 |
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :               Starting STEP 1: iosxe -> ShowCdpNeighborsDetail               :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :      Starting STEP 1.1: Test Golden -> iosxe -> ShowCdpNeighborsDetail       :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.1: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_1                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_1 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.2: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_2                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.2: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_2 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.3: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_3                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.3: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_3 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.4: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_5                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.4: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_5 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.5: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_6                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.5: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_6 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.6: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_7                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.6: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_7 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.7: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_8                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.7: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_8 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.1.8: Gold -> iosxe -> ShowCdpNeighborsDetail -> device    :
2021-01-07T19:34:54: %AETEST-INFO: :                                  _output_9                                   :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1.8: Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_9 is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowCdpNeighborsDetail is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :       Starting STEP 1.2: Test Empty -> iosxe -> ShowCdpNeighborsDetail       :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: :    Starting STEP 1.2.1: Empty -> iosxe -> ShowCdpNeighborsDetail -> empty    :
2021-01-07T19:34:54: %AETEST-INFO: :                                   _output                                    :
2021-01-07T19:34:54: %AETEST-INFO: +..............................................................................+
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowCdpNeighborsDetail -> empty_output is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowCdpNeighborsDetail is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: The result of STEP 1: iosxe -> ShowCdpNeighborsDetail is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +----------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: |                       STEPS Report                       |
2021-01-07T19:34:54: %AETEST-INFO: +----------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: STEP 1 - iosxe -> ShowCdpNeighborsDetail          Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowCdpNeighborsDetailPassed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_1Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.2 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_2Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.3 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_3Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.4 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_5Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.5 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_6Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.6 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_7Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.7 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_8Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.1.8 - Gold -> iosxe -> ShowCdpNeighborsDetail -> device_output_9Passed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowCdpNeighborsDetailPassed
2021-01-07T19:34:54: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowCdpNeighborsDetail -> empty_outputPassed
2021-01-07T19:34:54: %AETEST-INFO: ------------------------------------------------------------
2021-01-07T19:34:54: %AETEST-INFO: The result of section test[operating_system=iosxe] is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: The result of testcase FileBasedTest is => PASSED
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: |                               Detailed Results                               |
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO:  SECTIONS/TESTCASES                                                      RESULT
2021-01-07T19:34:54: %AETEST-INFO: --------------------------------------------------------------------------------
2021-01-07T19:34:54: %AETEST-INFO: .
2021-01-07T19:34:54: %AETEST-INFO: `-- FileBasedTest                                                         PASSED
2021-01-07T19:34:54: %AETEST-INFO:     |-- setup                                                             PASSED
2021-01-07T19:34:54: %AETEST-INFO:     `-- test[operating_system=iosxe]                                      PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1: iosxe -> ShowCdpNeighborsDetail                       PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1: Test Golden -> iosxe -> ShowCdpNeighborsDetail      PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.1: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.2: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.3: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.4: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.5: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.6: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.7: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.1.8: Gold -> iosxe -> ShowCdpNeighborsDetail -> ...    PASSED
2021-01-07T19:34:54: %AETEST-INFO:         |-- Step 1.2: Test Empty -> iosxe -> ShowCdpNeighborsDetail       PASSED
2021-01-07T19:34:54: %AETEST-INFO:         `-- Step 1.2.1: Empty -> iosxe -> ShowCdpNeighborsDetail ->...    PASSED
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO: |                                   Summary                                    |
2021-01-07T19:34:54: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-01-07T19:34:54: %AETEST-INFO:  Number of ABORTED                                                            0
2021-01-07T19:34:54: %AETEST-INFO:  Number of BLOCKED                                                            0
2021-01-07T19:34:54: %AETEST-INFO:  Number of ERRORED                                                            0
2021-01-07T19:34:54: %AETEST-INFO:  Number of FAILED                                                             0
2021-01-07T19:34:54: %AETEST-INFO:  Number of PASSED                                                             1
2021-01-07T19:34:54: %AETEST-INFO:  Number of PASSX                                                              0
2021-01-07T19:34:54: %AETEST-INFO:  Number of SKIPPED                                                            0
2021-01-07T19:34:54: %AETEST-INFO:  Total Number                                                                 1
2021-01-07T19:34:54: %AETEST-INFO:  Success Rate                                                            100.0%
2021-01-07T19:34:54: %AETEST-INFO: --------------------------------------------------------------------------------
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated the changelog.
- [X] I have updated the documentation (If applicable).
- [X] I have added tests to cover my changes (If applicable).
- [X] All new and existing tests passed.
- [X] All new code passed compilation.
