### PR TITLE
Bugfix/version as a tuple nxos

### DIFF
--- a/changelog/undistributed/changelog_nxos_show_version_20210123182903.rst
+++ b/changelog/undistributed/changelog_nxos_show_version_20210123182903.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* nxos
+    * Modified ShowVersion:
+      * Adding key ```version``` under ```platform/software``` which is derived from ```platform/software/system_version```

--- a/src/genie/libs/parser/nxos/show_platform.py
+++ b/src/genie/libs/parser/nxos/show_platform.py
@@ -60,6 +60,7 @@ class ShowVersionSchema(MetaParser):
                        Optional('kickstart_compile_time'): str,
                        Optional('kickstart_image_file'): str,
                        Optional('system_version'): str,
+                       Optional('version'): tuple,
                        Optional('system_compile_time'): str,
                        Optional('system_image_file'): str}
                   }

--- a/src/genie/libs/parser/nxos/show_platform.py
+++ b/src/genie/libs/parser/nxos/show_platform.py
@@ -18,6 +18,14 @@ except Exception:
 from genie.metaparser import MetaParser
 from genie.metaparser.util.schemaengine import Any, Optional, Or, And, Default, Use
 
+def get_version_from_system_version (system_version:str) -> tuple :
+    # Tokenize system_version into a list with delimiters '.', '(' and ')'
+    ver: list = [ch for ch in re.split('\.|\(|\)', system_version.split(' ')[0]) if ch != '']
+    # Convert to int wherever possible
+    for i in range (len(ver)) :
+        try : ver[i] = int(ver[i])
+        except ValueError : continue
+    return tuple(ver)
 
 def regexp(expression):
     def match(value):
@@ -149,6 +157,9 @@ class ShowVersion(ShowVersionSchema):
 
                 if 'system_version' not in version_dict['platform']['software']:
                     version_dict['platform']['software']['system_version'] = system_version
+                    ver: tuple = get_version_from_system_version(system_version)
+                    if 'version' not in version_dict['platform']['software'] :
+                        version_dict['platform']['software']['version'] = ver
                 continue
 
             p6 = re.compile(r'^\s*NXOS: +version +(?P<system_version>[A-Za-z0-9\.\(\)\[\]\s]+)$')
@@ -158,6 +169,9 @@ class ShowVersion(ShowVersionSchema):
 
                 if 'system_version' not in version_dict['platform']['software']:
                     version_dict['platform']['software']['system_version'] = system_version
+                    ver: tuple = get_version_from_system_version(system_version)
+                    if 'version' not in version_dict['platform']['software'] :
+                        version_dict['platform']['software']['version'] = ver
                 continue
 
             p7 = re.compile(r'^\s*BIOS +compile +time: +(?P<bios_compile_time>[0-9\/]+)?$')

--- a/src/genie/libs/parser/nxos/tests/test_show_platform.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_platform.py
@@ -49,6 +49,7 @@ class test_show_version(unittest.TestCase):
                                  'kickstart_compile_time': '4/30/2017 23:00:00 [04/15/2017 ''04:34:05]',
                                  'kickstart_image_file': 'slot0:///n7000-s2-kickstart.10.81.0.129.gbin',
                                  'system_version': '8.1(1) [build 8.1(0.129)] [gdb]',
+                                 'version': (8, 1, 1),
                                  'system_compile_time': '4/30/2017 23:00:00 [04/15/2017 ''06:43:41]',
                                  'system_image_file': 'slot0:///n7000-s2-dk10.34.1.0.129.gbin'}
                               }
@@ -75,6 +76,7 @@ class test_show_version(unittest.TestCase):
                                  'seconds': 37},
                               'software':
                                 {'system_version': '7.0(3)I5(2) [build 7.0(3)I5(1.145)]',
+                                 'version': (7, 0, 3, 'I5', 2),
                                  'system_compile_time': '1/4/2017 20:00:00 [01/04/2017 21:47:15]',
                                  'system_image_file': 'bootflash:///ISSUCleanGolden.system.gbin'}
                               }
@@ -251,6 +253,7 @@ Active Package(s):
                                 {'bios_version': '3.6.0',
                                  'kickstart_version': '7.3(3)N1(1)',
                                  'system_version': '7.3(3)N1(1)',
+                                 'version': (7, 3, 3, 'N1', 1),
                                  'bios_compile_time': '05/09/2012',
                                  'kickstart_image_file': 'bootflash:///n5000-uk9-kickstart.7.3.3.N1.1.bin',
                                  'kickstart_compile_time': '4/27/2018 9:00:00 [04/27/2018 17:18:59]',
@@ -330,6 +333,7 @@ Active Package(s):
                                 {'bios_version': '1.4.0',
                                  'kickstart_version': '6.0(2)U6(10)',
                                  'system_version': '6.0(2)U6(10)',
+                                 'version': (6, 0, 2, 'U6', 10),
                                  'bios_compile_time': '12/09/2013',
                                  'kickstart_image_file': 'bootflash:///n3000-uk9-kickstart.6.0.2.U6.10.bin',
                                  'kickstart_compile_time': '3/30/2017 9:00:00 [03/30/2017 19:37:34]',


### PR DESCRIPTION
## Description
```system_verions``` shows the complete version of the system along with build in a long string format. But the software version is typically a tuple of integers of the form ```10.1.1```.
To achieve this following steps are implemented:
1. Split ```system_verion``` with delimiter ```' '```. Pick 0th element from the split.
2. Split the new value using regular expression split with delimiters, ```','```, ```'('``` and ```')'```.
3. Remove empty elements from the new list.
4. Convert each element of the list to an integer value using ```int()```. If the element can't be converted then leave it as a string.
5. Convert the modified list into a tuple to keep it unmutable.

## Motivation and Context
The change provides the version in a tuple of int and str. This helps in version checks for features where int operators can be used. This is particularly useful in the latest version of nxos where the tuple generated will be a pure int tuple.

## Impact (If any)
None

## Screenshots:
```
$ python -m unittest nxos.test_show_platform.test_show_version -v 
test_empty (nxos.test_show_platform.test_show_version) ... ok
test_golden (nxos.test_show_platform.test_show_version) ... ok
test_golden2 (nxos.test_show_platform.test_show_version) ... ok
test_golden3 (nxos.test_show_platform.test_show_version) ... ok
test_golden4 (nxos.test_show_platform.test_show_version) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.012s

OK
```

## Checklist:
- [*] I have updated the changelog.
- [*] I have updated the documentation (If applicable).
- [*] I have added tests to cover my changes (If applicable).
- [*] All new and existing tests passed.
- [*] All new code passed compilation.
