### PR TITLE
added omp to iosxe show_route

### DIFF
--- a/changelog/undistributed/changelog_iosxe_show_routing_omp_source_protocol_20220418083332.rst
+++ b/changelog/undistributed/changelog_iosxe_show_routing_omp_source_protocol_20220418083332.rst
@@ -1,0 +1,12 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* iosxe
+    * Modified  ShowIpRouteDistributor:
+        * added omp to the protocol_set dictionary.
+    * Modified  ShowIpv6RouteDistributor:
+        * added omp to the protocol_set dictionary.
+    * Modified  ShowIpRoute:
+        * added omp to the source_protocol_dict dictionary.
+    * Modified  ShowIpv6RouteUpdated:
+        * added omp to the source_protocol_dict dictionary.    

--- a/src/genie/libs/parser/iosxe/show_routing.py
+++ b/src/genie/libs/parser/iosxe/show_routing.py
@@ -22,7 +22,7 @@ class ShowIpRouteDistributor(MetaParser):
                    'show ip route {protocol}']
 
     protocol_set = {'ospf', 'odr', 'isis', 'eigrp', 'static', 'mobile',
-                    'rip', 'lisp', 'nhrp', 'local', 'connected', 'bgp'}
+                    'rip', 'lisp', 'nhrp', 'local', 'connected', 'bgp', 'omp'}
 
     def cli(self, vrf=None, route=None, protocol=None, output=None):
 
@@ -68,7 +68,7 @@ class ShowIpv6RouteDistributor(MetaParser):
                    'show ipv6 route vrf {vrf} interface {interface}']
 
     protocol_set = {'ospf', 'odr', 'isis', 'eigrp', 'static', 'mobile',
-                    'rip', 'lisp', 'nhrp', 'local', 'connected', 'bgp'}
+                    'rip', 'lisp', 'nhrp', 'local', 'connected', 'bgp', 'omp'}
 
     def cli(self, vrf=None, route=None, protocol=None, interface=None, output=None):
         
@@ -220,6 +220,7 @@ class ShowIpRoute(ShowIpRouteSchema):
         source_protocol_dict['connected'] = ['C', '+', '%', 'p', '&']
         source_protocol_dict['local_connected'] = ['LC']
         source_protocol_dict['bgp'] = ['B', '+', '%', 'p', '&']
+        source_protocol_dict['omp'] = ['m']
 
         result_dict = {}
 
@@ -787,6 +788,7 @@ class ShowIpv6RouteUpdated(ShowIpv6RouteUpdatedSchema):
         source_protocol_dict['nd'] = ['ND','NDp']
         source_protocol_dict['destination'] = ['DCE']
         source_protocol_dict['redirect'] = ['NDr']
+        source_protocol_dict['omp'] = ['m']
 
         result_dict = {}
         # IPv6 Routing Table - default - 23 entries


### PR DESCRIPTION
added omp to iosxe show_route

## Description
Added OMP to the source protocols parsed. 
* iosxe
    * Modified  ShowIpRouteDistributor:
        * added omp to the protocol_set dictionary.
    * Modified  ShowIpv6RouteDistributor:
        * added omp to the protocol_set dictionary.
    * Modified  ShowIpRoute:
        * added omp to the source_protocol_dict dictionary.
    * Modified  ShowIpv6RouteUpdated:
        * added omp to the source_protocol_dict dictionary.    


## Motivation and Context
OMP (m protocol code) was not found when parsing iosxe show ip route vrf <vrf_number> command.

## Impact (If any)
Parsed can now be used with SDWAN iosxe routers. 
## Screenshots:
```
python folder_parsing_job.py -o iosxe -c ShowIpRoute
2022-04-18T09:08:03: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:03: %AETEST-INFO: |                   Starting testcase SuperFileBasedTesting                    |
2022-04-18T09:08:03: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:03: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:03: %AETEST-INFO: |                            Starting section setup                            |
2022-04-18T09:08:03: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: The result of section setup is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: The result of testcase SuperFileBasedTesting is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: |                           Starting testcase iosxe                            |
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: |                            Starting section setup                            |
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: The result of section setup is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: |                         Starting section ShowIpRoute                         |
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :                    Starting STEP 1: iosxe -> ShowIpRoute                     :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :            Starting STEP 1.1: Test Golden -> iosxe -> ShowIpRoute            :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :     Starting STEP 1.1.1: Gold -> iosxe -> ShowIpRoute -> golden_output1      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxe -> ShowIpRoute -> golden_output1 is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :     Starting STEP 1.1.2: Gold -> iosxe -> ShowIpRoute -> golden_output2      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1.2: Gold -> iosxe -> ShowIpRoute -> golden_output2 is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :     Starting STEP 1.1.3: Gold -> iosxe -> ShowIpRoute -> golden_output3      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1.3: Gold -> iosxe -> ShowIpRoute -> golden_output3 is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :     Starting STEP 1.1.4: Gold -> iosxe -> ShowIpRoute -> golden_output4      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1.4: Gold -> iosxe -> ShowIpRoute -> golden_output4 is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :     Starting STEP 1.1.5: Gold -> iosxe -> ShowIpRoute -> golden_output5      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1.5: Gold -> iosxe -> ShowIpRoute -> golden_output5 is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :     Starting STEP 1.1.6: Gold -> iosxe -> ShowIpRoute -> golden_output6      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1.6: Gold -> iosxe -> ShowIpRoute -> golden_output6 is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowIpRoute is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :            Starting STEP 1.2: Test Empty -> iosxe -> ShowIpRoute             :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: :      Starting STEP 1.2.1: Empty -> iosxe -> ShowIpRoute -> empty_output      :
2022-04-18T09:08:04: %AETEST-INFO: +..............................................................................+
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowIpRoute -> empty_output is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowIpRoute is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: The result of STEP 1: iosxe -> ShowIpRoute is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +..........................................................+
2022-04-18T09:08:04: %AETEST-INFO: :                       STEPS Report                       :
2022-04-18T09:08:04: %AETEST-INFO: +..........................................................+
2022-04-18T09:08:04: %AETEST-INFO: STEP 1 - iosxe -> ShowIpRoute                     Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowIpRoute    Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxe -> ShowIpRoute -> golden_output1Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1.2 - Gold -> iosxe -> ShowIpRoute -> golden_output2Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1.3 - Gold -> iosxe -> ShowIpRoute -> golden_output3Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1.4 - Gold -> iosxe -> ShowIpRoute -> golden_output4Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1.5 - Gold -> iosxe -> ShowIpRoute -> golden_output5Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.1.6 - Gold -> iosxe -> ShowIpRoute -> golden_output6Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowIpRoute     Passed
2022-04-18T09:08:04: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowIpRoute -> empty_outputPassed
2022-04-18T09:08:04: %AETEST-INFO: ............................................................
2022-04-18T09:08:04: %AETEST-INFO: The result of section ShowIpRoute is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: |                           Starting section cleanup                           |
2022-04-18T09:08:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %AETEST-INFO: The result of section cleanup is => PASSED
2022-04-18T09:08:04: %AETEST-INFO: The result of testcase iosxe is => PASSED
2022-04-18T09:08:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %GENIE-INFO: |                               Unittest results                               |
2022-04-18T09:08:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %GENIE-INFO:  SECTIONS/TESTCASES                                                      RESULT
2022-04-18T09:08:04: %GENIE-INFO: --------------------------------------------------------------------------------
2022-04-18T09:08:04: %GENIE-INFO: .
2022-04-18T09:08:04: %GENIE-INFO: |-- SuperFileBasedTesting                                                 PASSED
2022-04-18T09:08:04: %GENIE-INFO: |   `-- setup                                                             PASSED
2022-04-18T09:08:04: %GENIE-INFO: `-- iosxe                                                                 PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |-- setup                                                             PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |-- ShowIpRoute                                                       PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1: iosxe -> ShowIpRoute                                  PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1: Test Golden -> iosxe -> ShowIpRoute                 PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1.1: Gold -> iosxe -> ShowIpRoute -> golden_output1    PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1.2: Gold -> iosxe -> ShowIpRoute -> golden_output2    PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1.3: Gold -> iosxe -> ShowIpRoute -> golden_output3    PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1.4: Gold -> iosxe -> ShowIpRoute -> golden_output4    PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1.5: Gold -> iosxe -> ShowIpRoute -> golden_output5    PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.1.6: Gold -> iosxe -> ShowIpRoute -> golden_output6    PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   |-- Step 1.2: Test Empty -> iosxe -> ShowIpRoute                  PASSED
2022-04-18T09:08:04: %GENIE-INFO:     |   `-- Step 1.2.1: Empty -> iosxe -> ShowIpRoute -> empty_output     PASSED
2022-04-18T09:08:04: %GENIE-INFO:     `-- cleanup                                                           PASSED
2022-04-18T09:08:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %GENIE-INFO: |                                   Summary                                    |
2022-04-18T09:08:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-04-18T09:08:04: %GENIE-INFO:  Number of ABORTED                                                            0
2022-04-18T09:08:04: %GENIE-INFO:  Number of BLOCKED                                                            0
2022-04-18T09:08:04: %GENIE-INFO:  Number of ERRORED                                                            0
2022-04-18T09:08:04: %GENIE-INFO:  Number of FAILED                                                             0
2022-04-18T09:08:04: %GENIE-INFO:  Number of PASSED                                                             2
2022-04-18T09:08:04: %GENIE-INFO:  Number of PASSX                                                              0
2022-04-18T09:08:04: %GENIE-INFO:  Number of SKIPPED                                                            0
2022-04-18T09:08:04: %GENIE-INFO:  Total Number                                                                 2
2022-04-18T09:08:04: %GENIE-INFO:  Success Rate                                                            100.0%
2022-04-18T09:08:04: %GENIE-INFO: --------------------------------------------------------------------------------
2022-04-18T09:08:04: %GENIE-INFO:  Total Passing Unittests                                                      7
2022-04-18T09:08:04: %GENIE-INFO:  Total Failed Unittests                                                       0
2022-04-18T09:08:04: %GENIE-INFO:  Total Errored Unittests                                                      0
2022-04-18T09:08:04: %GENIE-INFO:  Total Unittests                                                              7
2022-04-18T09:08:04: %GENIE-INFO: --------------------------------------------------------------------------------
```
## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
