### PR TITLE
Modified switchport mode regex to include hyphens in "show interfaces switchport"

### DIFF
--- a/changelog/undistributed/changelog_show_interfaces_switchport_iosxe_20230516115049.rst
+++ b/changelog/undistributed/changelog_show_interfaces_switchport_iosxe_20230516115049.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowInterfacesSwitchport:
+        * Updated regex pattern p3 (Administrative Mode) to accommodate outputs with hyphens, such as private-vlan mode.
+        

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -1648,7 +1648,7 @@ class ShowInterfacesSwitchport(ShowInterfacesSwitchportSchema):
         p2 = re.compile(r'^Switchport: +(?P<switchport_enable>\w+)$')
 
         # Administrative Mode: trunk
-        p3 = re.compile(r'^Administrative +Mode: +(?P<switchport_mode>[\w\s]+)$')
+        p3 = re.compile(r'^Administrative +Mode: +(?P<switchport_mode>[\w\s\-]+)$')
 
         # Operational Mode: trunk (member of bundle Po12)
         # Operational Mode: down (suspended member of bundle Po12)


### PR DESCRIPTION
## Description
Added to the regex (p3, Administrative mode) to include hyphens to accommodate additional switchport modes 

## Motivation and Context
Whenever the parser would be used on a switch with a switchport mode such as private-vlan, the parser would fail and return this error (similar error is also seen on live devices as well):
```
2023-05-16T11:19:42: %SCRIPT-ERROR: Traceback (most recent call last):
2023-05-16T11:19:42: %SCRIPT-ERROR:   File "/home/virrsa/Projects/genieparser/src/genie/libs/parser/utils/unittests.py", line 574, in test_golden
2023-05-16T11:19:42: %SCRIPT-ERROR:     parsed_output = obj.parse(**arguments)
2023-05-16T11:19:42: %SCRIPT-ERROR:   File "src/genie/metaparser/_metaparser.py", line 312, in genie.metaparser._metaparser.MetaParser.parse
2023-05-16T11:19:42: %SCRIPT-ERROR:   File "src/genie/metaparser/_metaparser.py", line 292, in genie.metaparser._metaparser.MetaParser.parse
2023-05-16T11:19:42: %SCRIPT-ERROR:   File "src/genie/metaparser/util/schemaengine.py", line 415, in genie.metaparser.util.schemaengine.Schema.validate
2023-05-16T11:19:42: %SCRIPT-ERROR: genie.metaparser.util.exceptions.SchemaMissingKeyError: Missing keys: [['GigabitEthernet1/0/2', 'switchport_mode']]
```


## Impact (If any)
N/A

## Screenshots:
```
python3 folder_parsing_job.py -o iosxe -c ShowInterfacesSwitchport
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: |                   Starting testcase SuperFileBasedTesting                    |
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: |                            Starting section setup                            |
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: The result of section setup is => PASSED
2023-05-16T13:35:14: %AETEST-INFO: The result of testcase SuperFileBasedTesting is => PASSED
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: |                           Starting testcase iosxe                            |
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: |                            Starting section setup                            |
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: The result of section setup is => PASSED
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:14: %AETEST-INFO: |                  Starting section ShowInterfacesSwitchport                   |
2023-05-16T13:35:14: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :              Starting STEP 1: iosxe -> ShowInterfacesSwitchport              :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :     Starting STEP 1.1: Test Golden -> iosxe -> ShowInterfacesSwitchport      :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :    Starting STEP 1.1.1: Gold -> iosxe -> ShowInterfacesSwitchport -> gold    :
2023-05-16T13:35:15: %AETEST-INFO: :                                 en_output_2                                  :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output_2 is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :    Starting STEP 1.1.2: Gold -> iosxe -> ShowInterfacesSwitchport -> gold    :
2023-05-16T13:35:15: %AETEST-INFO: :                                 en_output_3                                  :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.1.2: Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output_3 is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :    Starting STEP 1.1.3: Gold -> iosxe -> ShowInterfacesSwitchport -> gold    :
2023-05-16T13:35:15: %AETEST-INFO: :                                 en_output_4                                  :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.1.3: Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output_4 is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :    Starting STEP 1.1.4: Gold -> iosxe -> ShowInterfacesSwitchport -> gold    :
2023-05-16T13:35:15: %AETEST-INFO: :                                  en_output                                   :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.1.4: Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowInterfacesSwitchport is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :      Starting STEP 1.2: Test Empty -> iosxe -> ShowInterfacesSwitchport      :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: :    Starting STEP 1.2.1: Empty -> iosxe -> ShowInterfacesSwitchport -> emp    :
2023-05-16T13:35:15: %AETEST-INFO: :                                  ty_output                                   :
2023-05-16T13:35:15: %AETEST-INFO: +..............................................................................+
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowInterfacesSwitchport -> empty_output is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowInterfacesSwitchport is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: The result of STEP 1: iosxe -> ShowInterfacesSwitchport is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: +..........................................................+
2023-05-16T13:35:15: %AETEST-INFO: :                       STEPS Report                       :
2023-05-16T13:35:15: %AETEST-INFO: +..........................................................+
2023-05-16T13:35:15: %AETEST-INFO: STEP 1 - iosxe -> ShowInterfacesSwitchport        Passed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowInterfacesSwitchportPassed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output_2Passed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.1.2 - Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output_3Passed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.1.3 - Gold -> iosxe -> ShowInterfacesSwitchport -> golden_output_4Passed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.1.4 - Gold -> iosxe -> ShowInterfacesSwitchport -> golden_outputPassed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowInterfacesSwitchportPassed    
2023-05-16T13:35:15: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowInterfacesSwitchport -> empty_outputPassed    
2023-05-16T13:35:15: %AETEST-INFO: ............................................................
2023-05-16T13:35:15: %AETEST-INFO: The result of section ShowInterfacesSwitchport is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %AETEST-INFO: |                           Starting section cleanup                           |
2023-05-16T13:35:15: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %AETEST-INFO: The result of section cleanup is => PASSED
2023-05-16T13:35:15: %AETEST-INFO: The result of testcase iosxe is => PASSED
2023-05-16T13:35:15: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %GENIE-INFO: |                               Unittest results                               |
2023-05-16T13:35:15: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %GENIE-INFO:  SECTIONS/TESTCASES                                                      RESULT   
2023-05-16T13:35:15: %GENIE-INFO: --------------------------------------------------------------------------------
2023-05-16T13:35:15: %GENIE-INFO: .
2023-05-16T13:35:15: %GENIE-INFO: |-- SuperFileBasedTesting                                                 PASSED
2023-05-16T13:35:15: %GENIE-INFO: |   `-- setup                                                             PASSED
2023-05-16T13:35:15: %GENIE-INFO: `-- iosxe                                                                 PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |-- setup                                                             PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |-- ShowInterfacesSwitchport                                          PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1: iosxe -> ShowInterfacesSwitchport                     PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1.1: Test Golden -> iosxe -> ShowInterfacesSwitchport    PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1.1.1: Gold -> iosxe -> ShowInterfacesSwitchport -...    PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1.1.2: Gold -> iosxe -> ShowInterfacesSwitchport -...    PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1.1.3: Gold -> iosxe -> ShowInterfacesSwitchport -...    PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1.1.4: Gold -> iosxe -> ShowInterfacesSwitchport -...    PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   |-- Step 1.2: Test Empty -> iosxe -> ShowInterfacesSwitchport     PASSED
2023-05-16T13:35:15: %GENIE-INFO:     |   `-- Step 1.2.1: Empty -> iosxe -> ShowInterfacesSwitchport ...    PASSED
2023-05-16T13:35:15: %GENIE-INFO:     `-- cleanup                                                           PASSED
2023-05-16T13:35:15: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %GENIE-INFO: |                                   Summary                                    |
2023-05-16T13:35:15: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T13:35:15: %GENIE-INFO:  Number of ABORTED                                                            0 
2023-05-16T13:35:15: %GENIE-INFO:  Number of BLOCKED                                                            0 
2023-05-16T13:35:15: %GENIE-INFO:  Number of ERRORED                                                            0 
2023-05-16T13:35:15: %GENIE-INFO:  Number of FAILED                                                             0 
2023-05-16T13:35:15: %GENIE-INFO:  Number of PASSED                                                             2 
2023-05-16T13:35:15: %GENIE-INFO:  Number of PASSX                                                              0 
2023-05-16T13:35:15: %GENIE-INFO:  Number of SKIPPED                                                            0 
2023-05-16T13:35:15: %GENIE-INFO:  Total Number                                                                 2 
2023-05-16T13:35:15: %GENIE-INFO:  Success Rate                                                            100.0% 
2023-05-16T13:35:15: %GENIE-INFO: --------------------------------------------------------------------------------
2023-05-16T13:35:15: %GENIE-INFO:  Total Passing Unittests                                                      5 
2023-05-16T13:35:15: %GENIE-INFO:  Total Failed Unittests                                                       0 
2023-05-16T13:35:15: %GENIE-INFO:  Total Errored Unittests                                                      0 
2023-05-16T13:35:15: %GENIE-INFO:  Total Unittests                                                              5 
2023-05-16T13:35:15: %GENIE-INFO: --------------------------------------------------------------------------------
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
