### PR TITLE
Remove space on regex for command "show isis adjacency vrf"

### DIFF
--- a/src/genie/libs/parser/nxos/show_isis.py
+++ b/src/genie/libs/parser/nxos/show_isis.py
@@ -1106,7 +1106,7 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
         result_dict = {}
 
         # IS-IS Process: test VRF: default
-        p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF: +(?P<vrf>\S+)$')
+        p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF:+(?P<vrf>\S+)$')
 
         # System ID       SNPA            Level  State  Hold Time  Interface
         # R2_xr           fa16.3eff.4abd  1      UP     00:00:09   Ethernet1/1.115

--- a/src/genie/libs/parser/nxos/show_isis.py
+++ b/src/genie/libs/parser/nxos/show_isis.py
@@ -1106,7 +1106,7 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
         result_dict = {}
 
         # IS-IS Process: test VRF: default
-        p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF:+(?P<vrf>\S+)$')
+        p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF:( |)+(?P<vrf>\S+)$')
 
         # System ID       SNPA            Level  State  Hold Time  Interface
         # R2_xr           fa16.3eff.4abd  1      UP     00:00:09   Ethernet1/1.115


### PR DESCRIPTION
BEFORE : p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF: +(?P<vrf>\S+)$')
AFTER   : p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF:+(?P<vrf>\S+)$')

Remove the space after "VRF:" in the regex.

## Description

Support issue link - https://github.com/CiscoTestAutomation/genieparser/issues/693

## Motivation and Context
On some n9k, when launching command: "show isis adjacency vrf all", the output put a whitespace or not after VRF. So the output can be 
"IS-IS process: process_id VRF: default" or "IS-IS process: process_id VRF:default"

But actually the parser only support a white space.

p1 = re.compile(r'^IS-IS +[Pp]rocess: +(?P<process_id>\S+) +VRF: +(?P<vrf>\S+)$')"

## Impact (If any)

Change regex on parser to support whitespace or not

## Screenshots:

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
