### PR TITLE
Updated source_template parser

### DIFF
--- a/changelog/2022/june.rst
+++ b/changelog/2022/june.rst
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+                                    Modified                                    
+--------------------------------------------------------------------------------
+
+* iosxe
+    * Updated ShowRun
+        * Modified show run parser for (dot1x) source_template to handle special characters in the template's name.
+
+

--- a/src/genie/libs/parser/iosxe/show_run.py
+++ b/src/genie/libs/parser/iosxe/show_run.py
@@ -646,8 +646,8 @@ class ShowRunInterface(ShowRunInterfaceSchema):
         # switchport port-security mac-address sticky 1020.4bb1.6f2f
         p61 = re.compile(r"^switchport port-security mac-address sticky (?P<value>([a-fA-F\d]{4}\.){2}[a-fA-F\d]{4})$")
 
-        # source template USER_NoAuth
-        p62 = re.compile(r"^source template (?P<template>\w+)$")
+        # source template USER_No_802.1X_Auth
+        p62 = re.compile(r"^source template (?P<template>[a-zA-Z0-9@#$&()-`.+,/]*)$")
 
         # host-reachability protocol bgp
         p63 = re.compile(r'^host-reachability protocol (?P<protocol>[a-zA-Z]+)$')


### PR DESCRIPTION
## Description
A bug is simply a situation we haven't thought of.
While parsing a "show run" for an interface, I hit the following line `source template 802.1X_PORT_AUTH_TEMPLATE` that did not parse the source template attribute.
The current parser doesn't handle special characters in the templates' names.

## Motivation and Context
Allow the parser to handle special characters in the templates' names.

## Impact (If any)
<!--- If there is any negative impact - what is it? -->

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
