### PR TITLE
IOSXR: fix AS parsing for dynamic neighbors

### DIFF
--- a/changelog/undistributed/changelog_iosxr_showBgpInstanceNeighborsDetail_20210903.rst
+++ b/changelog/undistributed/changelog_iosxr_showBgpInstanceNeighborsDetail_20210903.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowBgpInstanceNeighborsDetail
+        * Fix parsing of local and remote AS of dynamic neighbors

--- a/src/genie/libs/parser/iosxr/show_bgp.py
+++ b/src/genie/libs/parser/iosxr/show_bgp.py
@@ -2521,7 +2521,7 @@ class ShowBgpInstanceNeighborsDetail(ShowBgpInstanceNeighborsDetailSchema):
                             '(?P<instance>[a-zA-Z0-9\-\_\']+)$')
         p2 =  re.compile(r'^\s*BGP +neighbor +is +(?P<neighbor>[a-zA-Z0-9\.\:]+)$')
         p2_1 =  re.compile(r'^\s*BGP +neighbor +is +(?P<neighbor>[a-zA-Z0-9\.\:]+), +vrf +(?P<vrf>\S+)$')
-        p3 = re.compile(r'^Remote +AS +(?P<remote_as>[0-9]+), +local +AS +(?P<local_as_as_no>[0-9]+)(?:, +(?P<local_as_no_prepend>no-prepend))?(?:, +(?P<local_as_replace_as>replace-as))?(?:, +(?P<local_as_dual_as>dual-as))?(?:, +(?P<link_state>[a-zA-Z\s]+))?$')
+        p3 = re.compile(r'^Remote +AS +(?P<remote_as>[0-9]+), +local +AS +(?P<local_as_as_no>[0-9]+)(?:, +(?P<local_as_no_prepend>no-prepend))?(?:, +(?P<local_as_replace_as>replace-as))?(?:, +(?P<local_as_dual_as>dual-as))?(?:, +(?P<link_state>[a-zA-Z\s]+))?(?:, +.*)$')
         p4 = re.compile(r'^Remote *router *ID *(?P<router_id>[a-zA-Z0-9\.\:]+)$')
         p5 = re.compile(r'^\s*BGP +state += +(?P<session_state>[a-zA-Z0-9]+)'
                             '(?:, +up +for +(?P<up_time>[\w\:]+))?$')


### PR DESCRIPTION
Dynamic neighbors get an additional "Dynamic" property on the line
where remote and local AS are specified:

```
Remote AS 65498, local AS 65499, external link, Dynamic
```

Currently, the regex to parse this line expects a precise set of
properties and reject any unkown property. I propose to extend the
regex to accept and discard any unknown property. It seems better than
to return neighbors without local/remote AS, as this is quite an
essential information.

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
