### PR TITLE
fixed an issue where ShowIpRoute for iosxe would not parse nat_dia routes of type n and Nd, which would throw an error

### DIFF
--- a/changelog/undistributed/changelog_show_ip_route_iosxe_20221128145747.rst
+++ b/changelog/undistributed/changelog_show_ip_route_iosxe_20221128145747.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* iosxe
+    * Modified ShowIpRoute
+        * Updated source_protocol_dict to support nat dia routes with type "n" and "Nd"

--- a/src/genie/libs/parser/iosxe/show_routing.py
+++ b/src/genie/libs/parser/iosxe/show_routing.py
@@ -225,7 +225,7 @@ class ShowIpRoute(ShowIpRouteSchema):
         source_protocol_dict['Destination'] = ['DCE']
         source_protocol_dict['Redirect'] = ['NDr']
         source_protocol_dict['omp'] = ['m']
-
+        source_protocol_dict['nat_dia'] = ['n', 'Nd']
 
         result_dict = {}
 

--- a/src/genie/libs/parser/iosxe/tests/ShowIpRoute/cli/equal/golden_output11_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpRoute/cli/equal/golden_output11_expected.py
@@ -1,0 +1,313 @@
+expected_output = {
+    "vrf": {
+        "default": {
+            "address_family": {
+                "ipv4": {
+                    "routes": {
+                        "0.0.0.0/0": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "outgoing_interface": {
+                                    "Null0": {"outgoing_interface": "Null0"}
+                                }
+                            },
+                            "route": "0.0.0.0/0",
+                            "route_preference": 6,
+                            "source_protocol": "nat_dia",
+                            "source_protocol_codes": "n*Nd",
+                        },
+                        "10.0.1.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.0.1.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.1.3.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.1.3.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.1.4.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.9",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.1.4.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.128.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.128.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.129.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.129.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.130.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.130.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.131.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.131.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.132.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.132.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.133.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.133.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.140.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.140.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.145.0.0/16": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.145.0.0/16",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.146.2.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.7",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.146.2.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.147.0.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.7",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.147.0.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.147.1.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.7",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.147.1.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.151.99.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:14:21",
+                                    }
+                                }
+                            },
+                            "route": "10.151.99.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                        "10.166.0.0/24": {
+                            "active": True,
+                            "metric": 0,
+                            "next_hop": {
+                                "next_hop_list": {
+                                    1: {
+                                        "index": 1,
+                                        "next_hop": "172.30.1.10",
+                                        "outgoing_interface": "Sdwan-system-intf",
+                                        "updated": "04:13:21",
+                                    }
+                                }
+                            },
+                            "route": "10.166.0.0/24",
+                            "route_preference": 251,
+                            "source_protocol": "omp",
+                            "source_protocol_codes": "m",
+                        },
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowIpRoute/cli/equal/golden_output11_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowIpRoute/cli/equal/golden_output11_output.txt
@@ -1,0 +1,35 @@
+
+R_iosxe#show ip route vrf 1
+Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
+       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area 
+       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+       E1 - OSPF external type 1, E2 - OSPF external type 2, m - OMP
+       n - NAT, Ni - NAT inside, No - NAT outside, Nd - NAT DIA
+       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
+       ia - IS-IS inter area, * - candidate default, U - per-user static route
+       H - NHRP, G - NHRP registered, g - NHRP registration summary
+       o - ODR, P - periodic downloaded static route, l - LISP
+       a - application route
+       + - replicated route, % - next hop override, p - overrides from PfR
+       & - replicated local route overrides by connected
+
+Gateway of last resort is 0.0.0.0 to network 0.0.0.0
+
+n*Nd  0.0.0.0/0 [6/0], 3w2d, Null0
+      10.0.0.0/8 is variably subnetted, 35 subnets, 4 masks
+m        10.0.1.0/24 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.1.3.0/24 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.1.4.0/24 [251/0] via 172.30.1.9, 04:14:21, Sdwan-system-intf
+m        10.128.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.129.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.130.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.131.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.132.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.133.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.140.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.145.0.0/16 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.146.2.0/24 [251/0] via 172.30.1.7, 04:14:21, Sdwan-system-intf
+m        10.147.0.0/24 [251/0] via 172.30.1.7, 04:14:21, Sdwan-system-intf
+m        10.147.1.0/24 [251/0] via 172.30.1.7, 04:14:21, Sdwan-system-intf
+m        10.151.99.0/24 [251/0] via 172.30.1.10, 04:14:21, Sdwan-system-intf
+m        10.166.0.0/24 [251/0] via 172.30.1.10, 04:13:21, Sdwan-system-intf


### PR DESCRIPTION
## Description
Added the following line to iosxe/show_routing.py parser
source_protocol_dict['nat_dia'] = ['n', 'Nd']

## Motivation and Context
Related to issue https://github.com/CiscoTestAutomation/pyats/issues/190.
It fixes an issue where ShowIpRoute for iosxe would not parse nat dia routes of the type n and Nd

## Impact (If any)
No negative impact - Tests passed succesfully.

## Screenshots:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/37215596/204297525-eff53e1a-4b78-4eed-93cb-4eec0d8b2c5c.png">

Full output from test
➜  tests git:(master) ✗ python3 folder_parsing_job.py -o iosxe -c ShowIpRoute
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: |                   Starting testcase SuperFileBasedTesting                    |
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: |                            Starting section setup                            |
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: The result of section setup is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: The result of testcase SuperFileBasedTesting is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: |                           Starting testcase iosxe                            |
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: |                            Starting section setup                            |
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: The result of section setup is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: |                         Starting section ShowIpRoute                         |
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :                    Starting STEP 1: iosxe -> ShowIpRoute                     :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :            Starting STEP 1.1: Test Golden -> iosxe -> ShowIpRoute            :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.1: Gold -> iosxe -> ShowIpRoute -> golden_output1      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxe -> ShowIpRoute -> golden_output1 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.2: Gold -> iosxe -> ShowIpRoute -> golden_output2      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.2: Gold -> iosxe -> ShowIpRoute -> golden_output2 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.3: Gold -> iosxe -> ShowIpRoute -> golden_output3      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.3: Gold -> iosxe -> ShowIpRoute -> golden_output3 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.4: Gold -> iosxe -> ShowIpRoute -> golden_output4      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.4: Gold -> iosxe -> ShowIpRoute -> golden_output4 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.5: Gold -> iosxe -> ShowIpRoute -> golden_output5      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.5: Gold -> iosxe -> ShowIpRoute -> golden_output5 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.6: Gold -> iosxe -> ShowIpRoute -> golden_output6      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.6: Gold -> iosxe -> ShowIpRoute -> golden_output6 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.7: Gold -> iosxe -> ShowIpRoute -> golden_output7      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.7: Gold -> iosxe -> ShowIpRoute -> golden_output7 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.8: Gold -> iosxe -> ShowIpRoute -> golden_output8      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.8: Gold -> iosxe -> ShowIpRoute -> golden_output8 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :     Starting STEP 1.1.9: Gold -> iosxe -> ShowIpRoute -> golden_output11     :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1.9: Gold -> iosxe -> ShowIpRoute -> golden_output11 is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowIpRoute is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :            Starting STEP 1.2: Test Empty -> iosxe -> ShowIpRoute             :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: :      Starting STEP 1.2.1: Empty -> iosxe -> ShowIpRoute -> empty_output      :
2022-11-28T14:54:50: %AETEST-INFO: +..............................................................................+
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowIpRoute -> empty_output is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowIpRoute is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: The result of STEP 1: iosxe -> ShowIpRoute is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +..........................................................+
2022-11-28T14:54:50: %AETEST-INFO: :                       STEPS Report                       :
2022-11-28T14:54:50: %AETEST-INFO: +..........................................................+
2022-11-28T14:54:50: %AETEST-INFO: STEP 1 - iosxe -> ShowIpRoute                     Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowIpRoute    Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxe -> ShowIpRoute -> golden_output1Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.2 - Gold -> iosxe -> ShowIpRoute -> golden_output2Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.3 - Gold -> iosxe -> ShowIpRoute -> golden_output3Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.4 - Gold -> iosxe -> ShowIpRoute -> golden_output4Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.5 - Gold -> iosxe -> ShowIpRoute -> golden_output5Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.6 - Gold -> iosxe -> ShowIpRoute -> golden_output6Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.7 - Gold -> iosxe -> ShowIpRoute -> golden_output7Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.8 - Gold -> iosxe -> ShowIpRoute -> golden_output8Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.1.9 - Gold -> iosxe -> ShowIpRoute -> golden_output11Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowIpRoute     Passed    
2022-11-28T14:54:50: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowIpRoute -> empty_outputPassed    
2022-11-28T14:54:50: %AETEST-INFO: ............................................................
2022-11-28T14:54:50: %AETEST-INFO: The result of section ShowIpRoute is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: |                           Starting section cleanup                           |
2022-11-28T14:54:50: %AETEST-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %AETEST-INFO: The result of section cleanup is => PASSED
2022-11-28T14:54:50: %AETEST-INFO: The result of testcase iosxe is => PASSED
2022-11-28T14:54:50: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %GENIE-INFO: |                               Unittest results                               |
2022-11-28T14:54:50: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %GENIE-INFO:  SECTIONS/TESTCASES                                                      RESULT   
2022-11-28T14:54:50: %GENIE-INFO: --------------------------------------------------------------------------------
2022-11-28T14:54:50: %GENIE-INFO: .
2022-11-28T14:54:50: %GENIE-INFO: |-- SuperFileBasedTesting                                                 PASSED
2022-11-28T14:54:50: %GENIE-INFO: |   `-- setup                                                             PASSED
2022-11-28T14:54:50: %GENIE-INFO: `-- iosxe                                                                 PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |-- setup                                                             PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |-- ShowIpRoute                                                       PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1: iosxe -> ShowIpRoute                                  PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1: Test Golden -> iosxe -> ShowIpRoute                 PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.1: Gold -> iosxe -> ShowIpRoute -> golden_output1    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.2: Gold -> iosxe -> ShowIpRoute -> golden_output2    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.3: Gold -> iosxe -> ShowIpRoute -> golden_output3    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.4: Gold -> iosxe -> ShowIpRoute -> golden_output4    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.5: Gold -> iosxe -> ShowIpRoute -> golden_output5    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.6: Gold -> iosxe -> ShowIpRoute -> golden_output6    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.7: Gold -> iosxe -> ShowIpRoute -> golden_output7    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.8: Gold -> iosxe -> ShowIpRoute -> golden_output8    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.1.9: Gold -> iosxe -> ShowIpRoute -> golden_outp...    PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   |-- Step 1.2: Test Empty -> iosxe -> ShowIpRoute                  PASSED
2022-11-28T14:54:50: %GENIE-INFO:     |   `-- Step 1.2.1: Empty -> iosxe -> ShowIpRoute -> empty_output     PASSED
2022-11-28T14:54:50: %GENIE-INFO:     `-- cleanup                                                           PASSED
2022-11-28T14:54:50: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %GENIE-INFO: |                                   Summary                                    |
2022-11-28T14:54:50: %GENIE-INFO: +------------------------------------------------------------------------------+
2022-11-28T14:54:50: %GENIE-INFO:  Number of ABORTED                                                            0 
2022-11-28T14:54:50: %GENIE-INFO:  Number of BLOCKED                                                            0 
2022-11-28T14:54:50: %GENIE-INFO:  Number of ERRORED                                                            0 
2022-11-28T14:54:50: %GENIE-INFO:  Number of FAILED                                                             0 
2022-11-28T14:54:50: %GENIE-INFO:  Number of PASSED                                                             2 
2022-11-28T14:54:50: %GENIE-INFO:  Number of PASSX                                                              0 
2022-11-28T14:54:50: %GENIE-INFO:  Number of SKIPPED                                                            0 
2022-11-28T14:54:50: %GENIE-INFO:  Total Number                                                                 2 
2022-11-28T14:54:50: %GENIE-INFO:  Success Rate                                                            100.0% 
2022-11-28T14:54:50: %GENIE-INFO: --------------------------------------------------------------------------------
2022-11-28T14:54:50: %GENIE-INFO:  Total Passing Unittests                                                     10 
2022-11-28T14:54:50: %GENIE-INFO:  Total Failed Unittests                                                       0 
2022-11-28T14:54:50: %GENIE-INFO:  Total Errored Unittests                                                      0 
2022-11-28T14:54:50: %GENIE-INFO:  Total Unittests                                                             10 
2022-11-28T14:54:50: %GENIE-INFO: --------------------------------------------------------------------------------


## Checklist:
- [X] I have updated the changelog.
- [X] I have updated the documentation (If applicable).
- [X] I have added tests to cover my changes (If applicable).
- [X] All new and existing tests passed.
- [?] All new code passed compilation.
