### PR TITLE
Fixed ShowPowerInline parsing for Cat45xxR

### DIFF
--- a/changelog/undistributed/changelog_fix_iosxe_ShowPowerInline_202112101042.rst
+++ b/changelog/undistributed/changelog_fix_iosxe_ShowPowerInline_202112101042.rst
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowPowerInline:
+        * Re-named regex pattern p1 to p1a and changed the pattern for <power> & <max> to always include ´.´,
+          to avoid falsely matching of Cat45xxR outputs.
+        * Added regex pattern p1b to cover 'show power inline' output from Cat45xxR.
+        

--- a/src/genie/libs/parser/iosxe/tests/ShowPowerInline/cli/equal/golden_output_4_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowPowerInline/cli/equal/golden_output_4_expected.py
@@ -1,0 +1,37 @@
+expected_output = {
+    'interface': {
+        'GigabitEthernet1/1': {
+            'admin_state': 'auto',
+            'max': 0.0,
+            'oper_state': 'off',
+            'power': 0.0,
+        },
+        'GigabitEthernet1/19': {
+            'admin_state': 'auto',
+            'class': '0',
+            'device': 'CTS-CODEC-inTouch',
+            'max': 16.2,
+            'oper_state': 'on',
+            'power': 15.4,
+        },
+        'GigabitEthernet2/5': {
+            'admin_state': 'auto',
+            'class': '3',
+            'device': 'IP Phone 7937',
+            'max': 11.1,
+            'oper_state': 'on',
+            'power': 10.5,
+        },
+        'GigabitEthernet5/48': {
+            'admin_state': 'auto',
+            'class': '4',
+            'device': 'AIR-AP2802I-B-K9',
+            'max': 27.5,
+            'oper_state': 'on',
+            'power': 26.1,
+        },
+    },
+    'watts': {
+        '0': {'available': 4800.0, 'module': '0', 'remaining': 4108.0, 'used': 692.0}
+    },
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowPowerInline/cli/equal/golden_output_4_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowPowerInline/cli/equal/golden_output_4_output.txt
@@ -1,0 +1,13 @@
+Available:4800(w)  Used:692(w)  Remaining:4108(w)
+
+Interface Admin  Oper            Power(Watts)     Device              Class
+                            From PS    To Device                    
+--------- ------ ---------- ---------- ---------- ------------------- -----
+
+Gi1/1     auto   off        0.0        0.0        n/a                 n/a  
+Gi1/19    auto   on         16.2       15.4       CTS-CODEC-inTouch   0    
+Gi2/5     auto   on         11.1       10.5       IP Phone 7937       3    
+Gi5/48    auto   on         27.5       26.1       AIR-AP2802I-B-K9    4    
+--------- ------ ---------- ---------- ---------- ------------------- -----
+
+Totals:          48   on    692.8      658.1 


### PR DESCRIPTION
## Description
Fixed an issue in ShowPowerInline for IOS-XE where the output from Cat45xxR devices wasn't parsed properly due to different column order.

## Motivation and Context
The current parser works with the column layout:
`Interface Admin  Oper       Power   Device              Class Max`  
While Cat45xxR have the column layout:
`Interface Admin  Oper            From PS    To Device     Device              Class`  

The current parser will interpret the Cat45xxR output like this:
![Issue found](https://user-images.githubusercontent.com/66589153/145576010-1031f0fc-2480-46bb-b5e3-18b81c4f857d.JPG)

The updated parser will work correctly with Cat45xxR outputs:
![Fixed Issue](https://user-images.githubusercontent.com/66589153/145576215-93785950-ef3b-4937-9bdc-99f8dd0dc61a.JPG)

And the current layout also still works:
![Current output still ok](https://user-images.githubusercontent.com/66589153/145576328-2d231cb5-cfb9-4b6a-92b8-e6d9d7e8c0a1.JPG)

## Impact (If any)
None expected. But two potential caveats:
- Power & Max columns now must include a decimal-point `.`. All outputs I've checked does have this, but could be a corner case?
- Cat45xxR doesn't have a Max reading, but rather the Power From PS. A bit similar, but not the exact same purpose. Good enough for me at least.

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [ ] All new code passed compilation.
