### PR TITLE
Fixing show isis adjacency when there are no interfaces

### DIFF
--- a/changelog/undistributed/changelog_show_isis_nxos_20230329160015.rst
+++ b/changelog/undistributed/changelog_show_isis_nxos_20230329160015.rst
@@ -1,0 +1,8 @@
+Only one changelog file per pull request. Combine these two templates where applicable.
+
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* NXOS
+    * Modified ShowIsisAdjacencySchema:
+        * Making interfaces optional as process without neighbors will not have interfaces.

--- a/src/genie/libs/parser/nxos/show_isis.py
+++ b/src/genie/libs/parser/nxos/show_isis.py
@@ -1060,7 +1060,7 @@ class ShowIsisAdjacencySchema(MetaParser):
             Any(): {
                 'vrf': {
                     Any(): {
-                        'interfaces': {
+                        Optional('interfaces'): {
                             Any(): {
                                 'adjacencies': {
                                     Any(): {

--- a/src/genie/libs/parser/nxos/tests/ShowIsisAdjacency/cli/equal/golden3_expected.py
+++ b/src/genie/libs/parser/nxos/tests/ShowIsisAdjacency/cli/equal/golden3_expected.py
@@ -1,0 +1,10 @@
+expected_output = {
+    "instance": {
+        "1": {
+            "vrf": {
+                "default": {
+                }
+            }
+        }
+    }
+}

--- a/src/genie/libs/parser/nxos/tests/ShowIsisAdjacency/cli/equal/golden3_output.txt
+++ b/src/genie/libs/parser/nxos/tests/ShowIsisAdjacency/cli/equal/golden3_output.txt
@@ -1,0 +1,4 @@
+IS-IS process: 1 VRF: default
+IS-IS adjacency database:
+Legend: '!': No AF level connectivity in given topology
+System ID       SNPA            Level  State  Hold Time  Interface


### PR DESCRIPTION
## Description
When there are no interfaces parser throws error

## Motivation and Context
Solving the following error
```
2023-03-29T16:06:23: %SCRIPT-ERROR: Traceback (most recent call last):
2023-03-29T16:06:23: %SCRIPT-ERROR:   File "/Users/rohsaluj/genieparser/src/genie/libs/parser/utils/unittests.py", line 574, in test_golden
2023-03-29T16:06:23: %SCRIPT-ERROR:     parsed_output = obj.parse(**arguments)
2023-03-29T16:06:23: %SCRIPT-ERROR:   File "src/genie/metaparser/_metaparser.py", line 342, in genie.metaparser._metaparser.MetaParser.parse
2023-03-29T16:06:23: %SCRIPT-ERROR:   File "src/genie/metaparser/_metaparser.py", line 322, in genie.metaparser._metaparser.MetaParser.parse
2023-03-29T16:06:23: %SCRIPT-ERROR:   File "src/genie/metaparser/util/schemaengine.py", line 419, in genie.metaparser.util.schemaengine.Schema.validate
2023-03-29T16:06:23: %SCRIPT-ERROR: genie.metaparser.util.exceptions.SchemaMissingKeyError: Missing keys: [['instance', '1', 'vrf', 'default', 'interfaces']]
```

## Impact (If any)
None

## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
