### PR TITLE
Fix parser for show flow exporter statistics if exporter contains special character

### DIFF
--- a/changelog/undistributed/changelog_iosxe_show_flow_exporter_statistics_20220407114823.rst
+++ b/changelog/undistributed/changelog_iosxe_show_flow_exporter_statistics_20220407114823.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* iosxe
+    * Modified ShowFlowExporterStatistics:
+        * Updated regex pattern to accommodate NetFlow exporters that have names containing special characters.

--- a/src/genie/libs/parser/iosxe/show_flow.py
+++ b/src/genie/libs/parser/iosxe/show_flow.py
@@ -458,7 +458,7 @@ class ShowFlowExporterStatistics(ShowFlowExporterStatisticsSchema):
                 output = self.device.execute(self.cli_command[1].format(exporter=exporter))
 
         # Flow Exporter test
-        p1 = re.compile(r"^Flow +Exporter +(?P<exporter>\w+):$")
+        p1 = re.compile(r"^Flow +Exporter +(?P<exporter>\S+):$")
 
         # Packet send statistics (last cleared 00:10:10 ago):
         p2 = re.compile(r"^Packet +send +statistics +\(last +cleared +(?P<last_cleared>[\d:]+) +ago\):$")

--- a/src/genie/libs/parser/iosxe/tests/ShowFlowExporterStatistics/cli/equal/golden_output2_exporter_arguments.json
+++ b/src/genie/libs/parser/iosxe/tests/ShowFlowExporterStatistics/cli/equal/golden_output2_exporter_arguments.json
@@ -1,0 +1,3 @@
+{
+    "exporter": "rest"
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowFlowExporterStatistics/cli/equal/golden_output2_exporter_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowFlowExporterStatistics/cli/equal/golden_output2_exporter_expected.py
@@ -1,0 +1,19 @@
+expected_output = {
+    "flow_exporter": {
+        "test-exporter": {
+            "pkt_send_stats": {
+                "last_cleared": "00:10:17",
+                "successfully_sent": 6,
+                "successfully_sent_bytes": 410,
+                "reason_not_given": 163,
+                "reason_not_given_bytes": 7820,
+            },
+            "client_send_stats": {
+                "Flow Monitor Test": {
+                    "records_added": {"total": 21, "sent": 8, "failed": 13},
+                    "bytes_added": {"total": 1260, "sent": 145, "failed": 1115},
+                }
+            },
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowFlowExporterStatistics/cli/equal/golden_output2_exporter_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowFlowExporterStatistics/cli/equal/golden_output2_exporter_output.txt
@@ -1,0 +1,16 @@
+
+show flow exporter test-exporter statistics
+Flow Exporter test-exporter:
+  Packet send statistics (last cleared 00:10:17 ago):
+    Successfully sent:         6                     (410 bytes)
+    Reason not given:          163                   (7820 bytes)
+
+  Client send statistics:
+    Client: Flow Monitor Test
+      Records added:           21
+        - sent:                8
+        - failed to send:      13
+      Bytes added:             1260
+        - sent:                145
+        - failed to send:      1115
+    


### PR DESCRIPTION
## Description
This PR fixes the issue reported in #648, where the parser for `show flow exporter statistics` fails if the name of the NetFlow exporter contains a special character.

## Motivation and Context
This change fixes a defect in the `show flow exporter statistics` parser.

## Impact (If any)
No negative impact is anticipated from this change.

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->
All tests (existing and new) passing per output below.
```
2022-04-07T11:42:51: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-04-07T11:42:51: %GENIE-INFO: |                                   Summary                                    |
2022-04-07T11:42:51: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-04-07T11:42:51: %GENIE-INFO:  Number of ABORTED                                                            0
2022-04-07T11:42:51: %GENIE-INFO:  Number of BLOCKED                                                            0
2022-04-07T11:42:51: %GENIE-INFO:  Number of ERRORED                                                            0
2022-04-07T11:42:51: %GENIE-INFO:  Number of FAILED                                                             0
2022-04-07T11:42:51: %GENIE-INFO:  Number of PASSED                                                            19
2022-04-07T11:42:51: %GENIE-INFO:  Number of PASSX                                                              0
2022-04-07T11:42:51: %GENIE-INFO:  Number of SKIPPED                                                            0
2022-04-07T11:42:51: %GENIE-INFO:  Total Number                                                                19
2022-04-07T11:42:51: %GENIE-INFO:  Success Rate                                                            100.0%
2022-04-07T11:42:51: %GENIE-INFO: --------------------------------------------------------------------------------
2022-04-07T11:42:51: %GENIE-INFO:  Total Parsers Missing Unittests                                            255
2022-04-07T11:42:51: %GENIE-INFO: --------------------------------------------------------------------------------
2022-04-07T11:42:51: %GENIE-INFO:  Total Passing Unittests                                                   5829
2022-04-07T11:42:51: %GENIE-INFO:  Total Failed Unittests                                                       0
2022-04-07T11:42:51: %GENIE-INFO:  Total Errored Unittests                                                      0
2022-04-07T11:42:51: %GENIE-INFO:  Total Unittests                                                           5829
2022-04-07T11:42:51: %GENIE-INFO: --------------------------------------------------------------------------------
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
