### PR TITLE
Fixing #668. checking that there are eigrp neighbors; otherwise, returning empty dict

### DIFF
--- a/changelog/2022/june.rst
+++ b/changelog/2022/june.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                                      Fix                                       
+--------------------------------------------------------------------------------
+
+* iosxe
+    * Modified ShowEigrpNeighborsSuperParser
+        * It checks if there are no eigrp neighbors, returning an empty dict if so.

--- a/src/genie/libs/parser/iosxe/show_eigrp.py
+++ b/src/genie/libs/parser/iosxe/show_eigrp.py
@@ -73,6 +73,8 @@ class ShowEigrpNeighborsSchema(MetaParser):
 class ShowEigrpNeighborsSuperParser(ShowEigrpNeighborsSchema):
 
     def cli(self, address_family='', vrf='', output=None):
+        if not self.check_neighbor_output_is_not_empty(output):
+            return {}
 
         # EIGRP-IPv4 Neighbors for AS(1100) VRF(VRF1)
         r1 = re.compile(r'^EIGRP\-(?P<address_family>IPv4|IPv6)\s'
@@ -271,6 +273,9 @@ class ShowEigrpNeighborsSuperParser(ShowEigrpNeighborsSchema):
                 continue
 
         return parsed_dict
+
+    def check_neighbor_output_is_not_empty(self, output):
+        return len(output.splitlines()) > 1
 
 
 # ===============================================


### PR DESCRIPTION


## Description
Returning empty dictionary when there is not any eigrp neighbor.

## Motivation and Context
It allows to keeps parsing when device has no eigrp neighbor.

## Impact (If any)
N/A

## Screenshots:
N/A
## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
