### PR TITLE
IOSXR: fix regular expression for `show controller fia diagshell`

### DIFF
--- a/changelog/undistributed/changelog_iosxr_showControllers_20210909.rst
+++ b/changelog/undistributed/changelog_iosxr_showControllers_20210909.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowControllersFiaDiagshellL2showLocation
+        * Remove extra bracket from regular expression

--- a/src/genie/libs/parser/iosxr/show_controllers.py
+++ b/src/genie/libs/parser/iosxr/show_controllers.py
@@ -76,10 +76,10 @@ class ShowControllersFiaDiagshellL2showLocation(ShowControllersFiaDiagshellL2sho
         # mac=fc:00:00:ff:01:9c vlan=2544 GPORT=0x8000048 Trunk=0 encap_id=0x2007
         # mac=fc:00:00:ff:01:0c vlan=2524 GPORT=0xc000000 Trunk=0 Static encap_id=0x3001'
         p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
-                         ' +GPORT\=(?P<gport>\d+|0x[[A-Fa-f0-9]+)'
+                         ' +GPORT\=(?P<gport>\d+|0x[A-Fa-f0-9]+)'
                          '(?: +Trunk\=(?P<trunk>\d+))?'
                          '(?: +(?P<b_static>(Static)))?'
-                         ' +encap_id\=(?P<encap_id>\d+|0x[[A-Fa-f0-9\']+)$')
+                         ' +encap_id\=(?P<encap_id>\d+|0x[A-Fa-f0-9\']+)$')
 
         for line in out.splitlines():
             line = line.strip()


### PR DESCRIPTION
## Description

The regular expression contained an extra opening bracket that was not
needed. This triggers the following warning with Python 3.9:

```
show_controllers.py:78: FutureWarning: Possible nested set at position 74
  p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
show_controllers.py:78: FutureWarning: Possible nested set at position 176
  p2 = re.compile(r'^mac\=(?P<mac>[A-Fa-f0-9:]+) +vlan=(?P<vlan>\d+)'
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
