### PR TITLE
IOSXR/NXOS: fix "show static routing" parsers to correctly handle IPv6

### DIFF
--- a/changelog/undistributed/changelog_iosxr_showStaticTopologyDetail_20210827.rst
+++ b/changelog/undistributed/changelog_iosxr_showStaticTopologyDetail_20210827.rst
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowStaticTopologyDetail:
+        * Correctly match IPv6 addresses
+* NXOS
+    * Modified ShowIpv6StaticRoute
+        * Correctly match IPv6 addresses

--- a/src/genie/libs/parser/ios/tests/ShowBgpAllDetail/cli/equal/golden_output1_expected.py
+++ b/src/genie/libs/parser/ios/tests/ShowBgpAllDetail/cli/equal/golden_output1_expected.py
@@ -155,7 +155,7 @@ expected_output = {
                         },
                         "ipv6 unicast": {
                             "prefixes": {
-                                "2001:1:1:1::1/128": {
+                                "2001:1:1:a::1/128": {
                                     "available_path": "1",
                                     "best_path": "1",
                                     "index": {

--- a/src/genie/libs/parser/ios/tests/ShowBgpAllDetail/cli/equal/golden_output1_output.txt
+++ b/src/genie/libs/parser/ios/tests/ShowBgpAllDetail/cli/equal/golden_output1_output.txt
@@ -36,7 +36,7 @@ Local
 
 For address family: IPv6 Unicast
 
-BGP routing table entry for 2001:1:1:1::1/128, version 4
+BGP routing table entry for 2001:1:1:a::1/128, version 4
 Paths: (1 available, best #1, table default)
 Advertised to update-groups:
    1         

--- a/src/genie/libs/parser/ios/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_expected.py
+++ b/src/genie/libs/parser/ios/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_expected.py
@@ -6,12 +6,12 @@ expected_output = {
                     "rp": {
                         "bsr": {
                             "bsr_candidate": {
-                                "address": "2001:1:1:1::1",
+                                "address": "2001:1:1:a::1",
                                 "priority": 0,
                                 "hash_mask_length": 126,
                             },
                             "bsr": {
-                                "address": "2001:1:1:1::1",
+                                "address": "2001:1:1:a::1",
                                 "hash_mask_length": 126,
                                 "priority": 0,
                                 "up_time": "00:00:07",

--- a/src/genie/libs/parser/ios/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_output.txt
+++ b/src/genie/libs/parser/ios/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_output.txt
@@ -5,10 +5,10 @@ R1_xe#show ipv6 pim bsr election
     BSR Election Information
       Scope Range List: ff00::/8
       This system is the Bootstrap Router (BSR)
-         BSR Address: 2001:1:1:1::1
+         BSR Address: 2001:1:1:a::1
          Uptime: 00:00:07, BSR Priority: 0, Hash mask length: 126
          RPF: FE80::21E:F6FF:FE2D:3600,Loopback0
          BS Timer: 00:00:52
       This system is candidate BSR
-          Candidate BSR address: 2001:1:1:1::1, priority: 0, hash mask length: 126
+          Candidate BSR address: 2001:1:1:a::1, priority: 0, hash mask length: 126
     

--- a/src/genie/libs/parser/ios/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_expected.py
+++ b/src/genie/libs/parser/ios/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_expected.py
@@ -5,8 +5,8 @@ expected_output = {
             "address_family": {
                 "ipv6": {
                     "routes": {
-                        "2001:1:1:1::1/128": {
-                            "route": "2001:1:1:1::1/128",
+                        "2001:1:1:a::1/128": {
+                            "route": "2001:1:1:a::1/128",
                             "active": True,
                             "source_protocol_codes": "LC",
                             "source_protocol": "local",

--- a/src/genie/libs/parser/ios/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_output.txt
+++ b/src/genie/libs/parser/ios/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_output.txt
@@ -9,7 +9,7 @@ Codes: C - Connected, L - Local, S - Static, U - Per-user Static route
        O - OSPF Intra, OI - OSPF Inter, OE1 - OSPF ext 1, OE2 - OSPF ext 2
        ON1 - OSPF NSSA ext 1, ON2 - OSPF NSSA ext 2, la - LISP alt
        lr - LISP site-registrations, ld - LISP dyn-eid, a - Application
-LC  2001:1:1:1::1/128 [0/0]
+LC  2001:1:1:a::1/128 [0/0]
      via Loopback0, receive
       Last updated 22:55:51 04 December 2017
 S   2001:2:2:2::2/128 [1/0]

--- a/src/genie/libs/parser/iosxe/show_pim.py
+++ b/src/genie/libs/parser/iosxe/show_pim.py
@@ -242,7 +242,7 @@ class ShowIpv6PimBsrElection(ShowIpv6PimBsrElectionSchema):
                     ['rp']['bsr']['bsr']['scope_range_list'] = scope_range_list
                 continue
 
-            # BSR Address: 2001:1:1:1::1
+            # BSR Address: 2001:1:1:a::1
             p2 = re.compile(r'^\s*BSR +Address: +(?P<bsr_address>[\w\:\.]+)$')
             m = p2.match(line)
             if m:
@@ -290,7 +290,7 @@ class ShowIpv6PimBsrElection(ShowIpv6PimBsrElectionSchema):
                     ['bsr']['expires'] = bs_timer
                 continue
 
-            # Candidate BSR address: 2001:1:1:1::1, priority: 0, hash mask length: 126
+            # Candidate BSR address: 2001:1:1:a::1, priority: 0, hash mask length: 126
             p6 = re.compile(r'^\s*Candidate +BSR +address: +(?P<can_address>[\w\d\:\.]+),'
                             ' +priority: +(?P<can_priority>\d+),'
                             ' +hash +mask +length: +(?P<can_hash_mask_lenght>\d+)$')

--- a/src/genie/libs/parser/iosxe/show_routing.py
+++ b/src/genie/libs/parser/iosxe/show_routing.py
@@ -764,7 +764,7 @@ class ShowIpv6RouteUpdated(ShowIpv6RouteUpdatedSchema):
                 vrf = m.groupdict()['vrf']
                 continue
 
-            # LC  2001:1:1:1::1/128 [0/0]
+            # LC  2001:1:1:a::1/128 [0/0]
             p2 = re.compile(r'^\s*(?P<code>[\w]+) +(?P<route>[\w\/\:]+)?'
                             ' +\[(?P<route_preference>[\d\/]+)\]$')
             m = p2.match(line)

--- a/src/genie/libs/parser/iosxe/tests/ShowBgpAllDetail/cli/equal/golden_output1_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowBgpAllDetail/cli/equal/golden_output1_expected.py
@@ -155,7 +155,7 @@ expected_output = {
                         },
                         "ipv6 unicast": {
                             "prefixes": {
-                                "2001:1:1:1::1/128": {
+                                "2001:1:1:a::1/128": {
                                     "available_path": "1",
                                     "best_path": "1",
                                     "index": {

--- a/src/genie/libs/parser/iosxe/tests/ShowBgpAllDetail/cli/equal/golden_output1_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowBgpAllDetail/cli/equal/golden_output1_output.txt
@@ -36,7 +36,7 @@
 
         For address family: IPv6 Unicast
 
-        BGP routing table entry for 2001:1:1:1::1/128, version 4
+        BGP routing table entry for 2001:1:1:a::1/128, version 4
         Paths: (1 available, best #1, table default)
         Advertised to update-groups:
            1         

--- a/src/genie/libs/parser/iosxe/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_expected.py
@@ -6,12 +6,12 @@ expected_output = {
                     "rp": {
                         "bsr": {
                             "bsr_candidate": {
-                                "address": "2001:1:1:1::1",
+                                "address": "2001:1:1:a::1",
                                 "priority": 0,
                                 "hash_mask_length": 126,
                             },
                             "bsr": {
-                                "address": "2001:1:1:1::1",
+                                "address": "2001:1:1:a::1",
                                 "hash_mask_length": 126,
                                 "priority": 0,
                                 "up_time": "00:00:07",

--- a/src/genie/libs/parser/iosxe/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpv6PimBsrElection/cli/equal/golden_output_bsr_elec_2_output.txt
@@ -5,10 +5,10 @@ R1_xe#show ipv6 pim bsr election
     BSR Election Information
       Scope Range List: ff00::/8
       This system is the Bootstrap Router (BSR)
-         BSR Address: 2001:1:1:1::1
+         BSR Address: 2001:1:1:a::1
          Uptime: 00:00:07, BSR Priority: 0, Hash mask length: 126
          RPF: FE80::21E:F6FF:FE2D:3600,Loopback0
          BS Timer: 00:00:52
       This system is candidate BSR
-          Candidate BSR address: 2001:1:1:1::1, priority: 0, hash mask length: 126
+          Candidate BSR address: 2001:1:1:a::1, priority: 0, hash mask length: 126
     

--- a/src/genie/libs/parser/iosxe/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_expected.py
@@ -5,8 +5,8 @@ expected_output = {
             "address_family": {
                 "ipv6": {
                     "routes": {
-                        "2001:1:1:1::1/128": {
-                            "route": "2001:1:1:1::1/128",
+                        "2001:1:1:a::1/128": {
+                            "route": "2001:1:1:a::1/128",
                             "active": True,
                             "source_protocol_codes": "LC",
                             "source_protocol": "local",

--- a/src/genie/libs/parser/iosxe/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpv6RouteUpdated/cli/equal/golden_output_1_output.txt
@@ -9,7 +9,7 @@ Codes: C - Connected, L - Local, S - Static, U - Per-user Static route
        O - OSPF Intra, OI - OSPF Inter, OE1 - OSPF ext 1, OE2 - OSPF ext 2
        ON1 - OSPF NSSA ext 1, ON2 - OSPF NSSA ext 2, la - LISP alt
        lr - LISP site-registrations, ld - LISP dyn-eid, a - Application
-LC  2001:1:1:1::1/128 [0/0]
+LC  2001:1:1:a::1/128 [0/0]
      via Loopback0, receive
       Last updated 22:55:51 04 December 2017
 S   2001:2:2:2::2/128 [1/0]

--- a/src/genie/libs/parser/iosxe/tests/test_show_bgp.py
+++ b/src/genie/libs/parser/iosxe/tests/test_show_bgp.py
@@ -509,7 +509,7 @@ class TestShowIpBgpAllSummary(unittest.TestCase):
             [2019-06-05 09:47:19,474] +++ R1_xe: executing command 'show run | sec address-family ipv6 vrf' +++
             show run | sec address-family ipv6 vrf
              address-family ipv6 vrf VRF1
-              network 2001:1:1:1::1/128
+              network 2001:1:1:a::1/128
               neighbor 2001:2:2:2::2 remote-as 65000
               neighbor 2001:2:2:2::2 update-source Loopback300
               neighbor 2001:2:2:2::2 activate

--- a/src/genie/libs/parser/iosxr/show_bgp.py
+++ b/src/genie/libs/parser/iosxr/show_bgp.py
@@ -5419,7 +5419,7 @@ class ShowBgpSessions(ShowBgpSessionsSchema):
         instance = 'default'
 
         # 10.36.3.3         default                 0 65000     0     0  Established  None
-        # 2001:1:1:1::1   default                 0 65000     0     0  Established  None
+        # 2001:1:1:a::1   default                 0 65000     0     0  Established  None
         # 10.1.7.212     default                 0 10396     0     0  Established  NSR Ready
         p1 = re.compile(r'^(?P<neighbor>\S+) +(?P<vrf>\S+) +(?P<spk>\d+) +'
             '(?P<as_number>\d+) +(?P<in_q>\d+) +(?P<out_q>\d+) +'
@@ -5440,7 +5440,7 @@ class ShowBgpSessions(ShowBgpSessionsSchema):
             line = line.strip()
 
             # 10.36.3.3         default                 0 65000     0     0  Established  None
-            # 2001:1:1:1::1   default                 0 65000     0     0  Established  None
+            # 2001:1:1:a::1   default                 0 65000     0     0  Established  None
             # 10.1.7.212     default                 0 10396     0     0  Established  NSR Ready
             m = p1.match(line)
             if m:

--- a/src/genie/libs/parser/iosxr/show_routing.py
+++ b/src/genie/libs/parser/iosxr/show_routing.py
@@ -1093,7 +1093,7 @@ class ShowRouteIpv6(ShowRouteIpv4Schema):
         # VRF: L:123
         p1 = re.compile(r'^\s*VRF: +(?P<vrf>\S+)$')
 
-        # S    2001:1:1:1::1/128
+        # S    2001:1:1:a::1/128
         # L    2001:2:2:2::2/128 is directly connected,
         # i L2 2001:0:10:204:0:33::/126
         # i L1 2001:21:21:21::21/128
@@ -1112,9 +1112,9 @@ class ShowRouteIpv6(ShowRouteIpv4Schema):
         # 01:52:24, Loopback0
         p5 = re.compile(r'^(?P<date>[\w+:]+), +(?P<interface>\S+)$')
 
-        # Routing entry for 2001:1:1:1::1/128, 1 known subnets
-        # Routing entry for 2001:1:1:1::1/128, supernet
-        # Routing entry for 2001:1:1:1::1/128
+        # Routing entry for 2001:1:1:a::1/128, 1 known subnets
+        # Routing entry for 2001:1:1:a::1/128, supernet
+        # Routing entry for 2001:1:1:a::1/128
         p6 = re.compile(r'^Routing +entry +for +(?P<network>(?P<ip>[\w\:\.]+)'
                         r'\/(?P<mask>\d+))(?:, +(?P<net>[\w\s]+))?$')
         
@@ -1179,7 +1179,7 @@ class ShowRouteIpv6(ShowRouteIpv4Schema):
                 vrf = m.groupdict()['vrf']
                 continue
 
-            # S    2001:1:1:1::1/128
+            # S    2001:1:1:a::1/128
             # L    2001:2:2:2::2/128 is directly connected,
             # i L2 2001:0:10:204:0:33::/126
             # i L1 2001:21:21:21::21/128
@@ -1252,9 +1252,9 @@ class ShowRouteIpv6(ShowRouteIpv4Schema):
                 outgoing_interface_dict.update({'updated': updated})
                 continue
             
-            # Routing entry for 2001:1:1:1::1/128, 1 known subnets
-            # Routing entry for 2001:1:1:1::1/128, supernet
-            # Routing entry for 2001:1:1:1::1/128
+            # Routing entry for 2001:1:1:a::1/128, 1 known subnets
+            # Routing entry for 2001:1:1:a::1/128, supernet
+            # Routing entry for 2001:1:1:a::1/128
             m = p6.match(line)
             if m:
                 group = m.groupdict()

--- a/src/genie/libs/parser/iosxr/show_static_routing.py
+++ b/src/genie/libs/parser/iosxr/show_static_routing.py
@@ -122,12 +122,13 @@ class ShowStaticTopologyDetail(ShowStaticTopologyDetailSchema):
                         ' +SAFI: +(?P<safi>[\w]+)$')
 
         # Prefix/Len          Interface                Nexthop             Object              Explicit-path       Metrics
-        # 2001:1:1:1::1/128   GigabitEthernet0_0_0_3   2001:10:1:2::1      None                None                [0/0/1/0/1]
+        # 2001:1:1:a::1/128   GigabitEthernet0_0_0_3   2001:10:1:2::1      None                None                [0/0/1/0/1]
         #             GigabitEthernet0_0_0_0   None                None                None                [0/4096/1/0/1]
         # Prefix/Len          Interface                Nexthop             Object         Explicit-path       Metrics          Local-Label
         # 172.16.0.89/32      TenGigE0_0_1_2           None                None          None                [0/4096/1/0/1]    No label    Path is configured at Sep 11 08:29:25.605
         # 10.00.00.0/00       Bundle-Ether2.25         10.01.02.03         None                None                [0/0/1/0/1]
-        p2 = re.compile(r'^(?P<route>[\d\s\/\.\:]+)?(?P<interface>[a-zA-Z][\w\/\.-]+) '
+        p2 = re.compile(r'^(?P<route>[a-fA-F\d\/\.\:]+)? '
+                        r'*(?P<interface>[a-zA-Z][\w\/\.-]+) '
                         r'+(?P<nexthop>[\w\/\.\:]+) +(?P<object>[\w]+) '
                         r'+(?P<explicit_path>[\w]+) +(?P<metrics>[\w\/\[\]]+)'
                         r'(\s+(?P<local_label>[\w\s]+?))?'

--- a/src/genie/libs/parser/iosxr/tests/ShowStaticTopologyDetail/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowStaticTopologyDetail/cli/equal/golden_output_2_expected.py
@@ -7,8 +7,8 @@ expected_output = {
                     'safi': 'unicast',
                     'table_id': '0xe0800000',
                     'routes': {
-                        '2001:1:1:1::1/128': {
-                            'route': '2001:1:1:1::1/128',
+                        '2001:1:1:a::1/128': {
+                            'route': '2001:1:1:a::1/128',
                             'next_hop': {
                                 'next_hop_list': {
                                     1: {
@@ -89,8 +89,8 @@ expected_output = {
                     'safi': 'unicast',
                     'table_id': '0xe0800010',
                     'routes': {
-                        '2001:1:1:1::1/128': {
-                            'route': '2001:1:1:1::1/128',
+                        '2001:1:1:a::1/128': {
+                            'route': '2001:1:1:a::1/128',
                             'next_hop': {
                                 'outgoing_interface': {
                                     'Null0': {

--- a/src/genie/libs/parser/iosxr/tests/ShowStaticTopologyDetail/cli/equal/golden_output_2_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowStaticTopologyDetail/cli/equal/golden_output_2_output.txt
@@ -6,7 +6,7 @@ Thu Dec  7 22:10:18.618 UTC
 VRF: default Table Id: 0xe0800000 AFI: IPv6 SAFI: Unicast
 Last path event occured at Dec  7 21:52:00.843
 Prefix/Len          Interface                Nexthop             Object              Explicit-path       Metrics
-2001:1:1:1::1/128   GigabitEthernet0_0_0_3   2001:10:1:2::1      None                None                [0/0/1/0/1]
+2001:1:1:a::1/128   GigabitEthernet0_0_0_3   2001:10:1:2::1      None                None                [0/0/1/0/1]
 Path is installed into RIB at Dec  7 21:52:00.843
 Path version: 1, Path status: 0xa1
 Path has best tag: 0
@@ -35,7 +35,7 @@ Path version: 0, Path status: 0x0
 VRF: VRF1 Table Id: 0xe0800010 AFI: IPv6 SAFI: Unicast
 Last path event occured at Dec  7 21:51:47.424
 Prefix/Len          Interface                Nexthop             Object              Explicit-path       Metrics
-2001:1:1:1::1/128   Null0                    None                None                None                [0/4096/99/0/1234]
+2001:1:1:a::1/128   Null0                    None                None                None                [0/4096/99/0/1234]
 Path is installed into RIB at Dec  7 21:51:47.424
 Path version: 1, Path status: 0x21
 Path has best tag: 0

--- a/src/genie/libs/parser/iosxr/tests/__test_show_bgp.py
+++ b/src/genie/libs/parser/iosxr/tests/__test_show_bgp.py
@@ -29710,7 +29710,7 @@ class TestShowBgpSessions(unittest.TestCase):
                                 "nbr_state": "Established",
                                 "nsr_state": "None",
                             },
-                            "2001:1:1:1::1": {
+                            "2001:1:1:a::1": {
                                 "spk": 0,
                                 "as_number": 65000,
                                 "in_q": 0,
@@ -29746,7 +29746,7 @@ class TestShowBgpSessions(unittest.TestCase):
                                 "nbr_state": "Established",
                                 "nsr_state": "None",
                             },
-                            "2001:1:1:1::1": {
+                            "2001:1:1:a::1": {
                                 "spk": 0,
                                 "as_number": 65000,
                                 "in_q": 0,
@@ -29777,11 +29777,11 @@ class TestShowBgpSessions(unittest.TestCase):
         Neighbor        VRF                   Spk    AS   InQ  OutQ  NBRState     NSRState
         10.4.1.1         default                 0 65000     0     0  Established  None
         10.36.3.3         default                 0 65000     0     0  Established  None
-        2001:1:1:1::1   default                 0 65000     0     0  Established  None
+        2001:1:1:a::1   default                 0 65000     0     0  Established  None
         2001:3:3:3::3   default                 0 65000     0     0  Established  None
         10.4.1.1         VRF1                    0 65000     0     0  Established  None
         10.36.3.3         VRF1                    0 65000     0     0  Established  None
-        2001:1:1:1::1   VRF1                    0 65000     0     0  Established  None
+        2001:1:1:a::1   VRF1                    0 65000     0     0  Established  None
         2001:3:3:3::3   VRF1                    0 65000     0     0  Established  None
         """
     }
@@ -29918,7 +29918,7 @@ class TestShowBgpInstanceAllSessions(unittest.TestCase):
                                 "nbr_state": "Established",
                                 "nsr_state": "None",
                             },
-                            "2001:1:1:1::1": {
+                            "2001:1:1:a::1": {
                                 "spk": 0,
                                 "as_number": 65000,
                                 "in_q": 0,
@@ -29954,7 +29954,7 @@ class TestShowBgpInstanceAllSessions(unittest.TestCase):
                                 "nbr_state": "Established",
                                 "nsr_state": "None",
                             },
-                            "2001:1:1:1::1": {
+                            "2001:1:1:a::1": {
                                 "spk": 0,
                                 "as_number": 65000,
                                 "in_q": 0,
@@ -29988,11 +29988,11 @@ class TestShowBgpInstanceAllSessions(unittest.TestCase):
         Neighbor        VRF                   Spk    AS   InQ  OutQ  NBRState     NSRState
         10.4.1.1         default                 0 65000     0     0  Established  None
         10.36.3.3         default                 0 65000     0     0  Established  None
-        2001:1:1:1::1   default                 0 65000     0     0  Established  None
+        2001:1:1:a::1   default                 0 65000     0     0  Established  None
         2001:3:3:3::3   default                 0 65000     0     0  Established  None
         10.4.1.1         VRF1                    0 65000     0     0  Established  None
         10.36.3.3         VRF1                    0 65000     0     0  Established  None
-        2001:1:1:1::1   VRF1                    0 65000     0     0  Established  None
+        2001:1:1:a::1   VRF1                    0 65000     0     0  Established  None
         2001:3:3:3::3   VRF1                    0 65000     0     0  Established  None
         """
     }

--- a/src/genie/libs/parser/iosxr/tests/test_show_mpls.py
+++ b/src/genie/libs/parser/iosxr/tests/test_show_mpls.py
@@ -1622,7 +1622,7 @@ class TestShowMplsForwarding(unittest.TestCase):
                 "outgoing_label": {
                     "Unlabelled": {
                         "prefix_or_id": {
-                            "2001:1:1:1::1/128[V]": {
+                            "2001:1:1:a::1/128[V]": {
                                 "outgoing_interface": {
                                     "GigabitEthernet0/0/0/0.390": {
                                         "next_hop": "fe80::f816:3eff:fe53:2cc7",
@@ -1762,7 +1762,7 @@ class TestShowMplsForwarding(unittest.TestCase):
         24003  Unlabelled  10.13.115.0/24     Gi0/0/0/0.115 10.12.115.1     0
         24004  Unlabelled  10.13.90.0/24      Gi0/0/0/0.90 10.12.90.1      0
             Unlabelled  10.13.90.0/24      Gi0/0/0/1.90 10.23.90.3      0
-        24005  Unlabelled  2001:1:1:1::1/128[V]   \
+        24005  Unlabelled  2001:1:1:a::1/128[V]   \
                                             Gi0/0/0/0.390 fe80::f816:3eff:fe53:2cc7   \
                                                                         3928399
         24006  Aggregate   VRF1: Per-VRF Aggr[V]   \
@@ -1816,7 +1816,7 @@ class TestShowMplsForwardingVrf(unittest.TestCase):
                         "outgoing_label": {
                             "Unlabelled": {
                                 "prefix_or_id": {
-                                    "2001:1:1:1::1/128[V]": {
+                                    "2001:1:1:a::1/128[V]": {
                                         "outgoing_interface": {
                                             "GigabitEthernet0/0/0/0.390": {
                                                 "next_hop": "fe80::f816:3eff:fe53:2cc7",
@@ -1917,7 +1917,7 @@ class TestShowMplsForwardingVrf(unittest.TestCase):
         Local  Outgoing    Prefix             Outgoing     Next Hop        Bytes
         Label  Label       or ID              Interface                    Switched
         ------ ----------- ------------------ ------------ --------------- ------------
-        24005  Unlabelled  2001:1:1:1::1/128[V]   \
+        24005  Unlabelled  2001:1:1:a::1/128[V]   \
                                               Gi0/0/0/0.390 fe80::f816:3eff:fe53:2cc7   \
                                                                           4102415
         24006  Aggregate   VRF1: Per-VRF Aggr[V]   \

--- a/src/genie/libs/parser/iosxr/tests/test_show_routing.py
+++ b/src/genie/libs/parser/iosxr/tests/test_show_routing.py
@@ -37,7 +37,7 @@ class TestShowRouteIpv6(unittest.TestCase):
 
         Gateway of last resort is not set
 
-        S    2001:1:1:1::1/128
+        S    2001:1:1:a::1/128
             [1/0] via 2001:20:1:2::1, 01:52:23, GigabitEthernet0/0/0/0
             [1/0] via 2001:10:1:2::1, 01:52:23, GigabitEthernet0/0/0/3
         L    2001:2:2:2::2/128 is directly connected,
@@ -61,8 +61,8 @@ class TestShowRouteIpv6(unittest.TestCase):
                 'address_family': {
                     'ipv6': {
                         'routes': {
-                            '2001:1:1:1::1/128': {
-                                'route': '2001:1:1:1::1/128',
+                            '2001:1:1:a::1/128': {
+                                'route': '2001:1:1:a::1/128',
                                 'active': True,
                                 'source_protocol_codes': 'S',
                                 'source_protocol': 'static',
@@ -571,7 +571,7 @@ class TestShowRouteIpv6(unittest.TestCase):
 
         Gateway of last resort is not set
 
-        D    2001:1:1:1::1/128
+        D    2001:1:1:a::1/128
             [90/10880] via fe80::f816:3eff:fe76:b56d, 5d23h, GigabitEthernet0/0/0/0.390
         L    2001:2:2:2::2/128 is directly connected,
             3w4d, Loopback300
@@ -625,8 +625,8 @@ class TestShowRouteIpv6(unittest.TestCase):
                 'address_family': {
                     'ipv6': {
                         'routes': {
-                            '2001:1:1:1::1/128': {
-                                'route': '2001:1:1:1::1/128',
+                            '2001:1:1:a::1/128': {
+                                'route': '2001:1:1:a::1/128',
                                 'active': True,
                                 'source_protocol_codes': 'D',
                                 'source_protocol': 'eigrp',
@@ -1192,10 +1192,10 @@ class TestShowRouteIpv6(unittest.TestCase):
     }
 
     golden_output_7 = {'execute.return_value': '''
-        show route vrf VRF1 ipv6 2001:1:1:1::1
+        show route vrf VRF1 ipv6 2001:1:1:a::1
         Tue Oct 29 19:31:30.848 UTC
 
-        Routing entry for 2001:1:1:1::1/128
+        Routing entry for 2001:1:1:a::1/128
         Known via "eigrp 100", distance 90, metric 10880, type internal
         Installed Oct 23 22:09:38.380 for 5d21h
         Routing Descriptor Blocks
@@ -1210,14 +1210,14 @@ class TestShowRouteIpv6(unittest.TestCase):
                 "address_family": {
                     "ipv6": {
                         "routes": {
-                            "2001:1:1:1::1/128": {
+                            "2001:1:1:a::1/128": {
                                 "active": True,
                                 "distance": 90,
                                 "installed": {
                                     "date": "Oct 23 22:09:38.380",
                                     "for": "5d21h"
                                 },
-                                "ip": "2001:1:1:1::1",
+                                "ip": "2001:1:1:a::1",
                                 "known_via": "eigrp 100",
                                 "mask": "128",
                                 "metric": 10880,
@@ -1232,7 +1232,7 @@ class TestShowRouteIpv6(unittest.TestCase):
                                         }
                                     }
                                 },
-                                "route": "2001:1:1:1::1/128",
+                                "route": "2001:1:1:a::1/128",
                                 "type": "internal"
                             }
                         }
@@ -2139,7 +2139,7 @@ class TestShowRouteIpv6(unittest.TestCase):
         self.maxDiff = None
         self.device = Mock(**self.golden_output_7)
         obj = ShowRouteIpv6(device=self.device)
-        parsed_output = obj.parse(vrf='VRF1', route='2001:1:1:1::1')
+        parsed_output = obj.parse(vrf='VRF1', route='2001:1:1:a::1')
         self.assertEqual(parsed_output, self.golden_parsed_output_7)
 
     def test_show_route_ipv6_3(self):

--- a/src/genie/libs/parser/nxos/show_static_routing.py
+++ b/src/genie/libs/parser/nxos/show_static_routing.py
@@ -306,9 +306,9 @@ class ShowIpv6StaticRoute(ShowIpv6StaticRouteSchema):
                         result_dict['vrf'][vrf]['address_family'][af] = {}
                 continue
 
-            # 2001:1:1:1::1/128 -> 2001:10:1:3::1/128, preference: 1
-            # 2001:1:1:1::1/128 -> Null0, preference: 1
-            p2 = re.compile(r'^\s*(?P<route>[\d\/\:]+)( +\-\> +(?P<nexthop>[\d\:\/]+), )?'
+            # 2001:1:1:a::1/128 -> 2001:10:1:3::1/128, preference: 1
+            # 2001:1:1:a::1/128 -> Null0, preference: 1
+            p2 = re.compile(r'^\s*(?P<route>[a-fA-F\d\:\/]+)( +\-\> +(?P<nexthop>[a-fA-F\d\:\/]+), )?'
                             '( \-\> +(?P<interface>[\w\.\/]+), )?'
                             '(preference: +(?P<preference>[\d]+))?$')
             m = p2.match(line)
@@ -411,7 +411,7 @@ class ShowIpv6StaticRoute(ShowIpv6StaticRouteSchema):
                 continue
 
             # real-next-hop: 2001:10:2:3::2, interface: Ethernet1/4
-            p4 = re.compile(r'^\s*real-next-hop: +(?P<real_next_hop>[\d\:]+)'
+            p4 = re.compile(r'^\s*real-next-hop: +(?P<real_next_hop>[a-fA-F\d\:]+)'
                             '(, +interface: +(?P<interface2>[\w\/\.]+))?$')
             m = p4.match(line)
             if m:

--- a/src/genie/libs/parser/nxos/tests/test_show_rip.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_rip.py
@@ -1596,7 +1596,7 @@ class test_show_ipv6_rip_route_vrf_all(unittest.TestCase):
                                             },
                                         'next_hops': 0,
                                         },
-                                    '2001:1:1:1::1/128': {
+                                    '2001:1:1:a::1/128': {
                                         'best_route': False,
                                         'index': {
                                             1: {
@@ -1639,7 +1639,7 @@ class test_show_ipv6_rip_route_vrf_all(unittest.TestCase):
         
         > - indicates best RIP route
         
-         2001:1:1:1::1/128 next-hops 1
+         2001:1:1:a::1/128 next-hops 1
          via fe80::f816:3eff:fe8f:fbd9 Ethernet1/2.120, metric 2, tag 0, timeout 00:02:58
         
         >2001:3:3:3::3/128 next-hops 0

--- a/src/genie/libs/parser/nxos/tests/test_show_routing.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_routing.py
@@ -3303,7 +3303,7 @@ class test_show_ipv6_route(unittest.TestCase):
         '**' denotes best mcast next-hop
         '[x/y]' denotes [preference/metric]
 
-        2001:1:1:1::1/128, ubest/mbest: 2/0
+        2001:1:1:a::1/128, ubest/mbest: 2/0
             *via 2001:10:1:3::1, Eth1/2, [1/0], 01:02:00, static
             *via 2001:20:1:3::1, Eth1/3, [1/0], 01:02:00, static
         2001:10:1:2::/64, ubest/mbest: 4/0
@@ -3329,9 +3329,9 @@ class test_show_ipv6_route(unittest.TestCase):
         '**' denotes best mcast next-hop
         '[x/y]' denotes [preference/metric]
 
-        2001:1:1:1::1/128, ubest/mbest: 2/0, attached
-            *via 2001:1:1:1::1, Lo4, [0/0], 00:00:35, direct,
-            *via 2001:1:1:1::1, Lo4, [0/0], 00:00:35, local
+        2001:1:1:a::1/128, ubest/mbest: 2/0, attached
+            *via 2001:1:1:a::1, Lo4, [0/0], 00:00:35, direct,
+            *via 2001:1:1:a::1, Lo4, [0/0], 00:00:35, local
 
         IPv6 Routing Table for VRF "management"
         '*' denotes best ucast next-hop
@@ -3345,7 +3345,7 @@ class test_show_ipv6_route(unittest.TestCase):
             'address_family': {
                 'ipv6': {
                     'routes': {
-                        '2001:1:1:1::1/128': {
+                        '2001:1:1:a::1/128': {
                             'active': True,
                             'attached': True,
                             'mbest': 0,
@@ -3356,7 +3356,7 @@ class test_show_ipv6_route(unittest.TestCase):
                                         'best_ucast_nexthop': True,
                                         'index': 1,
                                         'metric': 0,
-                                        'next_hop': '2001:1:1:1::1',
+                                        'next_hop': '2001:1:1:a::1',
                                         'outgoing_interface': 'Loopback4',
                                         'route_preference': 0,
                                         'source_protocol': 'direct',
@@ -3366,7 +3366,7 @@ class test_show_ipv6_route(unittest.TestCase):
                                         'best_ucast_nexthop': True,
                                         'index': 2,
                                         'metric': 0,
-                                        'next_hop': '2001:1:1:1::1',
+                                        'next_hop': '2001:1:1:a::1',
                                         'outgoing_interface': 'Loopback4',
                                         'route_preference': 0,
                                         'source_protocol': 'local',
@@ -3374,7 +3374,7 @@ class test_show_ipv6_route(unittest.TestCase):
                                     },
                                 },
                             },
-                            'route': '2001:1:1:1::1/128',
+                            'route': '2001:1:1:a::1/128',
                             'route_preference': 0,
                             'source_protocol': 'local',
                             'ubest': 2,
@@ -3446,7 +3446,7 @@ class test_show_ipv6_route(unittest.TestCase):
                             'source_protocol_status': 'intra',
                             'ubest': 4,
                         },
-                        '2001:1:1:1::1/128': {
+                        '2001:1:1:a::1/128': {
                             'active': True,
                             'mbest': 0,
                             'metric': 0,
@@ -3474,7 +3474,7 @@ class test_show_ipv6_route(unittest.TestCase):
                                     },
                                 },
                             },
-                            'route': '2001:1:1:1::1/128',
+                            'route': '2001:1:1:a::1/128',
                             'route_preference': 1,
                             'source_protocol': 'static',
                             'ubest': 2,
@@ -3601,7 +3601,7 @@ class test_show_ipv6_route(unittest.TestCase):
         '**' denotes best mcast next-hop
         '[x/y]' denotes [preference/metric]
 
-        2001:1:1:1::1/128, ubest/mbest: 1/0
+        2001:1:1:a::1/128, ubest/mbest: 1/0
             *via fe80::f816:3eff:fef8:e824, Eth1/2.90, [90/2848], 03:55:29, eigrp-test, internal
         2001:2:2:2::2/128, ubest/mbest: 1/0
             *via fe80::f816:3eff:fe80:67f4, Eth1/1.90, [90/2842], 03:51:46, eigrp-test, internal
@@ -3627,7 +3627,7 @@ class test_show_ipv6_route(unittest.TestCase):
         '**' denotes best mcast next-hop
         '[x/y]' denotes [preference/metric]
 
-        2001:1:1:1::1/128, ubest/mbest: 1/0
+        2001:1:1:a::1/128, ubest/mbest: 1/0
             *via fe80::f816:3eff:fef8:e824, Eth1/2.390, [90/2848], 03:55:29, eigrp-test, internal
         2001:2:2:2::2/128, ubest/mbest: 1/0
             *via fe80::f816:3eff:fe80:67f4, Eth1/1.390, [90/2842], 03:51:47, eigrp-test, internal
@@ -3796,7 +3796,7 @@ class test_show_ipv6_route(unittest.TestCase):
                             'source_protocol': 'direct',
                             'ubest': 1,
                         },
-                        '2001:1:1:1::1/128': {
+                        '2001:1:1:a::1/128': {
                             'active': True,
                             'mbest': 0,
                             'metric': 2848,
@@ -3816,7 +3816,7 @@ class test_show_ipv6_route(unittest.TestCase):
                                 },
                             },
                             'process_id': 'test',
-                            'route': '2001:1:1:1::1/128',
+                            'route': '2001:1:1:a::1/128',
                             'route_preference': 90,
                             'source_protocol': 'eigrp',
                             'source_protocol_status': 'internal',
@@ -4049,7 +4049,7 @@ class test_show_ipv6_route(unittest.TestCase):
                             'source_protocol': 'local',
                             'ubest': 1,
                         },
-                        '2001:1:1:1::1/128': {
+                        '2001:1:1:a::1/128': {
                             'active': True,
                             'mbest': 0,
                             'metric': 2848,
@@ -4069,7 +4069,7 @@ class test_show_ipv6_route(unittest.TestCase):
                                 },
                             },
                             'process_id': 'test',
-                            'route': '2001:1:1:1::1/128',
+                            'route': '2001:1:1:a::1/128',
                             'route_preference': 90,
                             'source_protocol': 'eigrp',
                             'source_protocol_status': 'internal',
@@ -4153,8 +4153,8 @@ class test_show_ipv6_route(unittest.TestCase):
                 'address_family': {
                     'ipv6': {
                         'routes': {
-                            '2001:1:1:1::1/128': {
-                                'route': '2001:1:1:1::1/128',
+                            '2001:1:1:a::1/128': {
+                                'route': '2001:1:1:a::1/128',
                                 'active': True,
                                 'ubest': 1,
                                 'mbest': 0,
@@ -4214,7 +4214,7 @@ class test_show_ipv6_route(unittest.TestCase):
         '**' denotes best mcast next-hop
         '[x/y]' denotes [preference/metric]
 
-        2001:1:1:1::1/128, ubest/mbest: 1/0
+        2001:1:1:a::1/128, ubest/mbest: 1/0
             *via fe80::f816:3eff:feb2:c76f, Eth1/2.390, [90/2848], 2w0d, eigrp-test, internal
             via fe80::f816:3eff:feb2:c76f, Eth1/2.420, [120/2], 2w0d, rip-1, rip
             via fe80::f816:3eff:feb2:c76f, Eth1/2.390, [200/0], 2w0d, bgp-65000, internal, tag 65000 (hidden)

--- a/src/genie/libs/parser/nxos/tests/test_show_static_routing.py
+++ b/src/genie/libs/parser/nxos/tests/test_show_static_routing.py
@@ -259,12 +259,12 @@ class test_show_ipv6_static_route(unittest.TestCase):
     R3_nxosv# show ipv6 static-route
     IPv6 Configured Static Routes for VRF "default"(1)
 
-    2001:1:1:1::1/128 -> 2001:10:1:3::1/128, preference: 1
+    2001:1:1:a::1/128 -> 2001:10:1:3::1/128, preference: 1
       nh_vrf(default) reslv_tid 0
       real-next-hop: 2001:10:1:3::1, interface: Ethernet1/2
         rnh(not installed in u6rib)
         bfd_enabled no
-    2001:1:1:1::1/128 -> 2001:20:1:3::1/128, preference: 1
+    2001:1:1:a::1/128 -> 2001:20:1:3::1/128, preference: 1
       nh_vrf(default) reslv_tid 0
       real-next-hop: 2001:20:1:3::1, interface: Ethernet1/3
         rnh(not installed in u6rib)
@@ -288,8 +288,8 @@ class test_show_ipv6_static_route(unittest.TestCase):
                 'address_family': {
                     'ipv6': {
                         'routes': {
-                            '2001:1:1:1::1/128': {
-                                'route': '2001:1:1:1::1/128',
+                            '2001:1:1:a::1/128': {
+                                'route': '2001:1:1:a::1/128',
                                 'next_hop': {
                                     'next_hop_list': {
                                          1: {
@@ -357,12 +357,12 @@ class test_show_ipv6_static_route(unittest.TestCase):
     R3_nxosv# show ipv6 static-route vrf all
     IPv6 Configured Static Routes for VRF "default"(1)
 
-    2001:1:1:1::1/128 -> 2001:10:1:3::1/128, preference: 1
+    2001:1:1:a::1/128 -> 2001:10:1:3::1/128, preference: 1
       nh_vrf(default) reslv_tid 0
       real-next-hop: 2001:10:1:3::1, interface: Ethernet1/2
         rnh(not installed in u6rib)
         bfd_enabled no
-    2001:1:1:1::1/128 -> 2001:20:1:3::1/128, preference: 1
+    2001:1:1:a::1/128 -> 2001:20:1:3::1/128, preference: 1
       nh_vrf(default) reslv_tid 0
       real-next-hop: 2001:20:1:3::1, interface: Ethernet1/3
         rnh(not installed in u6rib)
@@ -383,7 +383,7 @@ class test_show_ipv6_static_route(unittest.TestCase):
 
     IPv6 Configured Static Routes for VRF "VRF1"(3)
 
-    2001:1:1:1::1/128 -> Null0, preference: 1
+    2001:1:1:a::1/128 -> Null0, preference: 1
       nh_vrf(VRF1) reslv_tid 80000003
       real-next-hop: 0::, interface: Null0
         rnh(not installed in u6rib)
@@ -393,12 +393,12 @@ class test_show_ipv6_static_route(unittest.TestCase):
       real-next-hop: 0::, interface: Null0
         rnh(not installed in u6rib)
         bfd_enabled no
-    2001:1:1:1::1/128 -> 2001:10:1:3::1/128, preference: 1
+    2001:1:1:a::1/128 -> 2001:10:1:3::1/128, preference: 1
       nh_vrf(VRF1) reslv_tid 0
       real-next-hop: 2001:10:1:3::1, interface: none
         rnh(not installed in u6rib)
         bfd_enabled no
-    2001:1:1:1::1/128 -> 2001:20:1:3::1/128, preference: 1
+    2001:1:1:a::1/128 -> 2001:20:1:3::1/128, preference: 1
       nh_vrf(VRF1) reslv_tid 0
       real-next-hop: 2001:20:1:3::1, interface: none
         rnh(not installed in u6rib)
@@ -433,8 +433,8 @@ class test_show_ipv6_static_route(unittest.TestCase):
                 'address_family': {
                     'ipv6': {
                         'routes': {
-                            '2001:1:1:1::1/128': {
-                                'route': '2001:1:1:1::1/128',
+                            '2001:1:1:a::1/128': {
+                                'route': '2001:1:1:a::1/128',
                                 'next_hop': {
                                     'next_hop_list': {
                                         1: {
@@ -499,8 +499,8 @@ class test_show_ipv6_static_route(unittest.TestCase):
                 'address_family': {
                     'ipv6': {
                         'routes': {
-                            '2001:1:1:1::1/128': {
-                                'route': '2001:1:1:1::1/128',
+                            '2001:1:1:a::1/128': {
+                                'route': '2001:1:1:a::1/128',
                                 'next_hop': {
                                     'outgoing_interface': {
                                         'Null0': {


### PR DESCRIPTION
## Description

The regex to capture IPv6 were incorrect. I tested this on ASR9k,
NCS5k and NX7k. The tests were passing due to IPv6 addresses only
having digits. I have updated them to add non-digits. I have checked
there is no other occurences in the code base, but just to be sure, I
will push a followup commits to update other tests to add a non-digit
in IPv6 addresses.

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [ ] All new code passed compilation.
