### PR TITLE
Add logging level option to tests

### DIFF
--- a/tests/ci_folder_parsing.py
+++ b/tests/ci_folder_parsing.py
@@ -501,6 +501,11 @@ if __name__ == "__main__":
                         type=int,
                         help="The specific unittest we want to run, such as '25'",
                         default=None)
+    my_parser.add_argument('-v', "--verbose",
+                        action='store_true',
+                        help="Set Logging level to INFO",
+                        default=False)
+
     args = my_parser.parse_args()
 
     _os = args.operating_system
@@ -508,6 +513,10 @@ if __name__ == "__main__":
     _token = args.token
     _display_only_failed = args.display_only_failed
     _number = args.number
+    _verbose = args.verbose
+
+    if(_verbose):
+        log.setLevel(logging.INFO)
 
     if _number and (not _class or not _number):
         sys.exit("Unittest number provided but missing supporting arguments:"


### PR DESCRIPTION
## Description
Add verbose flag to ci_folder_parsing.py

## Motivation and Context
When creating parsers it's useful to see the parsed output and the expected output. 
With that flag the user can set the logging level to INFO and have that output printed

## Impact (If any)
None

## Screenshots:
None

## Checklist:
- [] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [] I have added tests to cover my changes (If applicable).
- [X] All new and existing tests passed.
- [X] All new code passed compilation.
