### PR TITLE
fixed an issue where show cdp neighbors detail didnt parse the vtp-do…

### DIFF
--- a/src/genie/libs/parser/iosxe/show_cdp.py
+++ b/src/genie/libs/parser/iosxe/show_cdp.py
@@ -248,7 +248,7 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
         # VTP Management Domain: 'Accounting Group'
         vtp_management_domain_re = re.compile(r'^VTP\s*Management\s*'
                                               r'Domain\s*:\s*'
-                                              r'\W*(?P<vtp_management_domain>([a-zA-Z\s]+'
+                                              r'\W*(?P<vtp_management_domain>([a-zA-Z0-9\s]+'
                                               r'))\W*')
 
         # Holdtime : 126 sec

--- a/src/genie/libs/parser/nxos/show_cdp.py
+++ b/src/genie/libs/parser/nxos/show_cdp.py
@@ -273,7 +273,7 @@ class ShowCdpNeighborsDetail(ShowCdpNeighborsDetailSchema):
         # VTP Management Domain: 'Accounting Group'
         vtp_management_domain_re = re.compile(r''
             'VTP\s*Management\s*Domain\s*:\s*\W*'
-            '(?P<vtp_management_domain>([a-zA-Z\s]+))\W*')
+            '(?P<vtp_management_domain>([a-zA-Z0-9\s]+))\W*')
 
         # Holdtime : 126 sec
         hold_time_re = re.compile(r'Holdtime\s*:\s*\s*(?P<hold_time>\d+)')


### PR DESCRIPTION
…main correctly.

## Description
vtp-domains can contain not only characters, but also numbers. I expanded the regex for numbers 0-9.

## Motivation and Context
We have vtp-domains which contains characters and numbers e.g. 'F16' or 'Z990'

## Impact (If any)
none


