### PR TITLE
Fix JUNOS ShowRouteReceiveProtocol for IPv6 Stuff

### DIFF
--- a/changelog/undistributed/changelog_show_route_receive_protocol_20210806.rst
+++ b/changelog/undistributed/changelog_show_route_receive_protocol_20210806.rst
@@ -1,0 +1,8 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* JUNOS
+    * Modified ShowRouteReceiveProtocol:
+        * Correctly match IPv6 output on multiple lines.
+        * Correctly match IPv6 routes and next-hops with a-f characters
+        * Correctly match the presence or absence of either med or local-pref in output

--- a/src/genie/libs/parser/junos/show_route.py
+++ b/src/genie/libs/parser/junos/show_route.py
@@ -1893,7 +1893,7 @@ class ShowRouteAdvertisingProtocol(ShowRouteAdvertisingProtocolSchema):
         # * 10.4.1.1/32              Self                                    I
         # * 10.36.3.3/32              Self                                    2 I
         # * 10.81.123.0/32        Self                                    67890 [1] I
-        p2 = re.compile(r'((?P<active_tag>\*) +)?(?P<rt_destination>[\d\w\.\:\/]+)'
+        p2 = re.compile(r'((?P<active_tag>\*) +)?(?P<rt_destination>[\d\.\:\/]+)'
                         r' +(?P<to>\S+)( +(?P<med>\d+) +(?P<local_preference>\d+))? '
                         r'+(?P<as_path>[\s\S]+)')
         

--- a/src/genie/libs/parser/junos/show_route.py
+++ b/src/genie/libs/parser/junos/show_route.py
@@ -1689,14 +1689,14 @@ class ShowRouteReceiveProtocol(ShowRouteReceiveProtocolSchema):
         # * 192.168.225.0/24           10.64.4.4                      100        200000 4 5 6 I   
         p2 = re.compile(r'^((?P<active_tag>\*) +)?(?P<rt_destination>[\d\.\:\/]+) '
                         r'+(?P<to>\S+)( +(?P<med>\d+)? +(?P<local_preference>\d+))? '
-                        r'+(?P<as_path>(\(([\S\s]+\)) +\w+)|([\d\s]+?\w))$')
+                        r'+(?P<as_path>(\(([\S\s]+\)) +\w+)|([\d\s]+?\S))$')
 
         # * 2001:db8:3000::/48      2001:db8:7fc5:ca45::2 1000               65509 I
         # * 2001:db8:3000::/48      2001:db8:7fc5:ca45::2 1000     100       65509 I
         # * 2001:db8:3000::/48      2001:db8:7fc5:ca45::2          100       65509 I
         p2_1 = re.compile(r'^((?P<active_tag>\*) +)?(?P<rt_destination>[\d\w\:]+\/[\d]+) '
                           r'+(?P<to>\S+) (((?P<med>\d+)? +)(?P<local_preference>\d+)?)? '
-                          r'+(?P<as_path>(\(([\S\s]+\)) +\w+)|([\d\s]+?\w))$')
+                          r'+(?P<as_path>(\(([\S\s]+\)) +\w+)|([\d\s]+?\S))$')
 
         # 2001:db8:7fc5:ca45::1
         p3 = re.compile(r'^(?P<rt_destination>[\d\:\w\/]+)$')

--- a/src/genie/libs/parser/junos/tests/ShowRouteReceiveProtocol/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/junos/tests/ShowRouteReceiveProtocol/cli/equal/golden_output_2_expected.py
@@ -2,14 +2,6 @@ expected_output = {
     "route-information": {
         "route-table": [
             {
-                "active-route-count": "21",
-                "destination-count": "21",
-                "hidden-route-count": "0",
-                "holddown-route-count": "0",
-                "table-name": "inet.0",
-                "total-route-count": "34",
-            },
-            {
                 "active-route-count": "24",
                 "destination-count": "24",
                 "hidden-route-count": "0",
@@ -140,6 +132,47 @@ expected_output = {
                             "protocol-name": "BGP",
                         },
                     },
+                    {
+                        "rt-destination": "2001:db8:22::/48",
+                        "rt-entry": {
+                            "active-tag": "*",
+                            "as-path": "65509 I",
+                            "med": "1000",
+                            "nh": {"to": "2001:db8:7fc5:ca45::2"},
+                            "protocol-name": "BGP",
+                        },
+                    },
+                    {
+                        "rt-destination": "2001:db8:a280::/48",
+                        "rt-entry": {
+                            "active-tag": "*",
+                            "as-path": "65509 I",
+                            "med": "1000",
+                            "nh": {"to": "2001:db8:7fc5:ca45::2"},
+                            "protocol-name": "BGP",
+                        },
+                    },
+                    {
+                        "rt-destination": "2001:db8:6880::/48",
+                        "rt-entry": {
+                            "active-tag": "*",
+                            "as-path": "65509 I",
+                            "local-preference": "100",
+                            "med": "1000",
+                            "nh": {"to": "2001:db8:7fc5:ca45::2"},
+                            "protocol-name": "BGP",
+                        },
+                    },
+                    {
+                        "rt-destination": "2001:db8:3000::/48",
+                        "rt-entry": {
+                            "active-tag": "*",
+                            "as-path": "65509 I",
+                            "local-preference": "100",
+                            "nh": {"to": "2001:db8:7fc5:ca45::2"},
+                            "protocol-name": "BGP",
+                        },
+                    },
                 ],
                 "table-name": "inet6.0",
                 "total-route-count": "36",
@@ -147,3 +180,5 @@ expected_output = {
         ]
     }
 }
+
+

--- a/src/genie/libs/parser/junos/tests/ShowRouteReceiveProtocol/cli/equal/golden_output_2_output.txt
+++ b/src/genie/libs/parser/junos/tests/ShowRouteReceiveProtocol/cli/equal/golden_output_2_output.txt
@@ -1,7 +1,5 @@
 
-        show route receive-protocol bgp 2001:db8:7fc5:ca45::4
 
-        inet.0: 21 destinations, 34 routes (21 active, 0 holddown, 0 hidden)
 
         inet6.0: 24 destinations, 36 routes (24 active, 0 holddown, 0 hidden)
         Prefix                  Nexthop              MED     Lclpref    AS path
@@ -31,4 +29,7 @@
                                 2001:db8:7fc5:ca45::3             100        I
         2001:db8:7fc5:9a4b::4/128
         *                         2001:db8:7fc5:ca45::4             100        I
-    
+        * 2001:db8:22::/48        2001:db8:7fc5:ca45::2 1000               65509 I
+        * 2001:db8:a280::/48      2001:db8:7fc5:ca45::2 1000               65509 I
+        * 2001:db8:6880::/48     2001:db8:7fc5:ca45::2 1000      100         65509 I
+        * 2001:db8:3000::/48      2001:db8:7fc5:ca45::2           100      65509 I


### PR DESCRIPTION
## Description
Fix more regex where IPv6 routes or next-hops weren't matching correctly.

## Motivation and Context
Routes were being missed by the parser.

## Impact (If any)
N/A

## Screenshots:
<img width="714" alt="Screen Shot 2021-08-06 at 5 14 24 PM" src="https://user-images.githubusercontent.com/6683984/128576038-afdd451f-68f9-4ff1-afc2-8dfd117a92c9.png">


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x ] I have added tests to cover my changes (If applicable).
- [x ] All new and existing tests passed.
- [ ] All new code passed compilation.
