### PR TITLE
show pim details fix

### DIFF
--- a/src/genie/libs/parser/iosxr/show_pim.py
+++ b/src/genie/libs/parser/iosxr/show_pim.py
@@ -300,7 +300,7 @@ class ShowPimVrfInterfaceDetail(ShowPimVrfInterfaceDetailSchema):
 
             # Propagation delay : 500
             p9 = re.compile(r'^Propagation +delay *:'
-                             ' +(?P<propagation_delay>[0-9]+)$')
+                             ' +(?P<propagation_delay>[0-9]+)')
             m = p9.match(line)
             if m:
                 sub_dict['propagation_delay'] = \
@@ -309,7 +309,7 @@ class ShowPimVrfInterfaceDetail(ShowPimVrfInterfaceDetailSchema):
 
             # Override Interval : 2500
             p10 = re.compile(r'^Override +Interval *:'
-                              ' +(?P<override_interval>[0-9]+)$')
+                              ' +(?P<override_interval>[0-9]+)')
             m = p10.match(line)
             if m:
                 sub_dict['override_interval'] = \


### PR DESCRIPTION

## Description
removed the end of line check enforced in 2 fields regular expression matches
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
show pim vrf <vrf> <address_family> interface detail
can return 
```
Bundle-Ether1.111          on   1     11     111
    Primary Address : 1.1.1.1
              Flags : B NP V
                BFD : Off/150 ms/3
                 DR : 1.1.1.1
  Propagation delay : 100    (config: 100)
  Override Interval : 400    (config: 400)
        Hello Timer : 00:00:20
    Neighbor Filter : -
```

in details, **Propagation delay** and **Override Interval** can return something different that the currently expected integer only.
enforcing end of line in the regular expression crashes execution in this valid scenario.
This situation can probably true also for other devices/os/fields. but I do not have enough knowledge to go further. 

To be more consistent with actual output of the device, the parser should return the whole string, but it is not probably required and  might break a lot of projects.
for this reason the proposed fix is just not to enforce end of line after the integer for those 2 properties, i do not see any drawback in doing this, if this is an acceptable way to solve the issue in general the ending '$' should probably be avoided in basically all fields to avoid future problems that might arise the same problematic.



## Impact (If any)
none expected

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
