### PR TITLE
Changes for show vrrp all parser

### DIFF
--- a/changelog/undistributed/showVrrlAllParserChange20210714120100.rst
+++ b/changelog/undistributed/showVrrlAllParserChange20210714120100.rst
@@ -1,0 +1,11 @@
+-------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowVrrpAll:
+        * Changed master_router_priority,master_advertisement_interval_secs and master_advertisement_interval_secs from schema to Support Str datastructure.
+        * Updated regex pattern <p1> to accommodate various outputs.
+        * Updated regex pattern p3 to accomdate output of no address
+        * Added regex pattern p16_2 to accomdate unknown values for negative cases
+        * Added regex pattern p17_2 to accomdate unknown values for negative cases 
+        * Added match codes for the new regex patterns 

--- a/src/genie/libs/parser/iosxe/tests/ShowVrrpAll/cli/equal/golden_output_show-vrrp-all_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowVrrpAll/cli/equal/golden_output_show-vrrp-all_expected.py
@@ -41,6 +41,48 @@ expected_output = {
                     'flags': '1/1'
                 }
             }
+        },
+        'GigabitEthernet1/0/19': {
+            'group': {
+                1: {
+                    'description': 'single_Vrrp', 
+                    'state': 'MASTER', 
+                    'virtual_ip_address': '10.50.10.104', 
+                    'virtual_mac_address': '0000.5E00.0101', 
+                    'advertise_interval_secs': 1.0, 
+                    'preemption': 'enabled', 
+                    'priority': 100, 
+                    'master_router_ip': '10.50.10.106', 
+                    'master_router': 'local', 
+                    'master_router_priority': 100, 
+                    'master_advertisement_interval_secs': 1.0, 
+                    'master_advertisement_expiration_secs': 0.441, 
+                    'master_down_interval_secs': 'unknown', 
+                    'flags': '1/1'
+                }
+            }
+        },
+        'GigabitEthernet1/0/20': {
+                'group': {
+                    1: {
+                        'description': 'single_Vrrp', 
+                        'state': 'INIT', 
+                        'state_duration': {
+                            'minutes': 20, 
+                            'seconds': 5.224
+                            }, 
+                        'virtual_ip_address': 'no address', 
+                        'virtual_mac_address': '0000.5E00.0101', 
+                        'advertise_interval_secs': 40.95, 
+                        'preemption': 'enabled', 
+                        'priority': 200, 
+                        'master_router_ip': 'unknown', 
+                        'master_router_priority': 'unknown', 
+                        'master_advertisement_interval_secs': 'unknown', 
+                        'master_down_interval_secs': 'unknown', 
+                        'flags': '0/0'
+                }
+            }
         }
     }
 }

--- a/src/genie/libs/parser/iosxe/tests/ShowVrrpAll/cli/equal/golden_output_show-vrrp-all_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowVrrpAll/cli/equal/golden_output_show-vrrp-all_output.txt
@@ -22,3 +22,35 @@ GigabitEthernet3.415 - Group 13
   Master Advertisement interval is 1.000 sec
   Master Down interval is 3.609 sec
   FLAGS: 1/1
+
+GigabitEthernet1/0/19 - Group 1 - Address-Family IPv4
+  Description is "single_Vrrp"
+  State is MASTER
+  State duration 23.134 secs
+  Virtual IP address is 10.50.10.104
+  Virtual MAC address is 0000.5E00.0101
+  Advertisement interval is 1000 msec
+  Preemption enabled
+  Priority is 100
+  State change reason:2
+  Tloc preference not configured, value 0
+  Master Router is 10.50.10.106 (local), priority is 100
+  Master Advertisement interval is 1000 msec (expires in 441 msec)
+  Master Down interval is unknown
+  FLAGS: 1/1
+
+GigabitEthernet1/0/20 - Group 1 - Address-Family IPv4
+  Description is "single_Vrrp"
+  State is INIT (No Primary virtual IP address configured)
+  State duration 20 mins 5.224 secs
+  Virtual IP address is no address
+  Virtual MAC address is 0000.5E00.0101
+  Advertisement interval is 40950 msec
+  Preemption enabled
+  Priority is 200
+  State change reason:7
+  Tloc preference not configured, value 0
+  Master Router is unknown, priority is unknown
+  Master Advertisement interval is unknown
+  Master Down interval is unknown
+  FLAGS: 0/0

--- a/src/genie/libs/parser/iosxe/tests/unittest_show_Vrrp.py
+++ b/src/genie/libs/parser/iosxe/tests/unittest_show_Vrrp.py
@@ -1,0 +1,83 @@
+# Import the Python mock functionality
+import unittest
+from unittest.mock import Mock
+
+# pyATS
+from pyats.topology import Device
+from pyats.topology import loader
+
+# Metaparser
+from genie.metaparser.util.exceptions import SchemaEmptyParserError, SchemaMissingKeyError
+
+# iosxe show_vrrp
+from genie.libs.parser.iosxe.show_vrrp import ShowVrrpAll
+
+# =================================
+# Unit test for 'show lisp session'
+# =================================
+class test_show_vrrp_session(unittest.TestCase):
+
+    '''Unit test for "show lisp session"'''
+
+    empty_output = {'execute.return_value': ''}
+
+    # Specify the expected result for the parsed output
+    golden_parsed_output1 = {
+            'interface' : {
+                'GigabitEthernet1/0/19': {
+            'group': {
+                1: {
+                    'description': 'single_Vrrp',
+                    'state': 'MASTER',
+                    'virtual_ip_address': '10.50.10.104',
+                    'virtual_mac_address': '0000.5E00.0101',
+                    'advertise_interval_secs': 1.0,
+                    'preemption': 'enabled',
+                    'priority': 100,
+                    'master_router_ip': '10.50.10.106',
+                    'master_router': 'local',
+                    'master_router_priority': 100,
+                    'master_advertisement_interval_secs': 1.0,
+                    'master_advertisement_expiration_secs': 0.441,
+                    'master_down_interval_secs': 'unknown',
+                    'flags': '1/1'
+                },
+            },
+        },
+    } }
+
+    # Specify the expected unparsed output
+    golden_output1 = {'execute.return_value': '''
+        GigabitEthernet1/0/19 - Group 1 - Address-Family IPv4
+        Description is "single_Vrrp"
+        State is MASTER
+        State duration 23.134 secs
+        Virtual IP address is 10.50.10.104
+        Virtual MAC address is 0000.5E00.0101
+        Advertisement interval is 1000 msec
+        Preemption enabled
+        Priority is 100
+        State change reason:2
+        Tloc preference not configured, value 0
+        Master Router is 10.50.10.106 (local), priority is 100
+        Master Advertisement interval is 1000 msec (expires in 441 msec)
+        Master Down interval is unknown
+        FLAGS: 1/1
+        '''}
+
+    def test_show_vrrp_session_full1(self):
+        self.maxDiff = None
+        self.device = Mock(**self.golden_output1)
+        obj = ShowVrrpAll(device=self.device)
+        parsed_output = obj.parse()
+        self.assertEqual(parsed_output, self.golden_parsed_output1)
+
+    def test_show_vrrp_session_empty(self):
+        self.maxDiff = None
+        self.device = Mock(**self.empty_output)
+        obj = ShowVrrpAll(device=self.device)
+        with self.assertRaises(SchemaEmptyParserError):
+            parsed_output = obj.parse()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
Needed some changes/Update to ShowVrrpAll Parser with respect to platform like CAT9K. Updated the regular expressions and edited few lines of the parser

## Motivation and Context
Updated for interface shut/ no vrrp address and edited as per show vrrp all output in cat9k

## Impact (If any)
NA

## Screenshots:
Folder Testing
![image](https://user-images.githubusercontent.com/87413781/126634873-c0342276-41b2-402c-960e-aca7a25362ef.png)
![image](https://user-images.githubusercontent.com/87413781/126634922-30ce2e3d-b2d2-4fcf-a943-824c5b33df54.png)


## Checklist:
- [x] I have updated the changelog - done
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed- done
- [ ] All new code passed compilation 
