### PR TITLE
Modified status key in "show access-sessions"

### DIFF
--- a/changelog/undistributed/changelog_show_access_session_iosxe_20230515150759.rst
+++ b/changelog/undistributed/changelog_show_access_session_iosxe_20230515150759.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowAccessSession:
+        * Changed status key to reflect status displayed on command output.

--- a/src/genie/libs/parser/iosxe/tests/ShowAccessSession/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowAccessSession/cli/equal/golden_output_expected.py
@@ -1,5 +1,5 @@
 expected_output = {
-    "session_count": 1,
+    "session_count": 2,
     "interfaces": {
         "GigabitEthernet1/0/1": {
             "interface": "GigabitEthernet1/0/1",
@@ -8,14 +8,30 @@ expected_output = {
                     "client": "f4cf.beff.9cb1",
                     "method": "dot1x",
                     "domain": "DATA",
-                    "status": "authenticator",
+                    "status": "Auth",
                     "session": {
                         "000000000000000BB6FC9EAF": {
                             "session_id": "000000000000000BB6FC9EAF"
                         }
-                    },
+                    }
                 }
-            },
+            }
+        },
+        "GigabitEthernet1/0/2": {
+            "interface": "GigabitEthernet1/0/2",
+            "client": {
+                "aabb.cc11.2233": {
+                    "client": "aabb.cc11.2233",
+                    "method": "dot1x",
+                    "domain": "VOICE",
+                    "status": "Unauth",
+                    "session": {
+                        "000000000000000A1B2C3D4E": {
+                            "session_id": "000000000000000A1B2C3D4E"
+                        }
+                    }
+                }
+            }
         }
-    },
+    }
 }

--- a/src/genie/libs/parser/iosxe/tests/ShowAccessSession/cli/equal/golden_output_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowAccessSession/cli/equal/golden_output_output.txt
@@ -1,6 +1,7 @@
 Interface                MAC Address    Method  Domain  Status Fg  Session ID
 --------------------------------------------------------------------------------------------
 Gi1/0/1                  f4cf.beff.9cb1 dot1x   DATA    Auth        000000000000000BB6FC9EAF
+Gi1/0/2                  aabb.cc11.2233 dot1x   VOICE   Unauth      000000000000000A1B2C3D4E
 
-Session count = 1
+Session count = 2
     


### PR DESCRIPTION
## Description
Modified the key in the show access-sessions parser to display the status that is shown in the command output, rather than something from a predetermined dictionary which does not indicate the status of the client.

## Motivation and Context
This change was made since we had to start using show access-session instead of show authentication sessions and noticed that the status displayed was "authenticator" (role of the switch) rather than the authentication status of the client, which gave us incorrect outputs when we used parsers to check for authentication status. 
The show authentication sessions parser did not have this issue.

For example: 
Output: `Gi1/0/1 f4cf.beff.9cb1 dot1x DATA Auth 000000000000000BB6FC9EAF`
Old: `"status": "authenticator"`
New: `"status": "Auth"`

## Impact (If any)
Removed information about the role of the switch. This information was not present in the show authentication sessions parser, in which both commands show the same output.

## Screenshots:
```
python3 folder_parsing_job.py -o iosxe -c ShowAccessSession
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: |                   Starting testcase SuperFileBasedTesting                    |
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: |                            Starting section setup                            |
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: The result of section setup is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: The result of testcase SuperFileBasedTesting is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: |                           Starting testcase iosxe                            |
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: |                            Starting section setup                            |
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: The result of section setup is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: |                      Starting section ShowAccessSession                      |
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: :                 Starting STEP 1: iosxe -> ShowAccessSession                  :
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: :         Starting STEP 1.1: Test Golden -> iosxe -> ShowAccessSession         :
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: :    Starting STEP 1.1.1: Gold -> iosxe -> ShowAccessSession -> golden_outp    :
2023-05-16T15:51:57: %AETEST-INFO: :                                      ut                                      :
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxe -> ShowAccessSession -> golden_output is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxe -> ShowAccessSession is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: :         Starting STEP 1.2: Test Empty -> iosxe -> ShowAccessSession          :
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: :    Starting STEP 1.2.1: Empty -> iosxe -> ShowAccessSession -> empty_outp    :
2023-05-16T15:51:57: %AETEST-INFO: :                                      ut                                      :
2023-05-16T15:51:57: %AETEST-INFO: +..............................................................................+
2023-05-16T15:51:57: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxe -> ShowAccessSession -> empty_output is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxe -> ShowAccessSession is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: The result of STEP 1: iosxe -> ShowAccessSession is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: +..........................................................+
2023-05-16T15:51:57: %AETEST-INFO: :                       STEPS Report                       :
2023-05-16T15:51:57: %AETEST-INFO: +..........................................................+
2023-05-16T15:51:57: %AETEST-INFO: STEP 1 - iosxe -> ShowAccessSession               Passed    
2023-05-16T15:51:57: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxe -> ShowAccessSessionPassed    
2023-05-16T15:51:57: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxe -> ShowAccessSession -> golden_outputPassed    
2023-05-16T15:51:57: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxe -> ShowAccessSessionPassed    
2023-05-16T15:51:57: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxe -> ShowAccessSession -> empty_outputPassed    
2023-05-16T15:51:57: %AETEST-INFO: ............................................................
2023-05-16T15:51:57: %AETEST-INFO: The result of section ShowAccessSession is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: |                           Starting section cleanup                           |
2023-05-16T15:51:57: %AETEST-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %AETEST-INFO: The result of section cleanup is => PASSED
2023-05-16T15:51:57: %AETEST-INFO: The result of testcase iosxe is => PASSED
2023-05-16T15:51:57: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %GENIE-INFO: |                               Unittest results                               |
2023-05-16T15:51:57: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %GENIE-INFO:  SECTIONS/TESTCASES                                                      RESULT   
2023-05-16T15:51:57: %GENIE-INFO: --------------------------------------------------------------------------------
2023-05-16T15:51:57: %GENIE-INFO: .
2023-05-16T15:51:57: %GENIE-INFO: |-- SuperFileBasedTesting                                                 PASSED
2023-05-16T15:51:57: %GENIE-INFO: |   `-- setup                                                             PASSED
2023-05-16T15:51:57: %GENIE-INFO: `-- iosxe                                                                 PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |-- setup                                                             PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |-- ShowAccessSession                                                 PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |   |-- Step 1: iosxe -> ShowAccessSession                            PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |   |-- Step 1.1: Test Golden -> iosxe -> ShowAccessSession           PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |   |-- Step 1.1.1: Gold -> iosxe -> ShowAccessSession -> golde...    PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |   |-- Step 1.2: Test Empty -> iosxe -> ShowAccessSession            PASSED
2023-05-16T15:51:57: %GENIE-INFO:     |   `-- Step 1.2.1: Empty -> iosxe -> ShowAccessSession -> empt...    PASSED
2023-05-16T15:51:57: %GENIE-INFO:     `-- cleanup                                                           PASSED
2023-05-16T15:51:57: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %GENIE-INFO: |                                   Summary                                    |
2023-05-16T15:51:57: %GENIE-INFO: +------------------------------------------------------------------------------+
2023-05-16T15:51:57: %GENIE-INFO:  Number of ABORTED                                                            0 
2023-05-16T15:51:57: %GENIE-INFO:  Number of BLOCKED                                                            0 
2023-05-16T15:51:57: %GENIE-INFO:  Number of ERRORED                                                            0 
2023-05-16T15:51:57: %GENIE-INFO:  Number of FAILED                                                             0 
2023-05-16T15:51:57: %GENIE-INFO:  Number of PASSED                                                             2 
2023-05-16T15:51:57: %GENIE-INFO:  Number of PASSX                                                              0 
2023-05-16T15:51:57: %GENIE-INFO:  Number of SKIPPED                                                            0 
2023-05-16T15:51:57: %GENIE-INFO:  Total Number                                                                 2 
2023-05-16T15:51:57: %GENIE-INFO:  Success Rate                                                            100.0% 
2023-05-16T15:51:57: %GENIE-INFO: --------------------------------------------------------------------------------
2023-05-16T15:51:57: %GENIE-INFO:  Total Passing Unittests                                                      2 
2023-05-16T15:51:57: %GENIE-INFO:  Total Failed Unittests                                                       0 
2023-05-16T15:51:57: %GENIE-INFO:  Total Errored Unittests                                                      0 
2023-05-16T15:51:57: %GENIE-INFO:  Total Unittests                                                              2 
2023-05-16T15:51:57: %GENIE-INFO: --------------------------------------------------------------------------------
```

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
