### PR TITLE
Feature/show eigrp topology

### DIFF
--- a/changelog/undistributed/changelog_add_show_eigrp_topology_20210126165528.rst
+++ b/changelog/undistributed/changelog_add_show_eigrp_topology_20210126165528.rst
@@ -1,0 +1,10 @@
+--------------------------------------------------------------------------------
+                                New
+--------------------------------------------------------------------------------
+* NXOS
+    * Added ShowEigrpTopologySchema:
+    * Added ShowEigrpTopologySuperParser:
+    * Added ShowIpv4EigrpTopology:
+    * Added ShowIpv6EigrpTopology:
+        * For 'show ip eigrp topology'
+        * For 'show ipv6 eigrp topology'

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -394,10 +394,11 @@ class ShowEigrpTopologySchema(MetaParser):
     '''
 
     schema = {
-        Any(): {
-            Any(): {
-                Any(): {
-                    Any(): {
+        Any(): { # eigrp_instance
+            Any(): { # vrf
+                'routeid': str,
+                Any(): { # address_family
+                    Any(): { # route
                         'state': str,
                         'successors': int,
                         'fd': int,

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -396,7 +396,7 @@ class ShowEigrpTopologySchema(MetaParser):
     schema = {
         'as': {
             Any(): {
-                'routeid': str,
+                'routerid': str,
                 'vrf': {
                     Any(): {
                         'address_family': {
@@ -500,7 +500,6 @@ class ShowEigrpTopologySuperParser(ShowEigrpTopologySchema):
                 route_dict['state'] = group['state']
                 route_dict['successors'] = int(group['successors'])
                 route_dict['fd'] = int(group['fd'])
-                route_dict['nexthops'] = {}
 
             result = r3.match(line)
             if result:
@@ -517,14 +516,13 @@ class ShowEigrpTopologySuperParser(ShowEigrpTopologySchema):
                     .setdefault('nexthops', {}) \
                     .setdefault(nexthop_count, {})
                 nexthop_count = nexthop_count + 1
-                nexthop_dict['nexthope'] = group['nexthop']
+                nexthop_dict['nexthop'] = group['nexthop']
                 for key in ('fd', 'rd') :
                     if group[key]:
                         nexthop_dict[key] = int(group[key])
                 if group['interface']:
                     nexthop_dict['interface'] = group['interface']
 
-        print(__import__('json').dumps(parsed_dict, indent=4))
         return parsed_dict
 
 class ShowIpv4EigrpTopology(ShowEigrpTopologySuperParser,

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -389,6 +389,8 @@ class ShowIpv6EigrpNeighborsDetail(ShowEigrpNeighborsDetailSuperParser,
 
 class ShowEigrpTopologySchema(MetaParser):
     '''Schema for:
+        * 'show ip eigrp topology'
+        * 'show ipv6 eigrp topology'
         * 'show ip eigrp topology vrf <vrf>'
         * 'show ipv6 eigrp topology vrf <vrf>'
     '''
@@ -426,6 +428,8 @@ class ShowEigrpTopologySchema(MetaParser):
 
 class ShowEigrpTopology(ShowEigrpTopologySchema):
     '''Super parser for:
+        * 'show ip eigrp topology'
+        * 'show ipv6 eigrp topology'
         * 'show ip eigrp topology vrf <vrf>'
         * 'show ipv6 eigrp topology vrf <vrf>'
     '''

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -409,7 +409,7 @@ class ShowEigrpTopologySchema(MetaParser):
                                         'num_successors': int,
                                         'fd': str,
                                         'nexthops': {
-                                            Any(): {
+                                            int: {
                                                 'nexthop': str,
                                                 Optional('fd'): int,
                                                 Optional('rd'): int,

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -421,24 +421,24 @@ class ShowEigrpTopologySuperParser(ShowEigrpTopologySchema):
         * 'show ipv6 eigrp topology vrf <vrf>'
     '''
 
-    def cli(self, vrf='', output=None): pass
+    def cli(self, vrf:str='', output:str=None) -> dict: pass
 
 class ShowIpv4EigrpTopology(ShowEigrpTopologySuperParser,
                             ShowEigrpTopologySchema):
     cli_command = 'show ip eigrp topology vrf {vrf}'
 
-    def cli(self, vrf='all', output=None):
+    def cli(self, vrf:str='all', output:str=None) -> dict:
         if output is None: 
-            cmd = self.cli_command.format(vrf=vrf)
-            output = self.device.execute(cmd)
+            cmd:str = self.cli_command.format(vrf=vrf)
+            output:str = self.device.execute(cmd)
         return super().cli(vrf=vrf, output=output)
 
 class ShowIpv6EigrpTopology(ShowEigrpTopologySuperParser,
                             ShowEigrpTopologySchema):
     cli_command = 'show ipv6 eigrp topology vrf {vrf}'
 
-    def cli(self, vrf='all', output=None):
+    def cli(self, vrf:str='all', output:str=None) -> dict:
         if output is None:
-            cmd = self.cli_command.format(vrf=vrf)
-            output = self.device.execute(cmd)
+            cmd:str = self.cli_command.format(vrf=vrf)
+            output:str = self.device.execute(cmd)
         return super().cli(vrf=vrf, output=output)

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -407,7 +407,7 @@ class ShowEigrpTopologySchema(MetaParser):
                                     Any(): {
                                         'state': str,
                                         'num_successors': int,
-                                        'fd': int,
+                                        'fd': str,
                                         'nexthops': {
                                             Any(): {
                                                 'nexthop': str,
@@ -456,9 +456,10 @@ class ShowEigrpTopology(ShowEigrpTopologySchema):
 
         # P 1.0.1.0/24, 1 successors, FD is 2816
         # P 2001:1::1:0/112, 1 successors, FD is 2816
+        # P 2.0.1.0/24, 2 successors, FD is Inaccessible
         r2 = re.compile(r'^(?P<state>P|A|U|Q|R|r|s)\s+(?P<route>\S+),\s+'
                         '(?P<num_successors>\d+)\s+successors,'
-                        '\s+FD\s+is\s+(?P<fd>\d+)$')
+                        '\s+FD\s+is\s+(?P<fd>(\d+)|Inaccessible)$')
 
         # via Connected, Ethernet1/2
         # via Rstatic (51200/0)
@@ -514,7 +515,7 @@ class ShowEigrpTopology(ShowEigrpTopologySchema):
                     .setdefault(route, {})
                 route_dict['state'] = group['state']
                 route_dict['num_successors'] = int(group['num_successors'])
-                route_dict['fd'] = int(group['fd'])
+                route_dict['fd'] = group['fd']
 
             result = r3.match(line)
             if result:

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -424,13 +424,24 @@ class ShowEigrpTopologySchema(MetaParser):
         }
     }
 
-class ShowEigrpTopologySuperParser(ShowEigrpTopologySchema):
+class ShowEigrpTopology(ShowEigrpTopologySchema):
     '''Super parser for:
         * 'show ip eigrp topology vrf <vrf>'
         * 'show ipv6 eigrp topology vrf <vrf>'
     '''
 
-    def cli(self, vrf:str='', output:str=None) -> dict:
+    cli_command = [
+        'show {af} eigrp topology',
+        'show {af} eigrp topology vrf {vrf}'
+    ]
+
+    def cli(self, af:str, vrf:str='', output:str=None) -> dict:
+        if output is None :
+            if (vrf == '') :
+                cmd:str = self.cli_command[0].format(af=af)
+            else :
+                cmd:str = self.cli_command[1].format(af=af, vrf=vrf)
+            output = self.device.execute(cmd)
 
         # IP-EIGRP Topology Table for AS(1)/ID(10.0.0.1) VRF default
         # IPv6-EIGRP Topology Table for AS(0)/ID(0.0.0.0) VRF vrf1
@@ -524,23 +535,3 @@ class ShowEigrpTopologySuperParser(ShowEigrpTopologySchema):
                     nexthop_dict['interface'] = group['interface']
 
         return parsed_dict
-
-class ShowIpv4EigrpTopology(ShowEigrpTopologySuperParser,
-                            ShowEigrpTopologySchema):
-    cli_command = 'show ip eigrp topology vrf {vrf}'
-
-    def cli(self, vrf:str='all', output:str=None) -> dict:
-        if output is None: 
-            cmd:str = self.cli_command.format(vrf=vrf)
-            output:str = self.device.execute(cmd)
-        return super().cli(vrf=vrf, output=output)
-
-class ShowIpv6EigrpTopology(ShowEigrpTopologySuperParser,
-                            ShowEigrpTopologySchema):
-    cli_command = 'show ipv6 eigrp topology vrf {vrf}'
-
-    def cli(self, vrf:str='all', output:str=None) -> dict:
-        if output is None:
-            cmd:str = self.cli_command.format(vrf=vrf)
-            output:str = self.device.execute(cmd)
-        return super().cli(vrf=vrf, output=output)

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -11,7 +11,7 @@ import re
 
 # Metaparser
 from genie.metaparser import MetaParser
-from genie.metaparser.util.schemaengine import Any
+from genie.metaparser.util.schemaengine import Any, Optional
 
 # Libs
 from genie.libs.parser.utils.common import Common
@@ -386,3 +386,59 @@ class ShowIpv6EigrpNeighborsDetail(ShowEigrpNeighborsDetailSuperParser,
             show_output = output
 
         return super().cli(output=show_output, vrf=vrf)
+
+class ShowEigrpTopologySchema(MetaParser):
+    '''Schema for:
+        * 'show ip eigrp topology vrf <vrf>'
+        * 'show ipv6 eigrp topology vrf <vrf>'
+    '''
+
+    schema = {
+        Any(): {
+            Any(): {
+                Any(): {
+                    Any(): {
+                        'state': str,
+                        'successors': int,
+                        'fd': int,
+                        'nexthops': {
+                            Any(): {
+                                'nexthop': str,
+                                Optional('fd'): int,
+                                Optional('rd'): int,
+                                Optional('interface'): str
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+class ShowEigrpTopologySuperParser(ShowEigrpTopologySchema):
+    '''Super parser for:
+        * 'show ip eigrp topology vrf <vrf>'
+        * 'show ipv6 eigrp topology vrf <vrf>'
+    '''
+
+    def cli(self, vrf='', output=None): pass
+
+class ShowIpv4EigrpTopology(ShowEigrpTopologySuperParser,
+                            ShowEigrpTopologySchema):
+    cli_command = 'show ip eigrp topology vrf {vrf}'
+
+    def cli(self, vrf='all', output=None):
+        if output is None: 
+            cmd = self.cli_command.format(vrf=vrf)
+            output = self.device.execute(cmd)
+        return super().cli(vrf=vrf, output=output)
+
+class ShowIpv6EigrpTopology(ShowEigrpTopologySuperParser,
+                            ShowEigrpTopologySchema):
+    cli_command = 'show ipv6 eigrp topology vrf {vrf}'
+
+    def cli(self, vrf='all', output=None):
+        if output is None:
+            cmd = self.cli_command.format(vrf=vrf)
+            output = self.device.execute(cmd)
+        return super().cli(vrf=vrf, output=output)

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -395,8 +395,9 @@ class ShowEigrpTopologySchema(MetaParser):
 
     schema = {
         Any(): { # eigrp_instance
+            'as': int,
+            'routeid': Or(IPv4Address, IPv6Address),
             Any(): { # vrf
-                'routeid': str,
                 Any(): { # address_family
                     Any(): { # route
                         'state': str,

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -397,7 +397,7 @@ class ShowEigrpTopologySchema(MetaParser):
 
     schema = {
         'as': {
-            Any(): {
+            int: {
                 'routerid': str,
                 'vrf': {
                     Any(): {
@@ -482,7 +482,7 @@ class ShowEigrpTopology(ShowEigrpTopologySchema):
                 address_family = group['address_family'].lower()
                 if address_family == 'ip':
                     address_family = 'ipv4'
-                as_num = group['as_num']
+                as_num = int(group['as_num'])
                 routerid = group['routerid']
                 vrf = group['vrf']
                 as_dict:dict = parsed_dict \

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -394,9 +394,8 @@ class ShowEigrpTopologySchema(MetaParser):
     '''
 
     schema = {
-        'eigrp_instance': {
+        'as': {
             Any(): {
-                'as': int,
                 'routeid': str,
                 'vrf': {
                     Any(): {

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -394,21 +394,29 @@ class ShowEigrpTopologySchema(MetaParser):
     '''
 
     schema = {
-        Any(): { # eigrp_instance
-            'as': int,
-            'routeid': Or(IPv4Address, IPv6Address),
-            Any(): { # vrf
-                Any(): { # address_family
-                    Any(): { # route
-                        'state': str,
-                        'successors': int,
-                        'fd': int,
-                        'nexthops': {
+        'eigrp_instance': {
+            Any(): {
+                'as': int,
+                'routeid': str,
+                'vrf': {
+                    Any(): {
+                        'address_family': {
                             Any(): {
-                                'nexthop': str,
-                                Optional('fd'): int,
-                                Optional('rd'): int,
-                                Optional('interface'): str
+                                'route': {
+                                    Any(): {
+                                        'state': str,
+                                        'successors': int,
+                                        'fd': int,
+                                        'nexthops': {
+                                            Any(): {
+                                                'nexthop': str,
+                                                Optional('fd'): int,
+                                                Optional('rd'): int,
+                                                Optional('interface'): str
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/genie/libs/parser/nxos/show_eigrp.py
+++ b/src/genie/libs/parser/nxos/show_eigrp.py
@@ -404,7 +404,7 @@ class ShowEigrpTopologySchema(MetaParser):
                                 'route': {
                                     Any(): {
                                         'state': str,
-                                        'successors': int,
+                                        'num_successors': int,
                                         'fd': int,
                                         'nexthops': {
                                             Any(): {
@@ -453,7 +453,7 @@ class ShowEigrpTopology(ShowEigrpTopologySchema):
         # P 1.0.1.0/24, 1 successors, FD is 2816
         # P 2001:1::1:0/112, 1 successors, FD is 2816
         r2 = re.compile(r'^(?P<state>P|A|U|Q|R|r|s)\s+(?P<route>\S+),\s+'
-                        '(?P<successors>\d+)\s+successors,'
+                        '(?P<num_successors>\d+)\s+successors,'
                         '\s+FD\s+is\s+(?P<fd>\d+)$')
 
         # via Connected, Ethernet1/2
@@ -509,7 +509,7 @@ class ShowEigrpTopology(ShowEigrpTopologySchema):
                     .setdefault('route', {}) \
                     .setdefault(route, {})
                 route_dict['state'] = group['state']
-                route_dict['successors'] = int(group['successors'])
+                route_dict['num_successors'] = int(group['num_successors'])
                 route_dict['fd'] = int(group['fd'])
 
             result = r3.match(line)

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -465,7 +465,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "fd": 2816,
                                         "nexthops": {
                                             "0": {
-                                                "nexthope": "Connected",
+                                                "nexthop": "Connected",
                                                 "interface": "Ethernet1/2"
                                             }
                                         }
@@ -476,12 +476,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "fd": 51200,
                                         "nexthops": {
                                             "0": {
-                                                "nexthope": "Rstatic",
+                                                "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
                                             "1": {
-                                                "nexthope": "1.0.1.2",
+                                                "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
                                                 "interface": "Ethernet1/2"
@@ -494,12 +494,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "fd": 51200,
                                         "nexthops": {
                                             "0": {
-                                                "nexthope": "Rstatic",
+                                                "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
                                             "1": {
-                                                "nexthope": "1.0.1.2",
+                                                "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
                                                 "interface": "Ethernet1/2"
@@ -512,12 +512,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "fd": 51200,
                                         "nexthops": {
                                             "0": {
-                                                "nexthope": "Rstatic",
+                                                "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
                                             "1": {
-                                                "nexthope": "1.0.1.2",
+                                                "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
                                                 "interface": "Ethernet1/2"
@@ -530,12 +530,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "fd": 51200,
                                         "nexthops": {
                                             "0": {
-                                                "nexthope": "Rstatic",
+                                                "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
                                             "1": {
-                                                "nexthope": "1.0.1.2",
+                                                "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
                                                 "interface": "Ethernet1/2"
@@ -548,12 +548,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "fd": 51200,
                                         "nexthops": {
                                             "0": {
-                                                "nexthope": "Rstatic",
+                                                "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
                                             "1": {
-                                                "nexthope": "1.0.1.2",
+                                                "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
                                                 "interface": "Ethernet1/2"

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -595,6 +595,151 @@ class test_show_eigrp_topology(unittest.TestCase):
                 via 1.0.1.2 (3072/576), Ethernet1/2
     '''}
 
+    expected_parsed_output_2 = {
+        "as": {
+            "1": {
+                "routerid": "2001:10::1",
+                "vrf": {
+                    "default": {
+                        "address_family": {
+                            "ipv6": {
+                                "route": {
+                                    "2001:1::1:0/112": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 2816,
+                                        "nexthops": {
+                                            0: {
+                                                "nexthop": "Connected",
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "2001:11::/112": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            0: {
+                                                "nexthop": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            1: {
+                                                "nexthop": "2001:1::1:2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "2001:11::1:0/112": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            0: {
+                                                "nexthop": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            1: {
+                                                "nexthop": "2001:1::1:2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "2001:11::2:0/112": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            0: {
+                                                "nexthop": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            1: {
+                                                "nexthop": "2001:1::1:2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "2001:11::3:0/112": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            0: {
+                                                "nexthop": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            1: {
+                                                "nexthop": "2001:1::1:2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "2001:11::4:0/112": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            0: {
+                                                "nexthop": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            1: {
+                                                "nexthop": "2001:1::1:2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    device_output_2 = {'execute.return_value': '''
+    # show ipv6 eigrp topology vrf all
+        IPv6-EIGRP Topology Table for AS(1)/ID(2001:10::1) VRF default
+
+        Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+            r - reply Status, s - sia Status 
+
+        P 2001:1::1:0/112, 1 successors, FD is 2816
+                via Connected, Ethernet1/2
+        P 2001:11::/112, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 2001:1::1:2 (3072/576), Ethernet1/2
+        P 2001:11::1:0/112, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 2001:1::1:2 (3072/576), Ethernet1/2
+        P 2001:11::2:0/112, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 2001:1::1:2 (3072/576), Ethernet1/2
+        P 2001:11::3:0/112, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 2001:1::1:2 (3072/576), Ethernet1/2
+        P 2001:11::4:0/112, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 2001:1::1:2 (3072/576), Ethernet1/2
+    '''}
+
     def test_show_eigrp_topology_empty(self):
         self.device = Mock(**self.device_output_empty)
         obj = ShowIpv4EigrpTopology(device=self.device)
@@ -608,8 +753,13 @@ class test_show_eigrp_topology(unittest.TestCase):
     def test_show_eigrp_topology_1(self):
         self.device = Mock(**self.device_output_1)
         obj = ShowIpv4EigrpTopology(device=self.device)
-        parsed_output = obj.parse()
+        parsed_output:dict = obj.parse()
         self.assertEqual(parsed_output, self.expected_parsed_output_1)
 
+    def test_show_eigrp_topology_2(self):
+        self.device = Mock(**self.device_output_2)
+        obj = ShowIpv6EigrpTopology(device=self.device)
+        parsed_output:dict = obj.parse()
+        self.assertEqual(parsed_output, self.expected_parsed_output_2)
 if __name__ == '__main__':
     unittest.main()

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -761,5 +761,6 @@ class test_show_eigrp_topology(unittest.TestCase):
         obj = ShowIpv6EigrpTopology(device=self.device)
         parsed_output:dict = obj.parse()
         self.assertEqual(parsed_output, self.expected_parsed_output_2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -12,7 +12,9 @@ from genie.metaparser.util.exceptions import SchemaEmptyParserError
 from genie.libs.parser.nxos.show_eigrp import ShowIpv4EigrpNeighbors,\
                                               ShowIpv6EigrpNeighbors,\
                                               ShowIpv4EigrpNeighborsDetail,\
-                                              ShowIpv6EigrpNeighborsDetail
+                                              ShowIpv6EigrpNeighborsDetail, \
+                                              ShowIpv4EigrpTopology, \
+                                              ShowIpv6EigrpTopology
 
 
 class test_show_eigrp_neighbors(unittest.TestCase):
@@ -440,6 +442,182 @@ class test_show_eigrp_neighbors_detail(unittest.TestCase):
         with self.assertRaises(SchemaEmptyParserError):
             parsed_output = obj.parse()
 
+
+class test_show_eigrp_topology(unittest.TestCase):
+
+    maxDiff = None
+    device = Device(name='aDevice')
+
+    device_output_empty = {'execute.return_value': ''}
+
+    expected_parsed_output_1 = {
+        '100': {
+            'default': {
+                'ipv4': {
+                    '1.0.1.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 2816,
+                        'nexthops': {
+                            0: {
+                                'nexthop': 'Connected',
+                                'interface': 'Ethernet1/2',
+                            }
+                        }
+                    },
+                    '11.0.0.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 51200,
+                        'nexthops': {
+                            0: {
+                                'nexthop': 'Rstatic',
+                                'fd': 51200,
+                                'rd': 0
+                            },
+                            1: {
+                                'nexthop': '1.0.1.2',
+                                'fd': 3072,
+                                'rd': 576,
+                                'interface': 'Ethernet1/2'
+                            }
+                        }
+                    },
+                    '11.0.1.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 51200,
+                        'nexthops': {
+                            0: {
+                                'nexthop': 'Rstatic',
+                                'fd': 51200,
+                                'rd': 0
+                            },
+                            1: {
+                                'nexthop': '1.0.1.2',
+                                'fd': 3072,
+                                'rd': 576,
+                                'interface': 'Ethernet1/2'
+                            }
+                        }
+                    },
+                    '11.0.2.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 51200,
+                        'nexthops': {
+                            0: {
+                                'nexthop': 'Rstatic',
+                                'fd': 51200,
+                                'rd': 0
+                            },
+                            1: {
+                                'nexthop': '1.0.1.2',
+                                'fd': 3072,
+                                'rd': 576,
+                                'interface': 'Ethernet1/2'
+                            }
+                        }
+                    },
+                    '11.0.3.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 51200,
+                        'nexthops': {
+                            0: {
+                                'nexthop': 'Rstatic',
+                                'fd': 51200,
+                                'rd': 0
+                            },
+                            1: {
+                                'nexthop': '1.0.1.2',
+                                'fd': 3072,
+                                'rd': 576,
+                                'interface': 'Ethernet1/2'
+                            }
+                        }
+                    },
+                    '11.0.4.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 51200,
+                        'nexthops': {
+                            0: {
+                                'nexthop': 'Rstatic',
+                                'fd': 51200,
+                                'rd': 0
+                            },
+                            1: {
+                                'nexthop': '1.0.1.2',
+                                'fd': 3072,
+                                'rd': 576,
+                                'interface': 'Ethernet1/2'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    excepteed_parsed_output_1 = {
+        '100': {
+            'default': {
+                'ipv4': {
+                    '1.0.1.0/24': {
+                        'state': 'P',
+                        'successors': 1,
+                        'fd': 2816,
+                        'via': {
+                            
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    device_output_1 = {'execute.return_value': '''
+        # show ip eigrp topology vrf all
+        IP-EIGRP Topology Table for AS(1)/ID(10.0.0.1) VRF default
+
+        Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+            r - reply Status, s - sia Status 
+
+        P 1.0.1.0/24, 1 successors, FD is 2816
+                via Connected, Ethernet1/2
+        P 11.0.0.0/24, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 1.0.1.2 (3072/576), Ethernet1/2
+        P 11.0.1.0/24, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 1.0.1.2 (3072/576), Ethernet1/2
+        P 11.0.2.0/24, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 1.0.1.2 (3072/576), Ethernet1/2
+        P 11.0.3.0/24, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 1.0.1.2 (3072/576), Ethernet1/2
+        P 11.0.4.0/24, 1 successors, FD is 51200
+                via Rstatic (51200/0)
+                via 1.0.1.2 (3072/576), Ethernet1/2
+    '''}
+
+    def test_show_eigrp_topology_empty(self):
+        self.device = Mock(**self.device_output_empty)
+        obj = ShowIpv4EigrpTopology(device=self.device)
+        with self.assertRaises(SchemaEmptyParserError):
+            obj.parse()
+        del obj
+        obj = ShowIpv6EigrpTopology(device=self.device)
+        with self.assertRaises(SchemaEmptyParserError):
+            obj.parse()
+
+    def test_show_eigrp_topology_1(self):
+        self.device = Mock(**self.device_output_1)
+        obj = ShowIpv4EigrpTopology(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.expected_output_1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -13,8 +13,7 @@ from genie.libs.parser.nxos.show_eigrp import ShowIpv4EigrpNeighbors,\
                                               ShowIpv6EigrpNeighbors,\
                                               ShowIpv4EigrpNeighborsDetail,\
                                               ShowIpv6EigrpNeighborsDetail, \
-                                              ShowIpv4EigrpTopology, \
-                                              ShowIpv6EigrpTopology
+                                              ShowEigrpTopology
 
 
 class test_show_eigrp_neighbors(unittest.TestCase):
@@ -742,24 +741,24 @@ class test_show_eigrp_topology(unittest.TestCase):
 
     def test_show_eigrp_topology_empty(self):
         self.device = Mock(**self.device_output_empty)
-        obj = ShowIpv4EigrpTopology(device=self.device)
+        obj = ShowEigrpTopology(device=self.device)
         with self.assertRaises(SchemaEmptyParserError):
-            obj.parse()
+            obj.parse(af='ip')
         del obj
-        obj = ShowIpv6EigrpTopology(device=self.device)
+        obj = ShowEigrpTopology(device=self.device)
         with self.assertRaises(SchemaEmptyParserError):
-            obj.parse()
+            obj.parse(af='ipv6')
 
     def test_show_eigrp_topology_1(self):
         self.device = Mock(**self.device_output_1)
-        obj = ShowIpv4EigrpTopology(device=self.device)
-        parsed_output:dict = obj.parse()
+        obj = ShowEigrpTopology(device=self.device)
+        parsed_output:dict = obj.parse(af='ip')
         self.assertEqual(parsed_output, self.expected_parsed_output_1)
 
     def test_show_eigrp_topology_2(self):
         self.device = Mock(**self.device_output_2)
-        obj = ShowIpv6EigrpTopology(device=self.device)
-        parsed_output:dict = obj.parse()
+        obj = ShowEigrpTopology(device=self.device)
+        parsed_output:dict = obj.parse(af='ipv6')
         self.assertEqual(parsed_output, self.expected_parsed_output_2)
 
 if __name__ == '__main__':

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -451,107 +451,116 @@ class test_show_eigrp_topology(unittest.TestCase):
     device_output_empty = {'execute.return_value': ''}
 
     expected_parsed_output_1 = {
-        '100': {
-            'default': {
-                'ipv4': {
-                    '1.0.1.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 2816,
-                        'nexthops': {
-                            0: {
-                                'nexthop': 'Connected',
-                                'interface': 'Ethernet1/2',
-                            }
-                        }
-                    },
-                    '11.0.0.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 51200,
-                        'nexthops': {
-                            0: {
-                                'nexthop': 'Rstatic',
-                                'fd': 51200,
-                                'rd': 0
-                            },
-                            1: {
-                                'nexthop': '1.0.1.2',
-                                'fd': 3072,
-                                'rd': 576,
-                                'interface': 'Ethernet1/2'
-                            }
-                        }
-                    },
-                    '11.0.1.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 51200,
-                        'nexthops': {
-                            0: {
-                                'nexthop': 'Rstatic',
-                                'fd': 51200,
-                                'rd': 0
-                            },
-                            1: {
-                                'nexthop': '1.0.1.2',
-                                'fd': 3072,
-                                'rd': 576,
-                                'interface': 'Ethernet1/2'
-                            }
-                        }
-                    },
-                    '11.0.2.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 51200,
-                        'nexthops': {
-                            0: {
-                                'nexthop': 'Rstatic',
-                                'fd': 51200,
-                                'rd': 0
-                            },
-                            1: {
-                                'nexthop': '1.0.1.2',
-                                'fd': 3072,
-                                'rd': 576,
-                                'interface': 'Ethernet1/2'
-                            }
-                        }
-                    },
-                    '11.0.3.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 51200,
-                        'nexthops': {
-                            0: {
-                                'nexthop': 'Rstatic',
-                                'fd': 51200,
-                                'rd': 0
-                            },
-                            1: {
-                                'nexthop': '1.0.1.2',
-                                'fd': 3072,
-                                'rd': 576,
-                                'interface': 'Ethernet1/2'
-                            }
-                        }
-                    },
-                    '11.0.4.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 51200,
-                        'nexthops': {
-                            0: {
-                                'nexthop': 'Rstatic',
-                                'fd': 51200,
-                                'rd': 0
-                            },
-                            1: {
-                                'nexthop': '1.0.1.2',
-                                'fd': 3072,
-                                'rd': 576,
-                                'interface': 'Ethernet1/2'
+        "as": {
+            "1": {
+                "routerid": "10.0.0.1",
+                "vrf": {
+                    "default": {
+                        "address_family": {
+                            "ipv4": {
+                                "route": {
+                                    "1.0.1.0/24": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 2816,
+                                        "nexthops": {
+                                            "0": {
+                                                "nexthope": "Connected",
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "11.0.0.0/24": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            "0": {
+                                                "nexthope": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            "1": {
+                                                "nexthope": "1.0.1.2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "11.0.1.0/24": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            "0": {
+                                                "nexthope": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            "1": {
+                                                "nexthope": "1.0.1.2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "11.0.2.0/24": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            "0": {
+                                                "nexthope": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            "1": {
+                                                "nexthope": "1.0.1.2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "11.0.3.0/24": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            "0": {
+                                                "nexthope": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            "1": {
+                                                "nexthope": "1.0.1.2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    },
+                                    "11.0.4.0/24": {
+                                        "state": "P",
+                                        "successors": 1,
+                                        "fd": 51200,
+                                        "nexthops": {
+                                            "0": {
+                                                "nexthope": "Rstatic",
+                                                "fd": 51200,
+                                                "rd": 0
+                                            },
+                                            "1": {
+                                                "nexthope": "1.0.1.2",
+                                                "fd": 3072,
+                                                "rd": 576,
+                                                "interface": "Ethernet1/2"
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -464,7 +464,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "successors": 1,
                                         "fd": 2816,
                                         "nexthops": {
-                                            "0": {
+                                            0: {
                                                 "nexthop": "Connected",
                                                 "interface": "Ethernet1/2"
                                             }
@@ -475,12 +475,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
-                                            "0": {
+                                            0: {
                                                 "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
-                                            "1": {
+                                            1: {
                                                 "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
@@ -493,12 +493,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
-                                            "0": {
+                                            0: {
                                                 "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
-                                            "1": {
+                                            1: {
                                                 "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
@@ -511,12 +511,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
-                                            "0": {
+                                            0: {
                                                 "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
-                                            "1": {
+                                            1: {
                                                 "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
@@ -529,12 +529,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
-                                            "0": {
+                                            0: {
                                                 "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
-                                            "1": {
+                                            1: {
                                                 "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
@@ -547,12 +547,12 @@ class test_show_eigrp_topology(unittest.TestCase):
                                         "successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
-                                            "0": {
+                                            0: {
                                                 "nexthop": "Rstatic",
                                                 "fd": 51200,
                                                 "rd": 0
                                             },
-                                            "1": {
+                                            1: {
                                                 "nexthop": "1.0.1.2",
                                                 "fd": 3072,
                                                 "rd": 576,
@@ -562,23 +562,6 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     }
                                 }
                             }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    excepteed_parsed_output_1 = {
-        '100': {
-            'default': {
-                'ipv4': {
-                    '1.0.1.0/24': {
-                        'state': 'P',
-                        'successors': 1,
-                        'fd': 2816,
-                        'via': {
-                            
                         }
                     }
                 }
@@ -626,7 +609,7 @@ class test_show_eigrp_topology(unittest.TestCase):
         self.device = Mock(**self.device_output_1)
         obj = ShowIpv4EigrpTopology(device=self.device)
         parsed_output = obj.parse()
-        self.assertEqual(parsed_output, self.expected_output_1)
+        self.assertEqual(parsed_output, self.expected_parsed_output_1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -451,7 +451,7 @@ class test_show_eigrp_topology(unittest.TestCase):
 
     expected_parsed_output_1 = {
         "as": {
-            "1": {
+            1: {
                 "routerid": "10.0.0.1",
                 "vrf": {
                     "default": {
@@ -596,7 +596,7 @@ class test_show_eigrp_topology(unittest.TestCase):
 
     expected_parsed_output_2 = {
         "as": {
-            "1": {
+            1: {
                 "routerid": "2001:10::1",
                 "vrf": {
                     "default": {

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -461,7 +461,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "1.0.1.0/24": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 2816,
+                                        "fd": "2816",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Connected",
@@ -472,7 +472,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "11.0.0.0/24": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -490,7 +490,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "11.0.1.0/24": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -508,7 +508,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "11.0.2.0/24": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -526,7 +526,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "11.0.3.0/24": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -544,7 +544,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "11.0.4.0/24": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "Inaccessible",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -589,7 +589,7 @@ class test_show_eigrp_topology(unittest.TestCase):
         P 11.0.3.0/24, 1 successors, FD is 51200
                 via Rstatic (51200/0)
                 via 1.0.1.2 (3072/576), Ethernet1/2
-        P 11.0.4.0/24, 1 successors, FD is 51200
+        P 11.0.4.0/24, 1 successors, FD is Inaccessible
                 via Rstatic (51200/0)
                 via 1.0.1.2 (3072/576), Ethernet1/2
     '''}
@@ -606,7 +606,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "2001:1::1:0/112": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 2816,
+                                        "fd": "2816",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Connected",
@@ -617,7 +617,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "2001:11::/112": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -635,7 +635,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "2001:11::1:0/112": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -653,7 +653,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "2001:11::2:0/112": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -671,7 +671,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "2001:11::3:0/112": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "51200",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -689,7 +689,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     "2001:11::4:0/112": {
                                         "state": "P",
                                         "num_successors": 1,
-                                        "fd": 51200,
+                                        "fd": "Inaccessible",
                                         "nexthops": {
                                             0: {
                                                 "nexthop": "Rstatic",
@@ -734,7 +734,7 @@ class test_show_eigrp_topology(unittest.TestCase):
         P 2001:11::3:0/112, 1 successors, FD is 51200
                 via Rstatic (51200/0)
                 via 2001:1::1:2 (3072/576), Ethernet1/2
-        P 2001:11::4:0/112, 1 successors, FD is 51200
+        P 2001:11::4:0/112, 1 successors, FD is Inaccessible
                 via Rstatic (51200/0)
                 via 2001:1::1:2 (3072/576), Ethernet1/2
     '''}

--- a/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_eigrp.py
@@ -460,7 +460,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                 "route": {
                                     "1.0.1.0/24": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 2816,
                                         "nexthops": {
                                             0: {
@@ -471,7 +471,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "11.0.0.0/24": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -489,7 +489,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "11.0.1.0/24": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -507,7 +507,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "11.0.2.0/24": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -525,7 +525,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "11.0.3.0/24": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -543,7 +543,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "11.0.4.0/24": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -605,7 +605,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                 "route": {
                                     "2001:1::1:0/112": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 2816,
                                         "nexthops": {
                                             0: {
@@ -616,7 +616,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "2001:11::/112": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -634,7 +634,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "2001:11::1:0/112": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -652,7 +652,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "2001:11::2:0/112": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -670,7 +670,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "2001:11::3:0/112": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {
@@ -688,7 +688,7 @@ class test_show_eigrp_topology(unittest.TestCase):
                                     },
                                     "2001:11::4:0/112": {
                                         "state": "P",
-                                        "successors": 1,
+                                        "num_successors": 1,
                                         "fd": 51200,
                                         "nexthops": {
                                             0: {


### PR DESCRIPTION
## Description
Added classes and parsing for ```show {ip|ipv6} eigrp topology```.

## Motivation and Context
Need parser for ```show {ip|ipv6} eigrp topology``` as it's not present.

## Impact (If any)
None

## Screenshots:
**make json**:
```
$ make json

--------------------------------------------------------------------
Generating Parser json file

INFO:genie.json.make_json:Learning 'parser_genie_parser'

Done.
```

**unittest**
```
$ python -m unittest 
........................................................................................................................................................................................................................................................./Users/rohsaluj/genieparser/src/genie/libs/parser/iosxr/show_controllers.py:78: FutureWarning: Possible nested set at position 74
  p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
/Users/rohsaluj/genieparser/src/genie/libs/parser/iosxr/show_controllers.py:78: FutureWarning: Possible nested set at position 176
  p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................../Users/rohsaluj/genieparser/src/genie/libs/parser/utils/common.py:607: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  cmd_node = root.getchildren()[0]
/Users/rohsaluj/genieparser/src/genie/libs/parser/utils/common.py:620: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  cmd_node = cmd_node.getchildren()
......................................................................./Users/rohsaluj/genieparser/src/genie/libs/parser/nxos/show_bgp.py:8976: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  for item in nei.getchildren():
/Users/rohsaluj/genieparser/src/genie/libs/parser/nxos/show_bgp.py:8984: DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
  root = item.getchildren()[0]
..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 1511 tests in 24.954s

OK
```

## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
