### PR TITLE
Modified ShowChassisHardWareScheme and regex

### DIFF
--- a/changelog/undistributed/changelog_show_chassis_junos_20211103.rst
+++ b/changelog/undistributed/changelog_show_chassis_junos_20211103.rst
@@ -1,0 +1,14 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* JUNOS
+  * Modified ShowChassisHardwareSchema:
+    * Modified fields for chassis-module
+    * Modified chassis-sub-sub-module to list of dictionaries
+  * Modified ShowChassisHardware:
+    * Modified RegEx for p_chassis, p_module0, p_module1, p_sub_module, p_sub_sub_module, p_sub_sub_sub_module to capture:
+        * Correct empty version
+        * Multiple formats for part_number
+        * Multiple formats for serial number
+        * Capture description to end of line instead of end of all output
+    * Added relevant example output to test against


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Modified ShowChassisHardwareScheme to add additional fields based on output I saw on the routers.
Modified regex for p_chassis, p_module0, p_module1, p_sub_module, p_sub_sub_module, p_sub_sub_sub_module to capture the fields correctly based on differing formats/values based on output I saw on the router.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes incorrect regex/field capturing

## Impact (If any)
<!--- If there is any negative impact - what is it? -->

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->
See attached test screenshot

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] I have updated the changelog.
- [ x ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ x ] All new and existing tests passed.
- [ x ] All new code passed compilation
![Screenshot 2021-11-03 at 18 04 44](https://user-images.githubusercontent.com/21081291/140097692-f68fdcd2-823c-4afe-9cc5-d65716daacf9.png)
.
