### PR TITLE
fix issue #724:  iosxe - ShowCryptoSession SchemaMissingKeyError

### DIFF
--- a/changelog/undistributed/changelog_show_crypto_session_iosxe_20230120.rst
+++ b/changelog/undistributed/changelog_show_crypto_session_iosxe_20230120.rst
@@ -1,0 +1,12 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* iosxe
+    * Modified ShowCryptoSessionSchema:
+        * made keys peer, ipsec_flow, ike_sa Optional
+        * change interface key to an index instead of non-unique name
+        * added 'interface' to dictionary
+    * Modified ShowCryptoSessionSchema:
+        * adapted code to new number index for interface
+        * moved several flag underneath interface match - 
+                these flags must be reset when there is a new Interface  

--- a/src/genie/libs/parser/iosxe/show_crypto.py
+++ b/src/genie/libs/parser/iosxe/show_crypto.py
@@ -994,8 +994,9 @@ class ShowCryptoSessionSchema(MetaParser):
             Optional("profile"): str,
             Optional("group"): str,
             Optional("assigned_address"):str,
+            "interface":str,
             "session_status": str,
-            "peer":{
+            Optional("peer"):{
                 Any():
                 {
                     "port":{
@@ -1005,7 +1006,7 @@ class ShowCryptoSessionSchema(MetaParser):
                         Optional("ivrf"): str,
                         Optional("phase1_id"): str,
                         Optional("desc"): str,
-                        "ike_sa":{
+                        Optional("ike_sa"):{
                             Any():
                             {
                                 "local": str,
@@ -1020,7 +1021,7 @@ class ShowCryptoSessionSchema(MetaParser):
                                 Optional("session_id"): str
                             },
                         },
-                        "ipsec_flow": {
+                        Optional("ipsec_flow"): {
                             Any():
                                 {
                                 "active_sas": int,
@@ -1109,10 +1110,7 @@ class ShowCryptoSessionSuperParser(ShowCryptoSessionSchema):
         
         ret_dict = {}
         check_flag = 1
-        peer_flag = 1
-        sa_flag = 1
-        flow_flag = 1
-        ike_index = 1
+        interface_index=1
         session_id = None
         
         for line in output.splitlines():
@@ -1126,8 +1124,14 @@ class ShowCryptoSessionSuperParser(ShowCryptoSessionSchema):
             m1= p1.match(line)
             if m1:
                 groups=m1.groupdict()
-                crypto_session_dict[groups['interface_name']]={}
-                interface_dict=crypto_session_dict[groups['interface_name']]
+                crypto_session_dict[str(interface_index)]={}
+                interface_dict=crypto_session_dict[str(interface_index)]
+                interface_dict['interface']=groups['interface_name']
+                interface_index+= 1
+                peer_flag = 1
+                sa_flag = 1
+                flow_flag = 1
+                ike_index = 1
             
             #Uptime: 3d18h
             m2= p2.match(line)

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output1_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output1_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
     "interface": {
-        "Virtual-Access2": {
+        "1": {
+            "interface": "Virtual-Access2",
             "user_name": "cisco",
             "profile": "prof",
             "group": "easy",

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output2_expected.py
@@ -1,6 +1,7 @@
 expected_output = {
     "interface": {
-        "Tunnel0": {
+        "1": {
+            "interface": "Tunnel0",
             "profile": "polaris-test",
              "session_status": "UP-ACTIVE",
              "peer": {

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output3_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output3_expected.py
@@ -1,0 +1,75 @@
+expected_output= {
+    "interface": {
+        "1": {
+            "interface": "Tunnel3111",
+            "peer": {
+                "192.168.1.1": {
+                    "port": {
+                        "500": {
+                            "ipsec_flow": {
+                                "permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.0": {
+                                    "active_sas": 0,
+                                    "origin": "crypto map"
+                                },
+                                "permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.128": {
+                                    "active_sas": 0,
+                                    "origin": "crypto map"
+                                },
+                                "permit ip 100.75.0.0/255.255.255.192 192.168.26.0/255.255.255.0": {
+                                    "active_sas": 0,
+                                    "origin": "crypto map"
+                                },
+                                "permit ip host 100.74.10.1 192.168.25.0/255.255.255.0": {
+                                    "active_sas": 0,
+                                    "origin": "crypto map"
+                                },
+                                "permit ip host 100.74.10.1 192.168.25.0/255.255.255.128": {
+                                    "active_sas": 0,
+                                    "origin": "crypto map"
+                                },
+                                "permit ip host 100.74.10.1 192.168.26.0/255.255.255.0": {
+                                    "active_sas": 0,
+                                    "origin": "crypto map"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "session_status": "DOWN"
+        },
+        "2": {
+            "interface": "Tunnel3111",
+            "peer": {
+                "192.168.1.1": {
+                    "port": {
+                        "500": {
+                            "ike_sa": {
+                                "1": {
+                                    "local": "94.140.184.80",
+                                    "local_port": "500",
+                                    "remote": "192.168.1.1",
+                                    "remote_port": "500",
+                                    "sa_status": "Inactive",
+                                    "session_id": "0",
+                                    "version": "IKEv1"
+                                },
+                                "2": {
+                                    "local": "94.140.184.80",
+                                    "local_port": "500",
+                                    "remote": "192.168.1.1",
+                                    "remote_port": "500",
+                                    "sa_status": "Inactive",
+                                    "session_id": "0",
+                                    "version": "IKEv1"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "profile": "ISAKMP-inner-LOC_A",
+            "session_status": "DOWN-NEGOTIATING"
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output3_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output3_output.txt
@@ -1,0 +1,26 @@
+Crypto session current status
+
+Interface: Tunnel3111
+Session status: DOWN
+Peer: 192.168.1.1 port 500 
+  IPSEC FLOW: permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.128 
+        Active SAs: 0, origin: crypto map
+  IPSEC FLOW: permit ip host 100.74.10.1 192.168.25.0/255.255.255.128 
+        Active SAs: 0, origin: crypto map
+  IPSEC FLOW: permit ip 100.75.0.0/255.255.255.192 192.168.26.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+  IPSEC FLOW: permit ip host 100.74.10.1 192.168.26.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+  IPSEC FLOW: permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+  IPSEC FLOW: permit ip host 100.74.10.1 192.168.25.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+
+Interface: Tunnel3111
+Profile: ISAKMP-inner-LOC_A
+Session status: DOWN-NEGOTIATING
+Peer: 192.168.1.1 port 500 
+  Session ID: 0  
+  IKEv1 SA: local 94.140.184.80/500 remote 192.168.1.1/500 Inactive 
+  Session ID: 0  
+  IKEv1 SA: local 94.140.184.80/500 remote 192.168.1.1/500 Inactive

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSession/cli/equal/golden_output_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
     "interface": {
-        "Tunnel13": {
+        "1": {
+            "interface": "Tunnel13",
             "session_status": "UP-ACTIVE",
             "peer": {
                 "11.0.1.1": {

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output1_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output1_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
     "interface": {
-        "Tunnel0": {
+        "1": {
+            "interface":"Tunnel0",
             "session_status": "UP-ACTIVE",
             "peer": {
                 "10.1.1.3": {

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output2_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
     "interface": {
-        "Tunnel0": {
+        "1": {
+            "interface":"Tunnel0",
             "profile": "polaris-test",
             "uptime": "00:27:42",
             "session_status": "UP-ACTIVE",

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output3_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output3_expected.py
@@ -1,0 +1,137 @@
+expected_output= {
+  "interface": {
+    "1": {
+      "interface": "Tunnel3111",
+      "peer": {
+        "192.168.1.1": {
+          "port": {
+            "500": {
+              "desc": "none",
+              "fvrf": "none",
+              "ipsec_flow": {
+                "permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.0": {
+                  "active_sas": 0,
+                  "inbound_life_kb": "0",
+                  "inbound_life_secs": "0",
+                  "inbound_pkts_decrypted": 0,
+                  "inbound_pkts_drop": 0,
+                  "origin": "crypto map",
+                  "outbound_life_kb": "0",
+                  "outbound_life_secs": "0",
+                  "outbound_pkts_drop": 0,
+                  "outbound_pkts_encrypted": 0
+                },
+                "permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.128": {
+                  "active_sas": 0,
+                  "inbound_life_kb": "0",
+                  "inbound_life_secs": "0",
+                  "inbound_pkts_decrypted": 0,
+                  "inbound_pkts_drop": 0,
+                  "origin": "crypto map",
+                  "outbound_life_kb": "0",
+                  "outbound_life_secs": "0",
+                  "outbound_pkts_drop": 0,
+                  "outbound_pkts_encrypted": 0
+                },
+                "permit ip 100.75.0.0/255.255.255.192 192.168.26.0/255.255.255.0": {
+                  "active_sas": 0,
+                  "inbound_life_kb": "0",
+                  "inbound_life_secs": "0",
+                  "inbound_pkts_decrypted": 0,
+                  "inbound_pkts_drop": 0,
+                  "origin": "crypto map",
+                  "outbound_life_kb": "0",
+                  "outbound_life_secs": "0",
+                  "outbound_pkts_drop": 0,
+                  "outbound_pkts_encrypted": 0
+                },
+                "permit ip host 100.74.10.1 192.168.25.0/255.255.255.0": {
+                  "active_sas": 0,
+                  "inbound_life_kb": "0",
+                  "inbound_life_secs": "0",
+                  "inbound_pkts_decrypted": 0,
+                  "inbound_pkts_drop": 0,
+                  "origin": "crypto map",
+                  "outbound_life_kb": "0",
+                  "outbound_life_secs": "0",
+                  "outbound_pkts_drop": 0,
+                  "outbound_pkts_encrypted": 0
+                },
+                "permit ip host 100.74.10.1 192.168.25.0/255.255.255.128": {
+                  "active_sas": 0,
+                  "inbound_life_kb": "0",
+                  "inbound_life_secs": "0",
+                  "inbound_pkts_decrypted": 0,
+                  "inbound_pkts_drop": 0,
+                  "origin": "crypto map",
+                  "outbound_life_kb": "0",
+                  "outbound_life_secs": "0",
+                  "outbound_pkts_drop": 0,
+                  "outbound_pkts_encrypted": 0
+                },
+                "permit ip host 100.74.10.1 192.168.26.0/255.255.255.0": {
+                  "active_sas": 0,
+                  "inbound_life_kb": "0",
+                  "inbound_life_secs": "0",
+                  "inbound_pkts_decrypted": 0,
+                  "inbound_pkts_drop": 0,
+                  "origin": "crypto map",
+                  "outbound_life_kb": "0",
+                  "outbound_life_secs": "0",
+                  "outbound_pkts_drop": 0,
+                  "outbound_pkts_encrypted": 0
+                }
+              },
+              "ivrf": "inner",
+              "phase1_id": "(none)"
+            }
+          }
+        }
+      },
+      "session_status": "DOWN"
+    },
+    "2": {
+      "interface": "Tunnel3111",
+      "peer": {
+        "192.168.1.1": {
+          "port": {
+            "500": {
+              "desc": "none",
+              "fvrf": "none",
+              "ike_sa": {
+                "1": {
+                  "capabilities": "none",
+                  "conn_id": "0",
+                  "lifetime": "0",
+                  "local": "94.140.184.80",
+                  "local_port": "500",
+                  "remote": "192.168.1.1",
+                  "remote_port": "500",
+                  "sa_status": "Inactive",
+                  "session_id": "0",
+                  "version": "IKEv1"
+                },
+                "2": {
+                  "capabilities": "none",
+                  "conn_id": "0",
+                  "lifetime": "0",
+                  "local": "94.140.184.80",
+                  "local_port": "500",
+                  "remote": "192.168.1.1",
+                  "remote_port": "500",
+                  "sa_status": "Inactive",
+                  "session_id": "0",
+                  "version": "IKEv1"
+                }
+              },
+              "ivrf": "none",
+              "phase1_id": "(none)"
+            }
+          }
+        }
+      },
+      "profile": "ISAKMP-inner-LOC_A",
+      "session_status": "DOWN-NEGOTIATING"
+    }
+  }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output3_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output3_output.txt
@@ -1,0 +1,50 @@
+Crypto session current status
+
+Code: C - IKE Configuration mode, D - Dead Peer Detection     
+K - Keepalives, N - NAT-traversal, T - cTCP encapsulation     
+X - IKE Extended Authentication, F - IKE Fragmentation
+R - IKE Auto Reconnect, U - IKE Dynamic Route Update
+S - SIP VPN
+
+Interface: Tunnel3111
+Session status: DOWN
+Peer: 192.168.1.1 port 500 fvrf: (none) ivrf: inner
+      Desc: (none)
+      Phase1_id: (none)
+  IPSEC FLOW: permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.128 
+        Active SAs: 0, origin: crypto map
+        Inbound:  #pkts dec'ed 0 drop 0 life (KB/Sec) 0/0
+        Outbound: #pkts enc'ed 0 drop 0 life (KB/Sec) 0/0
+  IPSEC FLOW: permit ip host 100.74.10.1 192.168.25.0/255.255.255.128 
+        Active SAs: 0, origin: crypto map
+        Inbound:  #pkts dec'ed 0 drop 0 life (KB/Sec) 0/0
+        Outbound: #pkts enc'ed 0 drop 0 life (KB/Sec) 0/0
+  IPSEC FLOW: permit ip 100.75.0.0/255.255.255.192 192.168.26.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+        Inbound:  #pkts dec'ed 0 drop 0 life (KB/Sec) 0/0
+        Outbound: #pkts enc'ed 0 drop 0 life (KB/Sec) 0/0
+  IPSEC FLOW: permit ip host 100.74.10.1 192.168.26.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+        Inbound:  #pkts dec'ed 0 drop 0 life (KB/Sec) 0/0
+        Outbound: #pkts enc'ed 0 drop 0 life (KB/Sec) 0/0
+  IPSEC FLOW: permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+        Inbound:  #pkts dec'ed 0 drop 0 life (KB/Sec) 0/0
+        Outbound: #pkts enc'ed 0 drop 0 life (KB/Sec) 0/0
+  IPSEC FLOW: permit ip host 100.74.10.1 192.168.25.0/255.255.255.0 
+        Active SAs: 0, origin: crypto map
+        Inbound:  #pkts dec'ed 0 drop 0 life (KB/Sec) 0/0
+        Outbound: #pkts enc'ed 0 drop 0 life (KB/Sec) 0/0
+
+Interface: Tunnel3111
+Profile: ISAKMP-inner-LOC_A
+Session status: DOWN-NEGOTIATING
+Peer: 192.168.1.1 port 500 fvrf: (none) ivrf: (none)
+      Desc: (none)
+      Phase1_id: (none)
+  Session ID: 0  
+  IKEv1 SA: local 94.140.184.80/500 remote 192.168.1.1/500 Inactive 
+          Capabilities:(none) connid:0 lifetime:0
+  Session ID: 0  
+  IKEv1 SA: local 94.140.184.80/500 remote 192.168.1.1/500 Inactive 
+          Capabilities:(none) connid:0 lifetime:0

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionDetail/cli/equal/golden_output_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
     "interface": {
-        "Tunnel13": {
+        "1": {
+            "interface":"Tunnel13",
             "profile": "GS-GRE:ISAKMP", 
             "peer": {
                 "11.0.2.1": {

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionInterfaceDetail/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionInterfaceDetail/cli/equal/golden_output_expected.py
@@ -1,6 +1,7 @@
 expected_output = {
 	'interface': {
-		'Tunnel2': {
+		'1': {
+			'interface':'Tunnel2',
 			'peer': {
 				'70.70.70.70': {
 					'port': {

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionLocal/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionLocal/cli/equal/golden_output_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
      'interface': {
-         'Tunnel1': {
+         '1': {
+            'interface':'Tunnel1',
              'peer': {
                  '10.1.1.1': {
                      'port': {

--- a/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionLocalDetail/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCryptoSessionLocalDetail/cli/equal/golden_output_expected.py
@@ -1,6 +1,7 @@
 expected_output= {
      'interface': {
-         'Tunnel1': {
+         '1': {
+            'interface':'Tunnel1',
              'peer': {
                  '10.1.1.1': {
                      'port': {


### PR DESCRIPTION
## Description
modified Schema and parsing capabilities to resolve python execption failures in the genie parser capabilities to deal with possible duplicate interface names in the "show crypto session" CLI 

## Motivation and Context
not able to use genie parse on production devices where the static IPSEC tunnels were in DOWN state.
Traceback (most recent call last):
  File "src/genie/cli/commands/parser.py", line 339, in genie.cli.commands.parser.ParserCommand.parse
  File "src/genie/conf/base/device.py", line 531, in genie.conf.base.device.Device.parse
  File "src/genie/conf/base/device.py", line 570, in genie.conf.base.device.Device._get_parser_output
  File "src/genie/conf/base/device.py", line 568, in genie.conf.base.device.Device._get_parser_output
  File "src/genie/metaparser/_metaparser.py", line 342, in genie.metaparser._metaparser.MetaParser.parse
  File "src/genie/metaparser/_metaparser.py", line 322, in genie.metaparser._metaparser.MetaParser.parse
  File "src/genie/metaparser/util/schemaengine.py", line 419, in genie.metaparser.util.schemaengine.Schema.validate
genie.metaparser.util.exceptions.SchemaMissingKeyError: Missing keys: [['interface', '(unknown)', 'peer', '192.168.1.1', 'port', '500', 'ipsec_flow']]

## Impact (If any)
Schema was adapted as current code used a python dictionary with key values that were not guaranteed to be unique in the output. 
SuperParsesSchema was used other python test units too - adjusted those files too.


## Screenshots:
Adapted existing unit and included test with output from duplicate tunnel in output.
(22.11) 17:06:14-apieters@as8368-netdevops-vm:~/pyats/22.11/genieparser (master)$ genie parse "show crypto session detail" --testbed-file /home/apieters/pyats/SRC/INPUT/TOPOLOGY/UAT/cml_testbed.yaml --device virl.aal1-dmvpn 
  0%|                                                                                                                                                                         | 0/1 [00:00<?, ?it/s]{
  "interface": {
    "1": {
      "interface": "Tunnel3111",
      "peer": {
        "192.168.1.1": {
          "port": {
            "500": {
              "desc": "none",
              "fvrf": "none",
              "ipsec_flow": {
                "permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.0": {
                  "active_sas": 0,
                  "inbound_life_kb": "0",
                  "inbound_life_secs": "0",
                  "inbound_pkts_decrypted": 0,
                  "inbound_pkts_drop": 0,
                  "origin": "crypto map",
                  "outbound_life_kb": "0",
                  "outbound_life_secs": "0",
                  "outbound_pkts_drop": 0,
                  "outbound_pkts_encrypted": 0
                },
                "permit ip 100.75.0.0/255.255.255.192 192.168.25.0/255.255.255.128": {
                  "active_sas": 0,
                  "inbound_life_kb": "0",
                  "inbound_life_secs": "0",
                  "inbound_pkts_decrypted": 0,
                  "inbound_pkts_drop": 0,
                  "origin": "crypto map",
                  "outbound_life_kb": "0",
                  "outbound_life_secs": "0",
                  "outbound_pkts_drop": 0,
                  "outbound_pkts_encrypted": 0
                },
                "permit ip 100.75.0.0/255.255.255.192 192.168.26.0/255.255.255.0": {
                  "active_sas": 0,
                  "inbound_life_kb": "0",
                  "inbound_life_secs": "0",
                  "inbound_pkts_decrypted": 0,
                  "inbound_pkts_drop": 0,
                  "origin": "crypto map",
                  "outbound_life_kb": "0",
                  "outbound_life_secs": "0",
                  "outbound_pkts_drop": 0,
                  "outbound_pkts_encrypted": 0
                },
                "permit ip host 100.74.10.1 192.168.25.0/255.255.255.0": {
                  "active_sas": 0,
                  "inbound_life_kb": "0",
                  "inbound_life_secs": "0",
                  "inbound_pkts_decrypted": 0,
                  "inbound_pkts_drop": 0,
                  "origin": "crypto map",
                  "outbound_life_kb": "0",
                  "outbound_life_secs": "0",
                  "outbound_pkts_drop": 0,
                  "outbound_pkts_encrypted": 0
                },
                "permit ip host 100.74.10.1 192.168.25.0/255.255.255.128": {
                  "active_sas": 0,
                  "inbound_life_kb": "0",
                  "inbound_life_secs": "0",
                  "inbound_pkts_decrypted": 0,
                  "inbound_pkts_drop": 0,
                  "origin": "crypto map",
                  "outbound_life_kb": "0",
                  "outbound_life_secs": "0",
                  "outbound_pkts_drop": 0,
                  "outbound_pkts_encrypted": 0
                },
                "permit ip host 100.74.10.1 192.168.26.0/255.255.255.0": {
                  "active_sas": 0,
                  "inbound_life_kb": "0",
                  "inbound_life_secs": "0",
                  "inbound_pkts_decrypted": 0,
                  "inbound_pkts_drop": 0,
                  "origin": "crypto map",
                  "outbound_life_kb": "0",
                  "outbound_life_secs": "0",
                  "outbound_pkts_drop": 0,
                  "outbound_pkts_encrypted": 0
                }
              },
              "ivrf": "inner",
              "phase1_id": "(none)"
            }
          }
        }
      },
      "session_status": "DOWN"
    },
    "2": {
      "interface": "(unknown)",
      "peer": {
        "192.168.1.1": {
          "port": {
            "500": {
              "desc": "none",
              "fvrf": "none",
              "ike_sa": {
                "1": {
                  "capabilities": "none",
                  "conn_id": "0",
                  "lifetime": "0",
                  "local": "94.140.184.80",
                  "local_port": "500",
                  "remote": "192.168.1.1",
                  "remote_port": "500",
                  "sa_status": "Inactive",
                  "session_id": "0",
                  "version": "IKEv1"
                }
              },
              "ivrf": "none",
              "phase1_id": "(none)"
            }
          }
        }
      },
      "profile": "ISAKMP-inner-LOC_A",
      "session_status": "DOWN-NEGOTIATING"
    }
  }
}

due to impact on other python unit tests, adapted these expected output file also for these:
ShowCryptoSessionDetail:
ShowCryptoSessionInterfaceDetail:
ShowCryptoSessionLocal:
ShowCryptoSessionLocalDetail:


(22.11) 16:05:57-apieters@as8368-netdevops-vm:~/pyats/22.11/genieparser/tests (master)$ python folder_parsing_job.py -o iosxe -c ShowCryptoSession
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: |                   Starting testcase SuperFileBasedTesting                    |
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: |                            Starting section setup                            |
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: The result of section setup is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: The result of testcase SuperFileBasedTesting is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: |                           Starting testcase iosxe                            |
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: |                            Starting section setup                            |
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: The result of section setup is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: |                      Starting section ShowCryptoSession                      |
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :                 Starting STEP 1: iosxe -> ShowCryptoSession                  :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :         Starting STEP 1.1: Test Golden -> iosxe -> ShowCryptoSession         :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :    Starting STEP 1.1.1: Gold -> iosxe -> ShowCryptoSession -> golden_outp    :
2023-01-20T16:06:04: %AETEST-INFO: :                                     ut1                                      :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxe -> ShowCryptoSession -> golden_output1 is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :    Starting STEP 1.1.2: Gold -> iosxe -> ShowCryptoSession -> golden_outp    :
2023-01-20T16:06:04: %AETEST-INFO: :                                     ut2                                      :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.1.2: Gold -> iosxe -> ShowCryptoSession -> golden_output2 is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :    Starting STEP 1.1.3: Gold -> iosxe -> ShowCryptoSession -> golden_outp    :
2023-01-20T16:06:04: %AETEST-INFO: :                                     ut3                                      :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.1.3: Gold -> iosxe -> ShowCryptoSession -> golden_output3 is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :    Starting STEP 1.1.4: Gold -> iosxe -> ShowCryptoSession -> golden_outp    :
2023-01-20T16:06:04: %AETEST-INFO: :                                      ut                                      :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.1.4: Gold -> iosxe -> ShowCryptoSession -> golden_output is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowCryptoSession is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :         Starting STEP 1.2: Test Empty -> iosxe -> ShowCryptoSession          :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: :    Starting STEP 1.2.1: Empty -> iosxe -> ShowCryptoSession -> empty_outp    :
2023-01-20T16:06:04: %AETEST-INFO: :                                      ut                                      :
2023-01-20T16:06:04: %AETEST-INFO: +..............................................................................+
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowCryptoSession -> empty_output is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowCryptoSession is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: The result of STEP 1: iosxe -> ShowCryptoSession is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +..........................................................+
2023-01-20T16:06:04: %AETEST-INFO: :                       STEPS Report                       :
2023-01-20T16:06:04: %AETEST-INFO: +..........................................................+
2023-01-20T16:06:04: %AETEST-INFO: STEP 1 - iosxe -> ShowCryptoSession               Passed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowCryptoSessionPassed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxe -> ShowCryptoSession -> golden_output1Passed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.1.2 - Gold -> iosxe -> ShowCryptoSession -> golden_output2Passed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.1.3 - Gold -> iosxe -> ShowCryptoSession -> golden_output3Passed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.1.4 - Gold -> iosxe -> ShowCryptoSession -> golden_outputPassed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowCryptoSessionPassed    
2023-01-20T16:06:04: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowCryptoSession -> empty_outputPassed    
2023-01-20T16:06:04: %AETEST-INFO: ............................................................
2023-01-20T16:06:04: %AETEST-INFO: The result of section ShowCryptoSession is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: |                           Starting section cleanup                           |
2023-01-20T16:06:04: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %AETEST-INFO: The result of section cleanup is => PASSED
2023-01-20T16:06:04: %AETEST-INFO: The result of testcase iosxe is => PASSED
2023-01-20T16:06:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %GENIE-INFO: |                               Unittest results                               |
2023-01-20T16:06:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %GENIE-INFO:  SECTIONS/TESTCASES                                                      RESULT   
2023-01-20T16:06:04: %GENIE-INFO: --------------------------------------------------------------------------------
2023-01-20T16:06:04: %GENIE-INFO: .
2023-01-20T16:06:04: %GENIE-INFO: |-- SuperFileBasedTesting                                                 PASSED
2023-01-20T16:06:04: %GENIE-INFO: |   `-- setup                                                             PASSED
2023-01-20T16:06:04: %GENIE-INFO: `-- iosxe                                                                 PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |-- setup                                                             PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |-- ShowCryptoSession                                                 PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1: iosxe -> ShowCryptoSession                            PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1.1: Test Golden -> iosxe -> ShowCryptoSession           PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1.1.1: Gold -> iosxe -> ShowCryptoSession -> golde...    PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1.1.2: Gold -> iosxe -> ShowCryptoSession -> golde...    PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1.1.3: Gold -> iosxe -> ShowCryptoSession -> golde...    PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1.1.4: Gold -> iosxe -> ShowCryptoSession -> golde...    PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   |-- Step 1.2: Test Empty -> iosxe -> ShowCryptoSession            PASSED
2023-01-20T16:06:04: %GENIE-INFO:     |   `-- Step 1.2.1: Empty -> iosxe -> ShowCryptoSession -> empt...    PASSED
2023-01-20T16:06:04: %GENIE-INFO:     `-- cleanup                                                           PASSED
2023-01-20T16:06:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %GENIE-INFO: |                                   Summary                                    |
2023-01-20T16:06:04: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-01-20T16:06:04: %GENIE-INFO:  Number of ABORTED                                                            0 
2023-01-20T16:06:04: %GENIE-INFO:  Number of BLOCKED                                                            0 
2023-01-20T16:06:04: %GENIE-INFO:  Number of ERRORED                                                            0 
2023-01-20T16:06:04: %GENIE-INFO:  Number of FAILED                                                             0 
2023-01-20T16:06:04: %GENIE-INFO:  Number of PASSED                                                             2 
2023-01-20T16:06:04: %GENIE-INFO:  Number of PASSX                                                              0 
2023-01-20T16:06:04: %GENIE-INFO:  Number of SKIPPED                                                            0 
2023-01-20T16:06:04: %GENIE-INFO:  Total Number                                                                 2 
2023-01-20T16:06:04: %GENIE-INFO:  Success Rate                                                            100.0% 
2023-01-20T16:06:04: %GENIE-INFO: --------------------------------------------------------------------------------
2023-01-20T16:06:04: %GENIE-INFO:  Total Passing Unittests                                                      5 
2023-01-20T16:06:04: %GENIE-INFO:  Total Failed Unittests                                                       0 
2023-01-20T16:06:04: %GENIE-INFO:  Total Errored Unittests                                                      0 
2023-01-20T16:06:04: %GENIE-INFO:  Total Unittests                                                              5 
2023-01-20T16:06:04: %GENIE-INFO: --------------------------------------------------------------------------------

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ x ] I have added tests to cover my changes (If applicable).
- [ x ] All new and existing tests passed.
- [ x ] All new code passed compilation.