### PR TITLE
iosxr-ShowBgpInstanceNeighborsAdvertisedRoutes - Fix RegEx

### DIFF
--- a/changelog/undistributed/changelog_iosxr_ShowBgpInstanceNeighborsAdvertisedRoutes_20210828.rst
+++ b/changelog/undistributed/changelog_iosxr_ShowBgpInstanceNeighborsAdvertisedRoutes_20210828.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowBgpInstanceNeighborsAdvertisedRoutes:
+        * Modified RegEx <p4>,<5_1> to capture dotted Notation ASN
+

--- a/src/genie/libs/parser/iosxr/show_bgp.py
+++ b/src/genie/libs/parser/iosxr/show_bgp.py
@@ -4174,8 +4174,8 @@ class ShowBgpInstanceNeighborsAdvertisedRoutes(ShowBgpInstanceNeighborsAdvertise
         p4 = re.compile(
             r'^(?P<prefix>(?P<ip>[\w\.\:]+)/(?P<mask>\d+)) *(?P<next_hop>[\w\.\:]+) *('
             r'?P<froms>[\w\.\:]+) *'
-            '(?P<path>[\d\{\}\s]+)?(?P<origin_code>[e|i\?])?$')
-        p5_1 = re.compile(r'(?P<path>[\d\{\}\s]+)(?P<origin_code>e|i)?$')
+            r'(?P<path>[\d\.\{\}\s]+)?(?P<origin_code>[e|i\?])?$')
+        p5_1 = re.compile(r'(?P<path>[\d\.\{\}\s]+)(?P<origin_code>e|i)?$')
         p6 = re.compile(
             r'^Processed *(?P<processed_prefixes>[0-9]+) *prefixes, *(?P<processed_paths>[0-9]+) *paths$')
 
@@ -4241,6 +4241,7 @@ class ShowBgpInstanceNeighborsAdvertisedRoutes(ShowBgpInstanceNeighborsAdvertise
             # 10.169.1.0/24        10.186.5.1        10.16.2.2         100 300 33299 51178 47751 {27016}e
             # 2001:db8:cdc9:121::/64     10.4.1.1         2001:db8:20:1:5::5
             # 10.4.1.1/32         10.4.1.1         Local           ?
+            # 10.8.8.8/32        10.10.10.108    Local           65108.65108?
 
             m = p4.match(line)
             if m:
@@ -4285,6 +4286,7 @@ class ShowBgpInstanceNeighborsAdvertisedRoutes(ShowBgpInstanceNeighborsAdvertise
                     continue
 
             #                                                    200 33299 51178 47751 {27017}e
+            #                                                    200 33299 51178 65000.47751 {27017}e
 
             m = p5_1.match(line)
             if m:

--- a/src/genie/libs/parser/iosxr/tests/ShowBgpInstanceNeighborsAdvertisedRoutes/cli/equal/golden_output1_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowBgpInstanceNeighborsAdvertisedRoutes/cli/equal/golden_output1_expected.py
@@ -1,0 +1,48 @@
+expected_output = {
+  "instance": {
+    "default": {
+      "vrf": {
+        "default": {
+          "address_family": {
+            "ipv4 unicast": {
+              "advertised": {
+                "10.10.10.0/24": {
+                  "index": {
+                    1: {
+                      "froms": "Local",
+                      "next_hop": "10.10.10.108",
+                      "origin_code": "?",
+                      "path": "65108.65108"
+                    }
+                  }
+                },
+                "10.8.8.8/32": {
+                  "index": {
+                    1: {
+                      "froms": "Local",
+                      "next_hop": "10.10.10.108",
+                      "origin_code": "?",
+                      "path": "65108.65108"
+                    }
+                  }
+                },
+                "192.168.52.0/24": {
+                  "index": {
+                    1: {
+                      "froms": "Local",
+                      "next_hop": "10.10.10.108",
+                      "origin_code": "?",
+                      "path": "65108.65108"
+                    }
+                  }
+                }
+              },
+              "processed_paths": "3",
+              "processed_prefixes": "3"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowBgpInstanceNeighborsAdvertisedRoutes/cli/equal/golden_output1_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowBgpInstanceNeighborsAdvertisedRoutes/cli/equal/golden_output1_output.txt
@@ -1,0 +1,13 @@
+BGP instance 0: 'default'
+=========================
+
+Address Family: IPv4 Unicast
+----------------------------
+
+Network            Next Hop        From            AS Path
+10.8.8.8/32        10.10.10.108    Local           65108.65108?
+10.10.10.0/24      10.10.10.108    Local           65108.65108?
+192.168.52.0/24    10.10.10.108    Local           65108.65108?
+
+Processed 3 prefixes, 3 paths
+


### PR DESCRIPTION
## Description
Fix RegEx to capture dotted Notation ASN

## Motivation and Context
dotted Notation ASN was not captured by the current parser

## Impact (If any)
N/A

## Screenshots:
![genieparse_iosxr_ShowBgpInstanceNeighborsAdvertisedRoutes_20210829](https://user-images.githubusercontent.com/12904630/131266631-e3074df2-6ade-4930-8ab2-2403713ae07e.PNG)


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [ ] All new code passed compilation.
