### PR TITLE
Fix Issue#587

### DIFF
--- a/changelog/undistributed/changelog_showbgpneighbors
+++ b/changelog/undistributed/changelog_showbgpneighbors
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                                Update
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowBgpNeighborsReceivedRoutesSuperParser() parser
+        * Updated regex to make the CIDR notation optional
+

--- a/src/genie/libs/parser/iosxe/show_bgp.py
+++ b/src/genie/libs/parser/iosxe/show_bgp.py
@@ -5431,11 +5431,11 @@ class ShowBgpNeighborsReceivedRoutesSuperParser(ShowBgpNeighborsReceivedRoutesSc
         p3_2 = re.compile(r'^\s*(?P<status_codes>(s|x|S|d|h|\*|\>|\s)+)'
                             '(?P<path_type>(i|e|c|l|a|r|I))?(\s)?'
                             '(?P<prefix>(([0-9]+[\.][0-9]+[\.][0-9]+'
-                            '[\.][0-9]+[\/][0-9]+)|([a-zA-Z0-9]+[\:]'
+                            '[\.][0-9]+(?:[\/][0-9]+)?)|([a-zA-Z0-9]+[\:]'
                             '[a-zA-Z0-9]+[\:][a-zA-Z0-9]+[\:]'
                             '[a-zA-Z0-9]+[\:][\:][\/][0-9]+)|'
                             '([a-zA-Z0-9]+[\:][a-zA-Z0-9]+[\:]'
-                            '[a-zA-Z0-9]+[\:][\:][\/][0-9]+)))'
+                            '[a-zA-Z0-9]+[\:][\:](?:[\/][0-9]+)?)))'
                             ' +(?P<next_hop>[a-zA-Z0-9\.\:]+)'
                             ' +(?P<numbers>[a-zA-Z0-9\s\(\)\{\}]+)'
                             ' +(?P<origin_codes>(i|e|\?|\&|\|))$')


### PR DESCRIPTION
## Description
Updated REGEX for the parser for "show ip bgp neighbors <neighbor> received-routes" to make the CIDR notation after the prefix optional, as when it's not optional, some routes don't get parsed if they don't have the /CIDR notation.

## Motivation and Context
As reported in Issue#587, when running "show ip bgp neighbors <neighbor> received-routes" on a device, if run it manually, in one example i saw 91 prefixes. When using pyATS parser for this command, i only saw 85 prefixes. 6 of the prefixes received were just the subnet address, with no /CIDR notation, and these 6 routes did not get parsed. With this REGEX update, the parser will capture these routes as well.


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
