### PR TITLE
Feature/get version from system version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ uni.log
 # .vscode
 .vscode
 
+# Python virtual environment
+env

--- a/changelog/undistributed/changelog_add_get_version_from_system_version_20210126071304.rst
+++ b/changelog/undistributed/changelog_add_get_version_from_system_version_20210126071304.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                New
+--------------------------------------------------------------------------------
+* nxos
+    * Modified ShowVersion:
+      * Adding API get_version_from_system_version to get str or tuple version

--- a/src/genie/libs/parser/nxos/show_platform.py
+++ b/src/genie/libs/parser/nxos/show_platform.py
@@ -372,6 +372,32 @@ class ShowVersion(ShowVersionSchema):
 
         return version_dict
 
+    @staticmethod
+    def get_version_from_system_version(system_version:str, format:type=tuple):
+        """get version from system version
+
+        Args:
+            system_version (str): system version from ShowVersionSchema
+            format (type, optional): Return format between str and tuple.
+                    Defaults to tuple.
+
+        Returns:
+            (str, tuple): version in str or tuple format
+        """
+        # Version is the first token when split with ' '
+        ver: str = system_version.split(' ')[0]
+        if format == str :
+            # If desired format is string then return from here
+            return ver
+        else :
+            # Tokenize system_version into a list with delimiters '.', '(' and ')'
+            ver: list = [ch for ch in re.split('\.|\(|\)', ver) if ch != '']
+            # Convert to int whereever possible
+            for i in range(len(ver)):
+                try : ver[i] = int(ver[i])
+                except ValueError: continue
+            return tuple(ver)
+
 class ShowInventorySchema(MetaParser):
     """Schema for show inventory"""
     schema = {'name':

--- a/src/genie/libs/parser/nxos/tests/test_show_platform.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_platform.py
@@ -53,6 +53,8 @@ class test_show_version(unittest.TestCase):
                                  'system_image_file': 'slot0:///n7000-s2-dk10.34.1.0.129.gbin'}
                               }
                             }
+    golden_parsed_output_version_str = '8.1(1)'
+    golden_parsed_output_version_tuple = (8, 1, 1)
 
     golden_parsed_output2 = {'platform':
                               {'reason': 'Unknown',
@@ -79,6 +81,8 @@ class test_show_version(unittest.TestCase):
                                  'system_image_file': 'bootflash:///ISSUCleanGolden.system.gbin'}
                               }
                             }
+    golden_parsed_output2_version_str = '7.0(3)I5(2)'
+    golden_parsed_output2_version_tuple = (7, 0, 3, 'I5', 2)
 
     golden_output = {'execute.return_value': '''
  
@@ -258,6 +262,8 @@ Active Package(s):
                                  'system_compile_time': '4/27/2018 9:00:00 [04/27/2018 21:24:41]'}
                               }
                             }
+    golden_parsed_output3_version_str = '7.3(3)N1(1)'
+    golden_parsed_output3_version_tuple = (7, 3, 3, 'N1', 1)
 
     golden_output4 = {'execute.return_value': '''
  
@@ -337,6 +343,8 @@ Active Package(s):
                                  'system_compile_time': '3/30/2017 9:00:00 [03/30/2017 20:04:06]'}
                               }
                             }
+    golden_parsed_output4_version_str = '6.0(2)U6(10)'
+    golden_parsed_output4_version_tuple = (6, 0, 2, 'U6', 10)
 
     ats_mock.tcl.eval.return_value = 'nxos'
 
@@ -346,6 +354,12 @@ Active Package(s):
         version_obj = ShowVersion(device=self.device)
         parsed_output = version_obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version']
+        ), self.golden_parsed_output_version_tuple)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version'], format=str
+        ), self.golden_parsed_output_version_str)
 
     def test_golden2(self):
         self.maxDiff = None
@@ -353,6 +367,12 @@ Active Package(s):
         version_obj = ShowVersion(device=self.device)
         parsed_output = version_obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output2)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version']
+        ), self.golden_parsed_output2_version_tuple)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version'], format=str
+        ), self.golden_parsed_output2_version_str)
 
     def test_golden3(self):
         self.maxDiff = None
@@ -360,6 +380,12 @@ Active Package(s):
         version_obj = ShowVersion(device=self.device)
         parsed_output = version_obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output3)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version']
+        ), self.golden_parsed_output3_version_tuple)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version'], format=str
+        ), self.golden_parsed_output3_version_str)
 
     def test_golden4(self):
         self.maxDiff = None
@@ -367,6 +393,12 @@ Active Package(s):
         version_obj = ShowVersion(device=self.device)
         parsed_output = version_obj.parse()
         self.assertEqual(parsed_output,self.golden_parsed_output4)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version']
+        ), self.golden_parsed_output4_version_tuple)
+        self.assertEqual(ShowVersion.get_version_from_system_version(
+            parsed_output['platform']['software']['system_version'], format=str
+        ), self.golden_parsed_output4_version_str)
 
     def test_empty(self):
         self.device2 = Mock(**self.empty_output)


### PR DESCRIPTION
## Description
API to get ```version``` from ```system_version``` in a ```str``` or ```tuple``` format. The first token of ```system_version``` when split by ```' '``` is the version

## Motivation and Context
```version``` in tuple format makes the comparison of individual values easier for version comparison

## Impact (If any)
None

## Screenshots:
**make json**:
```
$ make json

--------------------------------------------------------------------
Generating Parser json file

INFO:genie.json.make_json:Learning 'parser_genie_parser'

Done.
```

**Unit tests**:
```
$ python -m unittest nxos.test_show_platform.test_show_version -v
test_empty (nxos.test_show_platform.test_show_version) ... ok
test_golden (nxos.test_show_platform.test_show_version) ... ok
test_golden2 (nxos.test_show_platform.test_show_version) ... ok
test_golden3 (nxos.test_show_platform.test_show_version) ... ok
test_golden4 (nxos.test_show_platform.test_show_version) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.012s

OK
```

## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
