### PR TITLE
SchemaMissingKeyError Fixes #635

### DIFF
--- a/changelog/undistributed/changelog_show_snmp_iosxe_20220306232929.rst
+++ b/changelog/undistributed/changelog_show_snmp_iosxe_20220306232929.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * modified showsnmp:
+        * updated the ShowSnmpSchema 'contact' key to fix SchemaMissingKeyError
+	* added new unittest to test this change of schema

--- a/changelog/undistributed/changelog_show_snmp_iosxe_20220306232929.rst
+++ b/changelog/undistributed/changelog_show_snmp_iosxe_20220306232929.rst
@@ -2,6 +2,5 @@
                             Fix
 --------------------------------------------------------------------------------
 * IOSXE
-    * modified showsnmp:
-        * updated the ShowSnmpSchema 'contact' key to fix SchemaMissingKeyError
-	* added new unittest to test this change of schema
+    * Modified ShowSnmp:
+        * updated the ShowSnmpSchema 'contact' key to be optional

--- a/src/genie/libs/parser/iosxe/show_snmp.py
+++ b/src/genie/libs/parser/iosxe/show_snmp.py
@@ -91,7 +91,7 @@ class ShowSnmpSchema(MetaParser):
 
     schema = {
         "chassis": str,
-        "contact": str,
+        Optional("contact"): str,
         Optional("location"): Optional(str),
         "snmp_input": {
             "packet_count": int,

--- a/src/genie/libs/parser/iosxe/tests/ShowSnmp/cli/equal/golden_output_1_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowSnmp/cli/equal/golden_output_1_expected.py
@@ -1,0 +1,62 @@
+expected_output = {
+    "chassis": "FCE2310A48M",
+    "snmp_input": {
+        "packet_count": 35072424,
+        "bad_snmp_version_errors": 0,
+        "unknown_community_name": 2089,
+        "illegal_operation_for_community_name_supplied": 68,
+        "encoding_errors": 0,
+        "number_of_requested_variables": 341796946,
+        "number_of_altered_variables": 7328,
+        "get_request_pdus": 954173,
+        "get_next_pdus": 31072480,
+        "set_request_pdus": 3878,
+        "input_queue_drops": 0,
+        "maximum_queue_size": 1000
+    },
+    "snmp_output": {
+        "packet_count": 35598123,
+        "too_big_errors": 0,
+        "maximum_packet_size": 1500,
+        "no_such_name_errors": 1,
+        "bad_value_errors": 0,
+        "general_errors": 0,
+        "response_pdus": 322899,
+        "trap_pdus": 527788
+    },
+    "snmp_input_queue": 0,
+    "snmp_global_trap": "enabled",
+    "snmp_logging": {
+        "status": "enabled",
+        "endpoints": {
+            "10.76.1.12": {
+                "port": 151,
+                "queue": 0,
+                "queue_size": 10,
+                "sent": 102045,
+                "dropped": 3065
+            },
+            "10.76.133.10": {
+                "port": 111,
+                "queue": 0,
+                "queue_size": 10,
+                "sent": 102045,
+                "dropped": 3065
+            },
+            "10.16.154.186": {
+                "port": 169,
+                "queue": 0,
+                "queue_size": 10,
+                "sent": 201075,
+                "dropped": 11383
+            },
+            "10.166.67.19": {
+                "port": 108,
+                "queue": 0,
+                "queue_size": 10,
+                "sent": 102045,
+                "dropped": 3065
+            }           
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowSnmp/cli/equal/golden_output_1_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowSnmp/cli/equal/golden_output_1_output.txt
@@ -1,0 +1,27 @@
+Chassis: FCE2310A48M
+35072424 SNMP packets input
+    0 Bad SNMP version errors
+    2089 Unknown community name
+    68 Illegal operation for community name supplied
+    0 Encoding errors
+    341796946 Number of requested variables
+    7328 Number of altered variables
+    954173 Get-request PDUs
+    31072480 Get-next PDUs
+    3878 Set-request PDUs
+    0 Input queue packet drops (Maximum queue size 1000)
+35598123 SNMP packets output
+    0 Too big errors (Maximum packet size 1500)
+    1 No such name errors
+    0 Bad values errors
+    0 General errors
+    322899 Response PDUs
+    527788 Trap PDUs
+Packets currently in SNMP process input queue: 0
+SNMP global trap: enabled
+
+SNMP logging: enabled
+    Logging to 10.76.1.12.151, 0/10, 102045 sent, 3065 dropped.
+    Logging to 10.76.133.10.111, 0/10, 102045 sent, 3065 dropped.
+    Logging to 10.16.154.186.169, 0/10, 201075 sent, 11383 dropped.
+    Logging to 10.166.67.19.108, 0/10, 102045 sent, 3065 dropped.


### PR DESCRIPTION
## Description
This pull request is raised to fix the #635 as when you do not configure the 'contact' under snmp, it will throw the following error.
`
genie.metaparser.util.exceptions.SchemaMissingKeyError: Missing keys: [['contact']]
`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Impact (If any)
No impact expected, only editing a single key 

## Screenshots:

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
