### PR TITLE
add vsmart and vmanage wan-interfaces table output for ShowControlLocalProperties class

### DIFF
--- a/changelog/2022/september.rst
+++ b/changelog/2022/september.rst
@@ -36,6 +36,20 @@
 * cheetah
     * Fix ShowCapwapClientRcb to handle optional keyword
 
+* viptela
+    * Modified ShowControlLocalProperties:
+        * Changed keygen_interval from schema to Optional
+
+        * Changed public_ipv4, public_port, private_ipv4, private_ipv6 from schema to Optional
+        * Changed private_port, vsmart, vmanage, color, state, from schema to Optional
+        * Changed max_cntrl, restrict, control, stun, lr, lb from schema to Optional 
+        * Changed spi_time_remaining, nat_type, vm_con_prf from schema to Optional 
+
+        * Added public_ipv4, public_port, private_ipv4, private_ipv6 into new Optional dictory
+        * Added private_port, vsmart, vmanage, color, state, last_connection into new Optional dictory
+
+        * Changed regex pattern p27 to p27_1 to accommodate vedge win-interfaces table output
+        * Added regex pattern p27_2 to accommodate vsmart and vmanage win-interfaces table output
 
 --------------------------------------------------------------------------------
                                       New                                       

--- a/src/genie/libs/parser/viptela/tests/ShowControlLocalProperties/cli/equal/golden_output1_expected.py
+++ b/src/genie/libs/parser/viptela/tests/ShowControlLocalProperties/cli/equal/golden_output1_expected.py
@@ -1,0 +1,56 @@
+expected_output = {
+    'certificate_not_valid_after': 'Sep 23 04:02:04 2023 GMT',
+    'certificate_not_valid_before': 'Sep 23 04:02:04 2022 GMT',
+    'certificate_status': 'Installed',
+    'certificate_validity': 'Valid',
+    'chassis_num_unique_id': 'aecb941b-00cb-4885-b540-4b91877f0060',
+    'dns_cache_ttl': '0:00:00:00',
+    'dns_name': '10.0.12.26',
+    'domain_id': '1',
+    'no_activity_exp_interval': '0:00:00:20',
+    'number_active_wan_interfaces': '2',
+    'number_vbond_peers': '1',
+    'organization_name': 'vIPtela Inc Regression',
+    'personality': 'vsmart',
+    'port_hopped': 'FALSE',
+    'protocol': 'dtls',
+    'retry_interval': '0:00:00:15',
+    'root_ca_chain_status': 'Installed',
+    'serial_num': '12345701',
+    'site_id': '100',
+    'sp_organization_name': 'vIPtela Inc Regression',
+    'system_ip': '172.16.255.19',
+    'time_since_last_port_hop': '0:00:00:00',
+    'tls_port': '23456',
+    'token': '-NA-',
+    'wan_interfaces': {
+        '0': {
+            'eth1': {
+                'color': 'default',
+                'last_connection': '0:00:00:13',
+                'private_ipv4': '10.0.5.19',
+                'private_ipv6': '::',
+                'private_port': '12355',
+                'public_ipv4': '10.0.5.19',
+                'public_port': '12355',
+                'state': 'up',
+                'vmanage': '1',
+                'vsmart': '1'
+            }
+        },
+        '1': {
+            'eth1': {
+                'color': 'default',
+                'last_connection': '0:00:00:11',
+                'private_ipv4': '10.0.5.19',
+                'private_ipv6': '::',
+                'private_port': '12455',
+                'public_ipv4': '10.0.5.19',
+                'public_port': '12455',
+                'state': 'up',
+                'vmanage': '0',
+                'vsmart': '0'
+            }
+        },
+    },
+}

--- a/src/genie/libs/parser/viptela/tests/ShowControlLocalProperties/cli/equal/golden_output1_output.txt
+++ b/src/genie/libs/parser/viptela/tests/ShowControlLocalProperties/cli/equal/golden_output1_output.txt
@@ -1,0 +1,43 @@
+ 
+vm9# show control local-properties 
+personality                       vsmart
+sp-organization-name              vIPtela Inc Regression
+organization-name                 vIPtela Inc Regression
+root-ca-chain-status              Installed
+
+certificate-status                Installed
+certificate-validity              Valid
+certificate-not-valid-before      Sep 23 04:02:04 2022 GMT
+certificate-not-valid-after       Sep 23 04:02:04 2023 GMT
+
+dns-name                          10.0.12.26
+site-id                           100
+domain-id                         1
+protocol                          dtls
+tls-port                          23456
+system-ip                         172.16.255.19
+chassis-num/unique-id             aecb941b-00cb-4885-b540-4b91877f0060
+serial-num                        12345701
+subject-serial-num                N/A
+token                             -NA-
+retry-interval                    0:00:00:15
+no-activity-exp-interval          0:00:00:20
+dns-cache-ttl                     0:00:00:00
+port-hopped                       FALSE
+time-since-last-port-hop          0:00:00:00
+cdb-locked                        false
+number-vbond-peers                1
+
+INDEX   IP                                      PORT
+-----------------------------------------------------
+0       10.0.12.26                              12346  
+
+number-active-wan-interfaces      2
+
+                                PUBLIC          PUBLIC PRIVATE         PRIVATE                                 PRIVATE                               LAST
+INSTANCE             INTERFACE  IPv4            PORT   IPv4            IPv6                                    PORT    VS/VM  COLOR            STATE CONNECTION
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+0                    eth1       10.0.5.19       12355  10.0.5.19       ::                                      12355   1/1    default          up    0:00:00:13
+1                    eth1       10.0.5.19       12455  10.0.5.19       ::                                      12455   0/0    default          up    0:00:00:11
+
+


### PR DESCRIPTION
## Description
current ShowControlLocalProperties wan-interfaces table only support vedge.  This PR adding vsmart and vmanage support.

## Motivation and Context
ShowControlLocalProperties support vsmart and vmanage for viptela device

## Impact (If any)
adding new unique key combination, instance+interface, for wan-interfaces dictionary to support multi-instance scenario.  The current folder based test will failed for vsmart and vmanage golden output format.  Need to implement unittest script to verify both vsmart/vmanage and vedge scenario.

## Screenshots:
(.p3) tester@ritayu-vtest:test_genie$ python test_show_control_local_properties.py -v
test_vedge_show_control_local_properties_empty (main.test_vedge_show_control_local_properties) ... ok
test_vedge_show_control_local_properties_full1 (main.test_vedge_show_control_local_properties) ... ok
test_vsmart_show_control_local_properties_empty (main.test_vsmart_show_control_local_properties) ... ok
test_vsmart_show_control_local_properties_full1 (main.test_vsmart_show_control_local_properties) ... ok

## Checklist:
validate my change at viptela sdwan testbed to verify vedge, vsmart and vmanage scenario.

- [Y] I have updated the changelog.
- [N] I have updated the documentation (If applicable). -- no new document
- [Y] I have added tests to cover my changes (If applicable).
- [Y] All new and existing tests passed. -- for unittest based test cases
- [Y] All new code passed compilation.
