### PR TITLE
Changed parser IOS show_platform for cat6k to work with c7600 device

### DIFF
--- a/changelog/undistributed/changelog_show_platform_ios_20221108102747.rst
+++ b/changelog/undistributed/changelog_show_platform_ios_20221108102747.rst
@@ -1,0 +1,13 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOS
+    * Modified ShowPlatform for platform cat6k:
+        * Changed some keys to Optional
+            cpu->[implementation, rev, l2_cache]
+            memory->[packet_buffer, flash_internal_SIMM]
+            last->reload_reason
+        * Updated regex patterns: p11, p14, p31_1 to accommodate output from new device as used in test files
+        * Added regex patterns: p13_1, p13_2 to accommodate output from new device as used in test files
+        * Added new test files: golden_output_c7600_1_*
+

--- a/src/genie/libs/parser/ios/c7600/tests/ShowVersion/cli/equal/golden_output_c7600_1_expected.py
+++ b/src/genie/libs/parser/ios/c7600/tests/ShowVersion/cli/equal/golden_output_c7600_1_expected.py
@@ -1,0 +1,38 @@
+expected_output = {
+    'version': {
+        'bootldr_version': 'Cisco IOS Software, c7600rsp72043_rp Software (c7600rsp72043_rp-ADVIPSERVICESK9-M), Version 12.2(33)SRE11, RELEASE SOFTWARE (fc3)',
+        'chassis': 'CISCO7606-S',
+        'compiled_by': 'prod_rel_team',
+        'compiled_date': 'Fri 12-Sep-14 00:22',
+        'control_processor_uptime': '1 year, 4 weeks, 5 days, 5 hours, 53 minutes',
+        'cpu': {
+            'name': 'MPC8548_E',
+            'speed': '1200MHz',
+        },
+        'curr_config_register': '0x2102',
+        'hostname': 'my-hostname',
+        'image_id': 'c7600rsp72043_rp-ADVIPSERVICESK9-M',
+        'interfaces': {
+            'gigabit_ethernet': 76,
+            'virtual_ethernet': 5,
+        },
+        'last_reload': {
+            'type': 'Normal Reload',
+        },
+        'last_reset': 'power-on',
+        'main_mem': '917504',
+        'memory': {
+            'non_volatile_conf': 3964,
+        },
+        'os': 'IOS',
+        'platform': 'c7600rsp72043_rp',
+        'processor_board_id': 'FOX11290K24',
+        'processor_type': 'M8500',
+        'returned_to_rom_by': 'power cycle (SP by power on)',
+        'rom': 'System Bootstrap, Version 12.2(33r)SRB4, RELEASE SOFTWARE',
+        'rom_version': '(fc1)',
+        'system_image': 'bootdisk:c7600rsp72043-advipservicesk9-mz.122-33.SRE11.bin',
+        'uptime': '1 year, 4 weeks, 5 days, 5 hours, 56 minutes',
+        'version': '12.2(33)SRE11',
+    },
+}

--- a/src/genie/libs/parser/ios/c7600/tests/ShowVersion/cli/equal/golden_output_c7600_1_output.txt
+++ b/src/genie/libs/parser/ios/c7600/tests/ShowVersion/cli/equal/golden_output_c7600_1_output.txt
@@ -1,0 +1,48 @@
+Cisco IOS Software, c7600rsp72043_rp Software (c7600rsp72043_rp-ADVIPSERVICESK9-M), Version 12.2(33)SRE11, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2014 by Cisco Systems, Inc.
+Compiled Fri 12-Sep-14 00:22 by prod_rel_team
+
+ROM: System Bootstrap, Version 12.2(33r)SRB4, RELEASE SOFTWARE (fc1)
+BOOTLDR: Cisco IOS Software, c7600rsp72043_rp Software (c7600rsp72043_rp-ADVIPSERVICESK9-M), Version 12.2(33)SRE11, RELEASE SOFTWARE (fc3)
+
+my-hostname uptime is 1 year, 4 weeks, 5 days, 5 hours, 56 minutes
+Uptime for this control processor is 1 year, 4 weeks, 5 days, 5 hours, 53 minutes
+System returned to ROM by  power cycle (SP by power on)
+System restarted at 12:47:35 MESZ Sat Oct 2 2021
+System image file is "bootdisk:c7600rsp72043-advipservicesk9-mz.122-33.SRE11.bin"
+Last reload type: Normal Reload
+
+
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+
+Cisco CISCO7606-S (M8500) processor (revision 1.0) with 917504K/65536K bytes of memory.
+Processor board ID FOX11290K24
+ BASEBOARD: RSP720
+ CPU: MPC8548_E, Version: 2.0, (0x80390020)
+ CORE: E500, Version: 2.0, (0x80210020)
+ CPU:1200MHz, CCB:400MHz, DDR:200MHz,
+ L1:    D-cache 32 kB enabled
+        I-cache 32 kB enabled
+
+Last reset from power-on
+5 Virtual Ethernet interfaces
+76 Gigabit Ethernet interfaces
+16 Ten Gigabit Ethernet interfaces
+3964K bytes of non-volatile configuration memory.
+
+500472K bytes of Internal ATA PCMCIA card (Sector size 512 bytes).
+Configuration register is 0x2102


### PR DESCRIPTION
## Description
Modified parser for IOS show_platform.py for cat6k

## Motivation and Context
Existing parser did not work for show_version for a C7600 device

## Impact (If any)

## Screenshots:
![image](https://user-images.githubusercontent.com/100724062/200534126-90e2a8e6-480a-4114-8418-179d11ff5f60.png)


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
