### PR TITLE
Updated iosxe show license summary regex pattern

### DIFF
--- a/changelog/undistributed/changelog_show_license_summary_iosxe_20210907095958.rst
+++ b/changelog/undistributed/changelog_show_license_summary_iosxe_20210907095958.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                                Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowLicenseSummary
+        * Updtaed regex pattern for <license> capturing group to accommodate various outputs

--- a/src/genie/libs/parser/iosxe/show_license.py
+++ b/src/genie/libs/parser/iosxe/show_license.py
@@ -217,7 +217,8 @@ class ShowLicenseSummary(ShowLicenseSummarySchema):
 
         # network-advantage       (C9300-48 Network Advan...)       1 IN USE
         # dna-advantage           (C9300-48 DNA Advantage)          1 IN USE
-        p0 = re.compile(r"^(?P<license>[\w-]+)\s+\((?P<entitlement>.+)\)\s+(?P<count>\d+)\s+(?P<status>.+)$")
+        
+        p0 = re.compile(r"^(?P<license>.+\S+)\s+\((?P<entitlement>.+)\)\s+(?P<count>\d+)\s+(?P<status>.+)$")
 
         for line in out.splitlines():
             line=line.strip()

--- a/src/genie/libs/parser/iosxe/show_license.py
+++ b/src/genie/libs/parser/iosxe/show_license.py
@@ -218,12 +218,7 @@ class ShowLicenseSummary(ShowLicenseSummarySchema):
         # network-advantage       (C9300-48 Network Advan...)       1 IN USE
         # dna-advantage           (C9300-48 DNA Advantage)          1 IN USE
 
-        # Example 2
         # C9300 48P DNA Advantage  (C9300-48 DNA Advantage)          2 AUTHORIZED
-        # C9300 48P Network Adv... (C9300-48 Network Advan...)       2 AUTHORIZED
-        # C9300 24P Network Adv... (C9300-24 Network Advan...)       1 AUTHORIZED
-        # C9300 24P DNA Advantage  (C9300-24 DNA Advantage)          1 AUTHORIZED
-        
         p0 = re.compile(r"^(?P<license>.+?)\s+\((?P<entitlement>.+)\)\s+(?P<count>\d+)\s+(?P<status>.+)$")
 
         for line in out.splitlines():

--- a/src/genie/libs/parser/iosxe/show_license.py
+++ b/src/genie/libs/parser/iosxe/show_license.py
@@ -224,7 +224,7 @@ class ShowLicenseSummary(ShowLicenseSummarySchema):
         # C9300 24P Network Adv... (C9300-24 Network Advan...)       1 AUTHORIZED
         # C9300 24P DNA Advantage  (C9300-24 DNA Advantage)          1 AUTHORIZED
         
-        p0 = re.compile(r"^(?P<license>.+\S+)\s+\((?P<entitlement>.+)\)\s+(?P<count>\d+)\s+(?P<status>.+)$")
+        p0 = re.compile(r"^(?P<license>.+?)\s+\((?P<entitlement>.+)\)\s+(?P<count>\d+)\s+(?P<status>.+)$")
 
         for line in out.splitlines():
             line=line.strip()

--- a/src/genie/libs/parser/iosxe/show_license.py
+++ b/src/genie/libs/parser/iosxe/show_license.py
@@ -217,6 +217,12 @@ class ShowLicenseSummary(ShowLicenseSummarySchema):
 
         # network-advantage       (C9300-48 Network Advan...)       1 IN USE
         # dna-advantage           (C9300-48 DNA Advantage)          1 IN USE
+
+        # Example 2
+        # C9300 48P DNA Advantage  (C9300-48 DNA Advantage)          2 AUTHORIZED
+        # C9300 48P Network Adv... (C9300-48 Network Advan...)       2 AUTHORIZED
+        # C9300 24P Network Adv... (C9300-24 Network Advan...)       1 AUTHORIZED
+        # C9300 24P DNA Advantage  (C9300-24 DNA Advantage)          1 AUTHORIZED
         
         p0 = re.compile(r"^(?P<license>.+\S+)\s+\((?P<entitlement>.+)\)\s+(?P<count>\d+)\s+(?P<status>.+)$")
 

--- a/src/genie/libs/parser/iosxe/tests/ShowLicenseSummary/cli/equal/golden_output2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowLicenseSummary/cli/equal/golden_output2_expected.py
@@ -1,0 +1,24 @@
+expected_output = {
+   'license_usage':{
+      'C9300 48P DNA Advantage':{
+         'entitlement':'C9300-48 DNA Advantage',
+         'count':'2',
+         'status':'AUTHORIZED'
+      },
+      'C9300 48P Network Adv...':{
+         'entitlement':'C9300-48 Network Advan...',
+         'count':'2',
+         'status':'AUTHORIZED'
+      },
+      'C9300 24P Network Adv...':{
+         'entitlement':'C9300-24 Network Advan...',
+         'count':'1',
+         'status':'AUTHORIZED'
+      },
+      'C9300 24P DNA Advantage':{
+         'entitlement':'C9300-24 DNA Advantage',
+         'count':'1',
+         'status':'AUTHORIZED'
+      }
+   }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowLicenseSummary/cli/equal/golden_output2_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowLicenseSummary/cli/equal/golden_output2_output.txt
@@ -1,0 +1,7 @@
+License Usage:
+License                  Entitlement Tag                Count Status
+-----------------------------------------------------------------------------
+C9300 48P DNA Advantage  (C9300-48 DNA Advantage)          2 AUTHORIZED
+C9300 48P Network Adv... (C9300-48 Network Advan...)       2 AUTHORIZED
+C9300 24P Network Adv... (C9300-24 Network Advan...)       1 AUTHORIZED
+C9300 24P DNA Advantage  (C9300-24 DNA Advantage)          1 AUTHORIZED


### PR DESCRIPTION
## Description
Updated the regex pattern for the license capture group to accommodate various outputs.

## Motivation and Context
I discovered that the license name may vary, so I wanted to make the regex pattern more broad.

## Impact (If any)
N/A

## Screenshots:
<img width="545" alt="licensesumm-fix-make" src="https://user-images.githubusercontent.com/13680237/132358828-583e33c2-9e36-494e-8897-c6981366b4a6.png">

![licensesumm-fix-test_output](https://user-images.githubusercontent.com/13680237/132358965-ba973788-1d33-47f5-9a28-fcb30add4153.png)



## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated the changelog.
- [X] I have updated the documentation (If applicable).
- [X] I have added tests to cover my changes (If applicable).
- [X] All new and existing tests passed.
- [X] All new code passed compilation.
