### PR TITLE
schema change

### DIFF
--- a/changelog/2021/november.rst
+++ b/changelog/2021/november.rst
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+                                      Fix
+--------------------------------------------------------------------------------
+
+* asa
+    * Modified ShowRouteSchema
+        * Added index to routes and supporting multiple routes to same subnet
+    * Modified ShowRoute
+        * Added index to routes and supporting multiple routes to same subnet

--- a/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output3_expected.py
+++ b/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output3_expected.py
@@ -5,398 +5,478 @@ expected_output = {
                 "ipv4": {
                     "routes": {
                         "0.0.0.0/0": {
-                            "active": True,
-                            "candidate_default": True,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.16.251.1",
-                                        "outgoing_interface_name": "outside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.16.251.2",
-                                        "outgoing_interface_name": "pod1000",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": True,
+                                "active": True,
+                                "route": "0.0.0.0/0",
+                                "source_protocol_codes": "S",
+                                "source_protocol": "static",
+                                "route_preference": 10,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.16.251.1",
+                                            "outgoing_interface_name": "outside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.16.251.2",
+                                            "outgoing_interface_name": "pod1000"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "0.0.0.0/0",
-                            "route_preference": 10,
-                            "source_protocol": "static",
-                            "source_protocol_codes": "S",
+                            }
                         },
                         "0.0.0.1/0": {
-                            "active": True,
-                            "candidate_default": False,
-                            "metric": 5,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.16.255.1",
-                                        "outgoing_interface_name": "outside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.16.255.2",
-                                        "outgoing_interface_name": "pod1001",
-                                    },
-                                    3: {
-                                        "index": 3,
-                                        "next_hop": "10.16.255.3",
-                                        "outgoing_interface_name": "pod1002",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "0.0.0.1/0",
+                                "source_protocol_codes": "S",
+                                "source_protocol": "static",
+                                "metric": 5,
+                                "route_preference": 10,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.16.255.1",
+                                            "outgoing_interface_name": "outside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.16.255.2",
+                                            "outgoing_interface_name": "pod1001"
+                                        },
+                                        "3": {
+                                            "index": 3,
+                                            "next_hop": "10.16.255.3",
+                                            "outgoing_interface_name": "pod1002"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "0.0.0.1/0",
-                            "route_preference": 10,
-                            "source_protocol": "static",
-                            "source_protocol_codes": "S",
-                        },
-                        "10.0.0.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "0:19:52",
-                            "metric": 30720,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "inside": {"outgoing_interface_name": "inside"}
-                                }
-                            },
-                            "route": "10.0.0.0/24",
-                            "route_preference": 90,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "D",
+                            }
                         },
                         "10.10.1.1/16": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "_internal_loopback": {
-                                        "outgoing_interface_name": "_internal_loopback"
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.1/16",
+                                "source_protocol_codes": "C",
+                                "source_protocol": "connected",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "_internal_loopback": {
+                                            "outgoing_interface_name": "_internal_loopback"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.10.1.1/16",
-                            "source_protocol": "connected",
-                            "source_protocol_codes": "C",
+                            }
                         },
                         "10.10.1.2/23": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "outside": {"outgoing_interface_name": "outside"}
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.2/23",
+                                "source_protocol_codes": "C",
+                                "source_protocol": "connected",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "outside": {
+                                            "outgoing_interface_name": "outside"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.10.1.2/23",
-                            "source_protocol": "connected",
-                            "source_protocol_codes": "C",
-                        },
-                        "10.10.1.3/32": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "pod2002": {"outgoing_interface_name": "pod2002"}
-                                }
-                            },
-                            "route": "10.10.1.3/32",
-                            "source_protocol": "local",
-                            "source_protocol_codes": "L",
-                        },
-                        "10.10.1.4/32": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "admin": {"outgoing_interface_name": "admin"}
-                                }
-                            },
-                            "route": "10.10.1.4/32",
-                            "source_protocol": "vpn",
-                            "source_protocol_codes": "V",
-                        },
-                        "10.10.1.5/32": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "pod2500": {"outgoing_interface_name": "pod2500"}
-                                }
-                            },
-                            "route": "10.10.1.5/32",
-                            "source_protocol": "local",
-                            "source_protocol_codes": "L",
-                        },
-                        "10.10.1.6/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "pod3000": {"outgoing_interface_name": "pod3000"}
-                                }
-                            },
-                            "route": "10.10.1.6/24",
-                            "source_protocol": "connected",
-                            "source_protocol_codes": "C",
-                        },
-                        "10.121.65.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.121.64.35",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.121.64.34",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                }
-                            },
-                            "route": "10.121.65.0/24",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
-                        },
-                        "10.121.67.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.67.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
-                        "10.121.68.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.68.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
-                        "10.121.69.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.121.64.35",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.121.64.34",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                }
-                            },
-                            "route": "10.121.69.0/24",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
-                        },
-                        "10.121.70.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.70.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
-                        "10.121.71.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.71.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
+                            }
                         },
                         "10.122.3.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 0,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {"index": 1, "next_hop": "172.25.141.2"}
-                                }
-                            },
-                            "route": "10.122.3.0/24",
-                            "route_preference": 20,
-                            "source_protocol": "bgp",
-                            "source_protocol_codes": "B",
-                        },
-                        "10.20.2.64/26": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2d03h",
-                            "metric": 1,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.19.1.1",
-                                        "outgoing_interface_name": "wan2",
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.122.3.0/24",
+                                "source_protocol_codes": "B",
+                                "source_protocol": "bgp",
+                                "metric": 0,
+                                "route_preference": 20,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "172.25.141.2"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.20.2.64/26",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "E2",
+                            }
+                        },
+                        "10.10.1.3/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.3/32",
+                                "source_protocol_codes": "L",
+                                "source_protocol": "local",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "pod2002": {
+                                            "outgoing_interface_name": "pod2002"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.10.1.4/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.4/32",
+                                "source_protocol_codes": "V",
+                                "source_protocol": "vpn",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "admin": {
+                                            "outgoing_interface_name": "admin"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.10.1.5/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.5/32",
+                                "source_protocol_codes": "L",
+                                "source_protocol": "local",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "pod2500": {
+                                            "outgoing_interface_name": "pod2500"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.10.1.6/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.6/24",
+                                "source_protocol_codes": "C",
+                                "source_protocol": "connected",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "pod3000": {
+                                            "outgoing_interface_name": "pod3000"
+                                        }
+                                    }
+                                }
+                            }
                         },
                         "10.20.58.64/26": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "3w6d",
-                            "metric": 11,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "172.20.192.3",
-                                        "outgoing_interface_name": "wan1",
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "3w6d",
+                                "route": "10.20.58.64/26",
+                                "source_protocol_codes": "E2",
+                                "source_protocol": "ospf",
+                                "metric": 11,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "172.20.192.3",
+                                            "outgoing_interface_name": "wan1"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.20.58.64/26",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "E2",
+                            }
+                        },
+                        "10.20.2.64/26": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2d03h",
+                                "route": "10.20.2.64/26",
+                                "source_protocol_codes": "E2",
+                                "source_protocol": "ospf",
+                                "metric": 1,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.19.1.1",
+                                            "outgoing_interface_name": "wan2"
+                                        }
+                                    }
+                                }
+                            }
                         },
                         "10.30.79.64/26": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "1w1d",
-                            "metric": 11,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.20.192.3",
-                                        "outgoing_interface_name": "wan3",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.20.192.4",
-                                        "outgoing_interface_name": "wan4",
-                                    },
-                                }
-                            },
-                            "route": "10.30.79.64/26",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "E2",
-                        },
-                        "10.205.8.0/23": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "172.20.1.1",
-                                        "outgoing_interface_name": "wan5",
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "1w1d",
+                                "route": "10.30.79.64/26",
+                                "source_protocol_codes": "E2",
+                                "source_protocol": "ospf",
+                                "metric": 11,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.20.192.3",
+                                            "outgoing_interface_name": "wan3"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.20.192.4",
+                                            "outgoing_interface_name": "wan4"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.205.8.0/23",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
+                            }
+                        },
+                        "10.205.8.0/23": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.205.8.0/23",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "172.20.1.1",
+                                            "outgoing_interface_name": "wan5"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.0.0.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "0:19:52",
+                                "route": "10.0.0.0/24",
+                                "source_protocol_codes": "D",
+                                "source_protocol": "eigrp",
+                                "metric": 30720,
+                                "route_preference": 90,
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "inside": {
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.65.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.121.65.0/24",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.121.64.35",
+                                            "outgoing_interface_name": "inside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.121.64.34",
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.67.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.67.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.68.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.68.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.69.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.121.69.0/24",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.121.64.35",
+                                            "outgoing_interface_name": "inside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.121.64.34",
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.70.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.70.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.71.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.71.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
                         },
                         "10.121.0.0/8": {
-                            "active": True,
-                            "candidate_default": False,
-                            "metric": 0,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "gig3": {"outgoing_interface_name": "gig3",}
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.121.0.0/8",
+                                "source_protocol_codes": "SI",
+                                "source_protocol": "static intervrf",
+                                "metric": 0,
+                                "route_preference": 1,
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "gig3": {
+                                            "outgoing_interface_name": "gig3"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.0.0/8",
-                            "route_preference": 1,
-                            "source_protocol": "static intervrf",
-                            "source_protocol_codes": "SI"        
-                        },
+                            }
+                        }
                     }
                 }
             }

--- a/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_2_expected.py
@@ -5,149 +5,167 @@ expected_output = {
                 "ipv4": {
                     "routes": {
                         "10.121.65.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.121.64.35",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.121.64.34",
-                                        "outgoing_interface_name": "inside",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.121.65.0/24",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.121.64.35",
+                                            "outgoing_interface_name": "inside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.121.64.34",
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.65.0/24",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
+                            }
                         },
                         "10.121.67.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.67.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.67.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
+                            }
                         },
                         "10.121.68.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.68.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.68.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
+                            }
                         },
                         "10.121.69.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.121.64.35",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.121.64.34",
-                                        "outgoing_interface_name": "inside",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.121.69.0/24",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.121.64.35",
+                                            "outgoing_interface_name": "inside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.121.64.34",
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.69.0/24",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
+                            }
                         },
                         "10.121.70.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.70.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.70.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
+                            }
                         },
                         "10.121.71.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.71.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.121.71.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
+                            }
+                        }
                     }
                 }
             }

--- a/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_4_expected.py
+++ b/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_4_expected.py
@@ -1,0 +1,94 @@
+expected_output = {
+    "vrf": {
+        "default": {
+            "address_family": {
+                "ipv4": {
+                    "routes": {
+                        "0.0.0.0/0": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": True,
+                                "active": True,
+                                "route": "0.0.0.0/0",
+                                "source_protocol_codes": "S",
+                                "source_protocol": "static",
+                                "metric": 0,
+                                "route_preference": 1,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "104.225.199.193",
+                                            "outgoing_interface_name": "Outside-Port-Channel"
+                                        }
+                                    }
+                                }
+                            },
+                            "2": {
+                                "index": 2,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "0.0.0.0/0",
+                                "source_protocol_codes": "S",
+                                "source_protocol": "static",
+                                "metric": 0,
+                                "route_preference": 255,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.98.126.1",
+                                            "outgoing_interface_name": "Inside-Port-Channel"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "1.1.1.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2d19h",
+                                "route": "1.1.1.0/24",
+                                "source_protocol_codes": "B",
+                                "source_protocol": "bgp",
+                                "metric": 0,
+                                "route_preference": 20,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.98.126.1"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "4.33.104.119/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2d19h",
+                                "route": "4.33.104.119/32",
+                                "source_protocol_codes": "B",
+                                "source_protocol": "bgp",
+                                "metric": 0,
+                                "route_preference": 20,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.98.126.1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_4_output.txt
+++ b/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_4_output.txt
@@ -1,0 +1,14 @@
+
+Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
+       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area
+       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+       E1 - OSPF external type 1, E2 - OSPF external type 2, V - VPN
+       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
+       ia - IS-IS inter area, * - candidate default, U - per-user static route
+       o - ODR, P - periodic downloaded static route, + - replicated route
+Gateway of last resort is 104.225.199.193 to network 0.0.0.0
+
+S*       0.0.0.0 0.0.0.0 [1/0] via 104.225.199.193, Outside-Port-Channel
+B        1.1.1.0 255.255.255.0 [20/0] via 10.98.126.1, 2d19h
+B        4.33.104.119 255.255.255.255 [20/0] via 10.98.126.1, 2d19h
+S    0.0.0.0 0.0.0.0 [255/0] via 10.98.126.1, Inside-Port-Channel tunneled

--- a/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/asa/tests/ShowRoute/cli/equal/golden_output_expected.py
@@ -5,384 +5,459 @@ expected_output = {
                 "ipv4": {
                     "routes": {
                         "0.0.0.0/0": {
-                            "active": True,
-                            "candidate_default": True,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.16.251.1",
-                                        "outgoing_interface_name": "outside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.16.251.2",
-                                        "outgoing_interface_name": "pod1000",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": True,
+                                "active": True,
+                                "route": "0.0.0.0/0",
+                                "source_protocol_codes": "S",
+                                "source_protocol": "static",
+                                "route_preference": 10,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.16.251.1",
+                                            "outgoing_interface_name": "outside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.16.251.2",
+                                            "outgoing_interface_name": "pod1000"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "0.0.0.0/0",
-                            "route_preference": 10,
-                            "source_protocol": "static",
-                            "source_protocol_codes": "S",
+                            }
                         },
                         "0.0.0.1/0": {
-                            "active": True,
-                            "candidate_default": False,
-                            "metric": 5,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.16.255.1",
-                                        "outgoing_interface_name": "outside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.16.255.2",
-                                        "outgoing_interface_name": "pod1001",
-                                    },
-                                    3: {
-                                        "index": 3,
-                                        "next_hop": "10.16.255.3",
-                                        "outgoing_interface_name": "pod1002",
-                                    },
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "0.0.0.1/0",
+                                "source_protocol_codes": "S",
+                                "source_protocol": "static",
+                                "metric": 5,
+                                "route_preference": 10,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.16.255.1",
+                                            "outgoing_interface_name": "outside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.16.255.2",
+                                            "outgoing_interface_name": "pod1001"
+                                        },
+                                        "3": {
+                                            "index": 3,
+                                            "next_hop": "10.16.255.3",
+                                            "outgoing_interface_name": "pod1002"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "0.0.0.1/0",
-                            "route_preference": 10,
-                            "source_protocol": "static",
-                            "source_protocol_codes": "S",
-                        },
-                        "10.0.0.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "0:19:52",
-                            "metric": 30720,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "inside": {"outgoing_interface_name": "inside"}
-                                }
-                            },
-                            "route": "10.0.0.0/24",
-                            "route_preference": 90,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "D",
+                            }
                         },
                         "10.10.1.1/16": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "_internal_loopback": {
-                                        "outgoing_interface_name": "_internal_loopback"
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.1/16",
+                                "source_protocol_codes": "C",
+                                "source_protocol": "connected",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "_internal_loopback": {
+                                            "outgoing_interface_name": "_internal_loopback"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.10.1.1/16",
-                            "source_protocol": "connected",
-                            "source_protocol_codes": "C",
+                            }
                         },
                         "10.10.1.2/23": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "outside": {"outgoing_interface_name": "outside"}
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.2/23",
+                                "source_protocol_codes": "C",
+                                "source_protocol": "connected",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "outside": {
+                                            "outgoing_interface_name": "outside"
+                                        }
+                                    }
                                 }
-                            },
-                            "route": "10.10.1.2/23",
-                            "source_protocol": "connected",
-                            "source_protocol_codes": "C",
-                        },
-                        "10.10.1.3/32": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "pod2002": {"outgoing_interface_name": "pod2002"}
-                                }
-                            },
-                            "route": "10.10.1.3/32",
-                            "source_protocol": "local",
-                            "source_protocol_codes": "L",
-                        },
-                        "10.10.1.4/32": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "admin": {"outgoing_interface_name": "admin"}
-                                }
-                            },
-                            "route": "10.10.1.4/32",
-                            "source_protocol": "vpn",
-                            "source_protocol_codes": "V",
-                        },
-                        "10.10.1.5/32": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "pod2500": {"outgoing_interface_name": "pod2500"}
-                                }
-                            },
-                            "route": "10.10.1.5/32",
-                            "source_protocol": "local",
-                            "source_protocol_codes": "L",
-                        },
-                        "10.10.1.6/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "next_hop": {
-                                "outgoing_interface_name": {
-                                    "pod3000": {"outgoing_interface_name": "pod3000"}
-                                }
-                            },
-                            "route": "10.10.1.6/24",
-                            "source_protocol": "connected",
-                            "source_protocol_codes": "C",
-                        },
-                        "10.121.65.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.121.64.35",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.121.64.34",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                }
-                            },
-                            "route": "10.121.65.0/24",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
-                        },
-                        "10.121.67.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.67.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
-                        "10.121.68.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.68.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
-                        "10.121.69.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.121.64.35",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.121.64.34",
-                                        "outgoing_interface_name": "inside",
-                                    },
-                                }
-                            },
-                            "route": "10.121.69.0/24",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
-                        },
-                        "10.121.70.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.70.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
-                        },
-                        "10.121.71.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2w1d",
-                            "metric": 345856,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.9.193.99",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.9.193.98",
-                                        "outgoing_interface_name": "esavpn",
-                                    },
-                                }
-                            },
-                            "route": "10.121.71.0/24",
-                            "route_preference": 170,
-                            "source_protocol": "eigrp",
-                            "source_protocol_codes": "EX",
+                            }
                         },
                         "10.122.3.0/24": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 0,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {"index": 1, "next_hop": "172.25.141.2"}
-                                }
-                            },
-                            "route": "10.122.3.0/24",
-                            "route_preference": 20,
-                            "source_protocol": "bgp",
-                            "source_protocol_codes": "B",
-                        },
-                        "10.20.2.64/26": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "2d03h",
-                            "metric": 1,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.19.1.1",
-                                        "outgoing_interface_name": "wan2",
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.122.3.0/24",
+                                "source_protocol_codes": "B",
+                                "source_protocol": "bgp",
+                                "metric": 0,
+                                "route_preference": 20,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "172.25.141.2"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.20.2.64/26",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "E2",
+                            }
+                        },
+                        "10.10.1.3/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.3/32",
+                                "source_protocol_codes": "L",
+                                "source_protocol": "local",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "pod2002": {
+                                            "outgoing_interface_name": "pod2002"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.10.1.4/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.4/32",
+                                "source_protocol_codes": "V",
+                                "source_protocol": "vpn",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "admin": {
+                                            "outgoing_interface_name": "admin"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.10.1.5/32": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.5/32",
+                                "source_protocol_codes": "L",
+                                "source_protocol": "local",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "pod2500": {
+                                            "outgoing_interface_name": "pod2500"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.10.1.6/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "route": "10.10.1.6/24",
+                                "source_protocol_codes": "C",
+                                "source_protocol": "connected",
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "pod3000": {
+                                            "outgoing_interface_name": "pod3000"
+                                        }
+                                    }
+                                }
+                            }
                         },
                         "10.20.58.64/26": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "3w6d",
-                            "metric": 11,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "172.20.192.3",
-                                        "outgoing_interface_name": "wan1",
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "3w6d",
+                                "route": "10.20.58.64/26",
+                                "source_protocol_codes": "E2",
+                                "source_protocol": "ospf",
+                                "metric": 11,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "172.20.192.3",
+                                            "outgoing_interface_name": "wan1"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.20.58.64/26",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "E2",
+                            }
+                        },
+                        "10.20.2.64/26": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2d03h",
+                                "route": "10.20.2.64/26",
+                                "source_protocol_codes": "E2",
+                                "source_protocol": "ospf",
+                                "metric": 1,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.19.1.1",
+                                            "outgoing_interface_name": "wan2"
+                                        }
+                                    }
+                                }
+                            }
                         },
                         "10.30.79.64/26": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "1w1d",
-                            "metric": 11,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "10.20.192.3",
-                                        "outgoing_interface_name": "wan3",
-                                    },
-                                    2: {
-                                        "index": 2,
-                                        "next_hop": "10.20.192.4",
-                                        "outgoing_interface_name": "wan4",
-                                    },
-                                }
-                            },
-                            "route": "10.30.79.64/26",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "E2",
-                        },
-                        "10.205.8.0/23": {
-                            "active": True,
-                            "candidate_default": False,
-                            "date": "7w0d",
-                            "metric": 20,
-                            "next_hop": {
-                                "next_hop_list": {
-                                    1: {
-                                        "index": 1,
-                                        "next_hop": "172.20.1.1",
-                                        "outgoing_interface_name": "wan5",
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "1w1d",
+                                "route": "10.30.79.64/26",
+                                "source_protocol_codes": "E2",
+                                "source_protocol": "ospf",
+                                "metric": 11,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.20.192.3",
+                                            "outgoing_interface_name": "wan3"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.20.192.4",
+                                            "outgoing_interface_name": "wan4"
+                                        }
                                     }
                                 }
-                            },
-                            "route": "10.205.8.0/23",
-                            "route_preference": 110,
-                            "source_protocol": "ospf",
-                            "source_protocol_codes": "O",
+                            }
                         },
+                        "10.205.8.0/23": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.205.8.0/23",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "172.20.1.1",
+                                            "outgoing_interface_name": "wan5"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.0.0.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "0:19:52",
+                                "route": "10.0.0.0/24",
+                                "source_protocol_codes": "D",
+                                "source_protocol": "eigrp",
+                                "metric": 30720,
+                                "route_preference": 90,
+                                "next_hop": {
+                                    "outgoing_interface_name": {
+                                        "inside": {
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.65.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.121.65.0/24",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.121.64.35",
+                                            "outgoing_interface_name": "inside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.121.64.34",
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.67.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.67.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.68.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.68.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.69.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "7w0d",
+                                "route": "10.121.69.0/24",
+                                "source_protocol_codes": "O",
+                                "source_protocol": "ospf",
+                                "metric": 20,
+                                "route_preference": 110,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.121.64.35",
+                                            "outgoing_interface_name": "inside"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.121.64.34",
+                                            "outgoing_interface_name": "inside"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.70.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.70.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "10.121.71.0/24": {
+                            1: {
+                                "index": 1,
+                                "candidate_default": False,
+                                "active": True,
+                                "date": "2w1d",
+                                "route": "10.121.71.0/24",
+                                "source_protocol_codes": "EX",
+                                "source_protocol": "eigrp",
+                                "metric": 345856,
+                                "route_preference": 170,
+                                "next_hop": {
+                                    "next_hop_list": {
+                                        1: {
+                                            "index": 1,
+                                            "next_hop": "10.9.193.99",
+                                            "outgoing_interface_name": "esavpn"
+                                        },
+                                        2: {
+                                            "index": 2,
+                                            "next_hop": "10.9.193.98",
+                                            "outgoing_interface_name": "esavpn"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
Changed the schema and parser for the ASA `show route` command to permit multiple routes with the same subnet.

## Motivation and Context
Issue #569 explains the motivation, but briefly, the existing schema overwrites data when two routes share a subnet e.g.

```
S*       0.0.0.0 0.0.0.0 [1/0] via 104.225.199.193, Outside-Port-Channel
S    0.0.0.0 0.0.0.0 [255/0] via 10.98.126.1, Inside-Port-Channel tunneled 
```

The output of the parser omits the first row while including the second. This is problematic because the first row represents the route that traffic would follow by default under normal conditions in the actual network. Ergo the parser output doesn't accurately reflect the config.

## Impact (If any)
There is considerable impact to the users of the library due to the schema change. I'm not sure what the policies are around schema changes and how they are scheduled in the roadmap.

## Screenshots:
Haven't done compile/demo yet

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable). -- N/A
- [x] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
