### PR TITLE
Fix ShowSnmpMibIfmibIfindex not parsing certain interfaces correctly

### DIFF
--- a/changelog/undistributed/changelog_fix_ShowSnmpMibIfmibIfindex_20211130163321.rst
+++ b/changelog/undistributed/changelog_fix_ShowSnmpMibIfmibIfindex_20211130163321.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowSnmpMibIfmibIfindex:
+        * Modify regex pattern p1 to correctly match interfaces of the type 'unrouted VLAN <ID>'

--- a/src/genie/libs/parser/iosxe/show_snmp.py
+++ b/src/genie/libs/parser/iosxe/show_snmp.py
@@ -850,12 +850,21 @@ class ShowSnmpMibIfmibIfindex(ShowSnmpMibIfmibIfindexSchema):
         #GigabitEthernet3/0/28: Ifindex = 36
         p1 =  re.compile(r'(?P<interface_index>\S+) +Ifindex = +(?P<ifIndex>\d+)$')
 
+        #unrouted VLAN 1003: Ifindex = 7
+        p_vlan = re.compile(r'unrouted VLAN (?P<vlan_id>\d+): +Ifindex = +(?P<ifIndex>\d+)$')
+
         for line in out.splitlines():
-            m = p1.match(line)
-            group = m.groupdict()
-            intf = Common.convert_intf_name(group.pop('interface_index')) 
-            intf = (intf.split(':'))[0]
+            if p1.match(line):
+                m = p1.match(line)
+                group = m.groupdict()
+                intf = Common.convert_intf_name(group.pop('interface_index')) 
+                intf = (intf.split(':'))[0]
+            elif p_vlan.match(line):
+                m = p_vlan.match(line)
+                group = m.groupdict()
+                intf = 'Vlan' + group.pop('vlan_id')
+
             int_dict = interface_dict.setdefault('interface',{}).setdefault(intf, group)
-            interface_dict.update() 
+            interface_dict.update()
 
         return interface_dict

--- a/src/genie/libs/parser/iosxe/show_snmp.py
+++ b/src/genie/libs/parser/iosxe/show_snmp.py
@@ -849,13 +849,15 @@ class ShowSnmpMibIfmibIfindex(ShowSnmpMibIfmibIfindexSchema):
 
         #GigabitEthernet3/0/28: Ifindex = 36
         #unrouted VLAN 1003: Ifindex = 7
-        p1 =  re.compile(r'^(unrouted\s+)?(?P<interface_index>(VLAN\s)?\S+) +Ifindex = +(?P<ifIndex>\d+)$')
+        p1 =  re.compile(r'^(?P<interface_index>(unrouted\sVLAN\s)?\S+) +Ifindex = +(?P<ifIndex>\d+)$')
 
         for line in out.splitlines():
+            #GigabitEthernet3/0/28: Ifindex = 36
+            #unrouted VLAN 1003: Ifindex = 7
             m = p1.match(line)
             if m:
                 group = m.groupdict()
-                intf = Common.convert_intf_name(group.pop('interface_index').replace(' ', ''))
+                intf = Common.convert_intf_name(group.pop('interface_index'))
                 intf = (intf.split(':'))[0]
                 interface_dict.setdefault('interface',{}).setdefault(intf, group)
 

--- a/src/genie/libs/parser/iosxe/show_snmp.py
+++ b/src/genie/libs/parser/iosxe/show_snmp.py
@@ -848,23 +848,15 @@ class ShowSnmpMibIfmibIfindex(ShowSnmpMibIfmibIfindexSchema):
         interface_dict = {}
 
         #GigabitEthernet3/0/28: Ifindex = 36
-        p1 =  re.compile(r'(?P<interface_index>\S+) +Ifindex = +(?P<ifIndex>\d+)$')
-
         #unrouted VLAN 1003: Ifindex = 7
-        p_vlan = re.compile(r'unrouted VLAN (?P<vlan_id>\d+): +Ifindex = +(?P<ifIndex>\d+)$')
+        p1 =  re.compile(r'^(unrouted\s+)?(?P<interface_index>(VLAN\s)?\S+) +Ifindex = +(?P<ifIndex>\d+)$')
 
         for line in out.splitlines():
-            if p1.match(line):
-                m = p1.match(line)
+            m = p1.match(line)
+            if m:
                 group = m.groupdict()
-                intf = Common.convert_intf_name(group.pop('interface_index')) 
+                intf = Common.convert_intf_name(group.pop('interface_index').replace(' ', ''))
                 intf = (intf.split(':'))[0]
-            elif p_vlan.match(line):
-                m = p_vlan.match(line)
-                group = m.groupdict()
-                intf = 'Vlan' + group.pop('vlan_id')
-
-            int_dict = interface_dict.setdefault('interface',{}).setdefault(intf, group)
-            interface_dict.update()
+                interface_dict.setdefault('interface',{}).setdefault(intf, group)
 
         return interface_dict

--- a/src/genie/libs/parser/iosxe/tests/ShowSnmpMibIfmibIfindex/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowSnmpMibIfmibIfindex/cli/equal/golden_output_expected.py
@@ -194,6 +194,9 @@ expected_output = {
          },
          "TenGigabitEthernet3/1/8": {
              "ifIndex": "68"
+         },
+         "UnroutedVLAN1003": {
+             "ifIndex": "7"
          }
      }
  }

--- a/src/genie/libs/parser/iosxe/tests/ShowSnmpMibIfmibIfindex/cli/equal/golden_output_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowSnmpMibIfmibIfindex/cli/equal/golden_output_output.txt
@@ -63,3 +63,4 @@ GigabitEthernet3/0/43: Ifindex = 51
 GigabitEthernet3/0/14: Ifindex = 22
 TenGigabitEthernet3/1/7: Ifindex = 67
 GigabitEthernet3/0/41: Ifindex = 49
+unrouted VLAN 1003: Ifindex = 7


### PR DESCRIPTION
## Description
Added an additional regex pattern to the ShowSnmpMibIfmibIfindex parser class. The regex patten (`unrouted VLAN (?P<vlan_id>\d+): +Ifindex = +(?P<ifIndex>\d+)$`) matches interfaces in the form `unrouted VLAN <ID>` which were not previously matched by this parser.

## Motivation and Context
The existing parser will fail if it encounters an unexpected interface name such as 'unrouted VLAN <ID>' as shown here:
```
Traceback (most recent call last):
  File "test.py", line 88, in <module>
    print(ShowSnmpMibIfmibIfindex(None).cli(output=output))
  File "/home/mckesm/.local/lib/python3.6/site-packages/genie/libs/parser/iosxe/show_snmp.py", line 855, in cli
    group = m.groupdict()
AttributeError: 'NoneType' object has no attribute 'groupdict'
```

Tested using this input:
<details>

```
Vlan2101: Ifindex = 74
TwoGigabitEthernet1/0/32: Ifindex = 39
TwoGigabitEthernet1/0/21: Ifindex = 28
unrouted VLAN 2101: Ifindex = 76
GigabitEthernet1/1/4: Ifindex = 59
TwoGigabitEthernet1/0/30: Ifindex = 37
unrouted VLAN 1005: Ifindex = 6
TwoGigabitEthernet1/0/23: Ifindex = 30
TwoGigabitEthernet1/0/3: Ifindex = 10
TwoGigabitEthernet1/0/12: Ifindex = 19
TenGigabitEthernet1/0/44: Ifindex = 51
TwoGigabitEthernet1/0/1: Ifindex = 8
TwoGigabitEthernet1/0/10: Ifindex = 17
TenGigabitEthernet1/0/46: Ifindex = 53
GigabitEthernet1/1/2: Ifindex = 57
FortyGigabitEthernet1/1/2: Ifindex = 69
unrouted VLAN 1003: Ifindex = 7
TwoGigabitEthernet1/0/36: Ifindex = 43
TwoGigabitEthernet1/0/25: Ifindex = 32
TwoGigabitEthernet1/0/34: Ifindex = 41
TenGigabitEthernet1/0/37: Ifindex = 44
TwoGigabitEthernet1/0/27: Ifindex = 34
TwoGigabitEthernet1/0/7: Ifindex = 14
TenGigabitEthernet1/0/40: Ifindex = 47
TwoGigabitEthernet1/0/16: Ifindex = 23
unrouted VLAN 2611: Ifindex = 78
TwoGigabitEthernet1/0/5: Ifindex = 12
TenGigabitEthernet1/0/42: Ifindex = 49
TwoGigabitEthernet1/0/14: Ifindex = 21
TenGigabitEthernet1/1/3: Ifindex = 62
TenGigabitEthernet1/0/39: Ifindex = 46
TwoGigabitEthernet1/0/29: Ifindex = 36
TenGigabitEthernet1/1/1: Ifindex = 60
StackSub-St1-1: Ifindex = 71
Bluetooth0/4: Ifindex = 80
unrouted VLAN 1: Ifindex = 3
unrouted VLAN 99: Ifindex = 75
unrouted VLAN 2521: Ifindex = 77
TwoGigabitEthernet1/0/9: Ifindex = 16
TwoGigabitEthernet1/0/18: Ifindex = 25
TwentyFiveGigE1/1/2: Ifindex = 82
TenGigabitEthernet1/1/7: Ifindex = 66
TenGigabitEthernet1/1/5: Ifindex = 64
AppGigabitEthernet1/0/1: Ifindex = 83
StackPort1: Ifindex = 70
TenGigabitEthernet1/0/48: Ifindex = 55
TwoGigabitEthernet1/0/20: Ifindex = 27
Null0: Ifindex = 2
TwoGigabitEthernet1/0/33: Ifindex = 40
TwoGigabitEthernet1/0/22: Ifindex = 29
TenGigabitEthernet1/1/8: Ifindex = 67
TwoGigabitEthernet1/0/31: Ifindex = 38
unrouted VLAN 1004: Ifindex = 5
Port-channel1: Ifindex = 79
TenGigabitEthernet1/0/45: Ifindex = 52
TwoGigabitEthernet1/0/13: Ifindex = 20
TwoGigabitEthernet1/0/2: Ifindex = 9
GigabitEthernet0/0: Ifindex = 1
TenGigabitEthernet1/0/47: Ifindex = 54
TwoGigabitEthernet1/0/11: Ifindex = 18
TwoGigabitEthernet1/0/24: Ifindex = 31
GigabitEthernet1/1/3: Ifindex = 58
unrouted VLAN 1002: Ifindex = 4
TwoGigabitEthernet1/0/26: Ifindex = 33
FortyGigabitEthernet1/1/1: Ifindex = 68
GigabitEthernet1/1/1: Ifindex = 56
TwoGigabitEthernet1/0/35: Ifindex = 42
Vlan1: Ifindex = 73
TwoGigabitEthernet1/0/17: Ifindex = 24
TenGigabitEthernet1/0/41: Ifindex = 48
TwoGigabitEthernet1/0/6: Ifindex = 13
TwoGigabitEthernet1/0/15: Ifindex = 22
TenGigabitEthernet1/0/43: Ifindex = 50
TwoGigabitEthernet1/0/4: Ifindex = 11
TenGigabitEthernet1/0/38: Ifindex = 45
TwoGigabitEthernet1/0/28: Ifindex = 35
TenGigabitEthernet1/1/2: Ifindex = 61
StackSub-St1-2: Ifindex = 72
unrouted VLAN 2522: Ifindex = 84
TwoGigabitEthernet1/0/19: Ifindex = 26
TwoGigabitEthernet1/0/8: Ifindex = 15
TenGigabitEthernet1/1/6: Ifindex = 65
TenGigabitEthernet1/1/4: Ifindex = 63
TwentyFiveGigE1/1/1: Ifindex = 81
```
</details>

## Impact (If any)
None

## Screenshots:
Before: Unrouted VLANs are not properly matched by the existing pattern
![image](https://user-images.githubusercontent.com/14773841/143946895-1a86e68d-7536-4919-bbc6-e8346c84c07f.png)
Now: New pattern matches and parses unrouted VLAN entries
![image](https://user-images.githubusercontent.com/14773841/143946986-67518e7e-eaed-4de2-8e0f-432e547d722c.png)


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
