### PR TITLE
Adding try/except block for rp_dict

### DIFF
--- a/changelog/undistributed/changelog_iosxe_show_inventory_fix_20210929.rst
+++ b/changelog/undistributed/changelog_iosxe_show_inventory_fix_20210929.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Updated ShowInventory:
+        * Fixed error where subslot dictionary wasn't initialized before accessing

--- a/src/genie/libs/parser/iosxe/show_platform.py
+++ b/src/genie/libs/parser/iosxe/show_platform.py
@@ -2133,6 +2133,12 @@ class ShowInventory(ShowInventorySchema):
                 # PID: EM7455/EM7430     , VID: 1.0  , SN: 355813070074072
                 elif subslot:
                     if ('STACK' in pid) or asr900_rp:
+                        # Try and access the rp_dict dict if already initialised
+                        try:
+                            rp_dict
+                        # If not found, initialise an empty dict to store results
+                        except NameError:
+                            rp_dict = dict()
                         subslot_dict = rp_dict.setdefault('subslot', {}).\
                             setdefault(subslot, {}).\
                             setdefault(pid, {})

--- a/src/genie/libs/parser/iosxe/show_platform.py
+++ b/src/genie/libs/parser/iosxe/show_platform.py
@@ -2132,13 +2132,21 @@ class ShowInventory(ShowInventorySchema):
                 # PID: SFP-GE-T          , VID: V02  , SN: MTC2139029X
                 # PID: EM7455/EM7430     , VID: 1.0  , SN: 355813070074072
                 elif subslot:
-                    if ('STACK' in pid) or asr900_rp:
-                        # Try and access the rp_dict dict if already initialised
+                    if ('STACK' in pid):
                         try:
                             rp_dict
-                        # If not found, initialise an empty dict to store results
                         except NameError:
-                            rp_dict = dict()
+                            stack_dict = slot_dict.setdefault('other', {}).\
+                                setdefault(pid, {})
+                            subslot_dict = stack_dict.setdefault('subslot', {}).\
+                                setdefault(subslot, {}).\
+                                setdefault(pid, {})
+                        else:
+                            subslot_dict = rp_dict.setdefault('subslot', {}).\
+                                setdefault(subslot, {}).\
+                                setdefault(pid, {})
+
+                    elif asr900_rp:
                         subslot_dict = rp_dict.setdefault('subslot', {}).\
                             setdefault(subslot, {}).\
                             setdefault(pid, {})

--- a/src/genie/libs/parser/iosxe/tests/ShowInventory/cli/equal/golden_output_6_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowInventory/cli/equal/golden_output_6_expected.py
@@ -1,0 +1,40 @@
+expected_output = {
+    'main': {
+        'swstack': True,
+    },
+    'slot': {
+        '1': {
+            'other': {
+                'C9300-48U': {
+                    'descr': 'C9300-48U',
+                    'name': 'Switch 1',
+                    'pid': 'C9300-48U',
+                    'sn': 'FCW999999999',
+                    'vid': 'V02',
+                },
+                'STACK-T1-50CM': {
+                    'subslot': {
+                        '1': {
+                            'STACK-T1-50CM': {
+                                'descr': 'StackPort1/1',
+                                'name': 'StackPort1/1',
+                                'pid': 'STACK-T1-50CM',
+                                'sn': 'MOC3333333',
+                                'vid': 'V01',
+                            },
+                        },
+                        '2': {
+                            'STACK-T1-50CM': {
+                                'descr': 'StackPort1/2',
+                                'name': 'StackPort1/2',
+                                'pid': 'STACK-T1-50CM',
+                                'sn': 'MOC4444444',
+                                'vid': 'V01',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowInventory/cli/equal/golden_output_6_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowInventory/cli/equal/golden_output_6_output.txt
@@ -1,0 +1,11 @@
+NAME: "c93xx Stack", DESCR: "c93xx Stack"
+PID: C9300-48U         , VID: V02  , SN: FCW88888888
+
+NAME: "Switch 1", DESCR: "C9300-48U"
+PID: C9300-48U         , VID: V02  , SN: FCW999999999
+
+NAME: "StackPort1/1", DESCR: "StackPort1/1"
+PID: STACK-T1-50CM     , VID: V01  , SN: MOC3333333
+
+NAME: "StackPort1/2", DESCR: "StackPort1/2"
+PID: STACK-T1-50CM     , VID: V01  , SN: MOC4444444


### PR DESCRIPTION
## Description
As described in #395, this parser is failing as it's trying to access a dictionary called `rp_dict` which at this point in the code does not exist. This fix is to address this bug.

## Motivation and Context
It's required to solve the problem whereby the `rp_dict` doesn't exist in this part of the code logic.

## Impact (If any)
No negative impact.

## Screenshots:

No screenshots.

## Checklist:

- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.

This is a bug and we have been asked to provide the fix. So it's been provided as requested.
