### PR TITLE
Unnumbered interface fails in show_interface.py

### DIFF
--- a/changelog/undistributed/changelog_iosxe_show_interface_fix_20211021.rst
+++ b/changelog/undistributed/changelog_iosxe_show_interface_fix_20211021.rst
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowIpInterface:
+        * Added if statements to broadcast address logic to check for existence
+          of 'ipv4' and 'address' in interface_dict
+        * Allows unnumbered interfaces to pass since they report a broadcast
+          address but do not have an IP address.

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -2085,8 +2085,10 @@ class ShowIpInterface(ShowIpInterfaceSchema):
             p3 = re.compile(r'^Broadcast +address +is +(?P<address>[\w\.\:]+)$')
             m = p3.match(line)
             if m:
-                interface_dict[interface]['ipv4'][address]['broadcast_address'] = \
-                    m.groupdict()['address']
+                if 'ipv4' in interface_dict[interface]:
+                    if address in interface_dict[interface]['ipv4']:
+                        interface_dict[interface]['ipv4'][address]['broadcast_address'] = \
+                            m.groupdict()['address']
                 continue
 
             # Address determined by configuration file

--- a/src/genie/libs/parser/iosxe/tests/ShowIpInterface/cli/equal/golden_output6_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpInterface/cli/equal/golden_output6_expected.py
@@ -1,0 +1,45 @@
+expected_output = {
+    'NVI0': {
+        'bgp_policy_mapping': False,
+        'directed_broadcast_forwarding': False,
+        'enabled': True,
+        'icmp': {
+            'mask_replies': 'never sent',
+            'redirects': 'always sent',
+            'unreachables': 'always sent',
+        },
+        'input_features': ['MCI Check'],
+        'ip_access_violation_accounting': False,
+        'ip_cef_switching': False,
+        'ip_fast_switching': False,
+        'ip_flow_switching': False,
+        'ip_multicast_distributed_fast_switching': False,
+        'ip_multicast_fast_switching': True,
+        'ip_null_turbo_vector': True,
+        'ip_output_packet_accounting': False,
+        'ip_route_cache_flags': ['CEF', 'Fast'],
+        'local_proxy_arp': False,
+        'mtu': 9216,
+        'network_address_translation': False,
+        'oper_status': 'up',
+        'policy_routing': False,
+        'probe_proxy_name_replies': False,
+        'router_discovery': False,
+        'rtp_ip_header_compression': False,
+        'security_level': 'default',
+        'split_horizon': True,
+        'tcp_ip_header_compression': False,
+        'unicast_routing_topologies': {
+            'topology': {
+                'base': {
+                    'status': 'up',
+                },
+            },
+        },
+        'wccp': {
+            'redirect_exclude': False,
+            'redirect_inbound': False,
+            'redirect_outbound': False,
+        },
+    },
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowIpInterface/cli/equal/golden_output6_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpInterface/cli/equal/golden_output6_output.txt
@@ -1,0 +1,40 @@
+NVI0 is up, line protocol is up
+  Broadcast address is 255.255.255.255
+  MTU is 9216 bytes
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Outgoing Common access list is not set 
+  Outgoing access list is not set
+  Inbound Common access list is not set 
+  Inbound  access list is not set
+  Proxy ARP is disabled (Globally)
+  Local Proxy ARP is disabled
+  Security level is default
+  Split horizon is enabled
+  ICMP redirects are always sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  IP fast switching is disabled
+  IP Flow switching is disabled
+  IP CEF switching is disabled
+  IP Null turbo vector
+  IP Null turbo vector
+  Associated unicast routing topologies:
+        Topology "base", operation state is UP
+  IP multicast fast switching is enabled
+  IP multicast distributed fast switching is disabled
+  IP route-cache flags are Fast, CEF
+  Router Discovery is disabled
+  IP output packet accounting is disabled
+  IP access violation accounting is disabled
+  TCP/IP header compression is disabled
+  RTP/IP header compression is disabled
+  Probe proxy name replies are disabled
+  Policy routing is disabled
+  Network address translation is disabled
+  BGP Policy Mapping is disabled
+  Input features: MCI Check
+  IPv4 WCCP Redirect outbound is disabled
+  IPv4 WCCP Redirect inbound is disabled
+  IPv4 WCCP Redirect exclude is disabled
+  IP Clear Dont Fragment is disabled


### PR DESCRIPTION
## Description
Unnumbered interfaces report a broadcast of 255.255.255.255 without having associated IP information causing an error when trying to access the interface['ipv4']['address'] dict. Added check for dict and skip the assignment if it is not set.

I added two if statements to check for the existence of the ipv4 and address keys under the interface object before accessing them after matching the broadcast address regex.

## Motivation and Context
The device.learn.interface method was failing on devices with unnumbered interfaces. I experienced this on an IR1101 router running SDWAN.

## Impact (If any)
I'm not aware of a negative impact.

## Screenshots:
NA

## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [yes] All new code passed compilation.
