### PR TITLE
Fix bug in IOS/IOSXE ShowInterfacesSwitchPort parsing

### DIFF
--- a/changelog/undistributed/changelog_fix_show_interfaces_switchport_20210315102854.rst
+++ b/changelog/undistributed/changelog_fix_show_interfaces_switchport_20210315102854.rst
@@ -1,0 +1,3 @@
+* IOSXE
+  * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
+  * Also modified ios/iosxe current tests because they were wrong

--- a/changelog/undistributed/changelog_fix_show_interfaces_switchport_20210315102854.rst
+++ b/changelog/undistributed/changelog_fix_show_interfaces_switchport_20210315102854.rst
@@ -1,3 +1,15 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
 * IOSXE
-  * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
-  * Also modified ios/iosxe current tests because they were wrong
+  
+  * Modified:
+  
+    * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
+    * Also modified iosxe current tests because they were wrong
+* IOS
+
+  * Modified:
+  
+    * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
+    * Also modified ios current tests because they were wrong

--- a/changelog/undistributed/changelog_fix_show_interfaces_switchport_20210315102854.rst
+++ b/changelog/undistributed/changelog_fix_show_interfaces_switchport_20210315102854.rst
@@ -2,14 +2,10 @@
                                 Fix
 --------------------------------------------------------------------------------
 * IOSXE
-  
   * Modified:
-  
     * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
     * Also modified iosxe current tests because they were wrong
 * IOS
-
   * Modified:
-  
     * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
     * Also modified ios current tests because they were wrong

--- a/src/genie/libs/parser/ios/tests/ShowInterfacesSwitchport/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/ios/tests/ShowInterfacesSwitchport/cli/equal/golden_output_2_expected.py
@@ -20,7 +20,7 @@ expected_output = {
         "pruning_vlans": "2-1001",
         "access_vlan": "1",
         "unknown_multicast_blocked": False,
-        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,",
+        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,470,480,490,500,616,619,700,709-712,720,723-725,760",
         "unknown_unicast_blocked": False,
     },
     "TenGigabitEthernet1/1/2": {
@@ -31,7 +31,7 @@ expected_output = {
         "switchport_enable": True,
         "private_vlan": {},
         "capture_mode": False,
-        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,",
+        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,470,480,490,500,616,619,700,709-712,720,723-725,760",
         "capture_vlans": "all",
         "negotiation_of_trunk": False,
         "unknown_multicast_blocked": False,

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -1783,6 +1783,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
             m = p21.match(line)
             if m:
                 ret_dict[intf]['trunk_vlans'] = m.groupdict()['trunk_vlans'].lower()
+                private_operational = None
                 continue
 
             # 10 (VLAN0010) 100 (VLAN0100)

--- a/src/genie/libs/parser/iosxe/tests/ShowInterfacesSwitchport/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowInterfacesSwitchport/cli/equal/golden_output_2_expected.py
@@ -20,7 +20,7 @@ expected_output = {
         "pruning_vlans": "2-1001",
         "access_vlan": "1",
         "unknown_multicast_blocked": False,
-        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,",
+        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,470,480,490,500,616,619,700,709-712,720,723-725,760",
         "unknown_unicast_blocked": False,
     },
     "TenGigabitEthernet1/1/2": {
@@ -31,7 +31,7 @@ expected_output = {
         "switchport_enable": True,
         "private_vlan": {},
         "capture_mode": False,
-        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,",
+        "trunk_vlans": "1,111,130,131,400,405,410,420,430,439-442,450,451,460,470,480,490,500,616,619,700,709-712,720,723-725,760",
         "capture_vlans": "all",
         "negotiation_of_trunk": False,
         "unknown_multicast_blocked": False,

--- a/src/genie/libs/parser/iosxe/tests/test_show_interface.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_interface.py
@@ -524,7 +524,7 @@ class TestShowInterfacesSwitchport(unittest.TestCase):
             'pruning_vlans': '2-1001',
             'access_vlan': '1',
             'unknown_multicast_blocked': False,
-            'trunk_vlans': '1,111,130,131,400,405,410,420,430,439-442,450,451,460,',
+            'trunk_vlans': '1,111,130,131,400,405,410,420,430,439-442,450,451,460,470,480,490,500,616,619,700,709-712,720,723-725,760',
             'unknown_unicast_blocked': False,
         },
         'TenGigabitEthernet1/1/2': {
@@ -536,7 +536,7 @@ class TestShowInterfacesSwitchport(unittest.TestCase):
             'private_vlan': {
             },
             'capture_mode': False,
-            'trunk_vlans': '1,111,130,131,400,405,410,420,430,439-442,450,451,460,',
+            'trunk_vlans': '1,111,130,131,400,405,410,420,430,439-442,450,451,460,470,480,490,500,616,619,700,709-712,720,723-725,760',
             'capture_vlans': 'all',
             'negotiation_of_trunk': False,
             'unknown_multicast_blocked': False,


### PR DESCRIPTION
## Description
* IOSXE
  * Modified show_interface.py to fix a bug in ShowInterfacesSwitchport
  * Also modified ios/iosxe current tests because they were wrong

## Motivation and Context
Applied fix for: https://wwwin-github.cisco.com/pyATS/support/issues/431
A bug was found in the ShowInterfacesSwitchport parsing for IOS/IOSXE. Also found that current tests were wrong.

## Impact (If any)
None expected

## Screenshots:
All tests run Ok.

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ x] All new and existing tests passed.
- [ x] All new code passed compilation.
