### PR TITLE
PR for adding functionality to parse additional interface configuration using ShowRunInterface

### DIFF
--- a/changelog/undistributed/change_log_show_running_interface_iosxe_20230621154805.rst
+++ b/changelog/undistributed/change_log_show_running_interface_iosxe_20230621154805.rst
@@ -1,0 +1,13 @@
+1. An existing parser class that has new/additional configuration lines to parse:
+
+--------------------------------------------------------------------------------
+                            New
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowRunInterfaceSchema to parse the following configuration lines for an interface:
+        * dot1x_timeout_supp_timeout : str
+        * dot1x_timeout_ratelimit_period : str
+        * dot1x_source_template : str
+        * ipv6_nd_raguard : bool
+        * spanning_tree_guard : str
+        * switchport_voice_vlan : str

--- a/src/genie/libs/parser/iosxe/tests/ShowRunInterface/cli/equal/golden_output21_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowRunInterface/cli/equal/golden_output21_expected.py
@@ -1,0 +1,13 @@
+expected_output = {
+    'interfaces': {
+        'GigabitEthernet1/0/1': {
+            'switchport_voice_vlan': '400',
+            'dot1x_timeout_supp_timeout': '5',
+            'dot1x_timeout_ratelimit_period': '300',
+            'dot1x_source_template': 'ENT-TEMPLATE_CLOSED_MODE',
+            'ipv6_nd_raguard': True,
+            'spanning_tree_guard': 'root'
+
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowRunInterface/cli/equal/golden_output21_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowRunInterface/cli/equal/golden_output21_output.txt
@@ -1,0 +1,7 @@
+interface GigabitEthernet1/0/1
+ switchport voice vlan 400
+ ipv6 nd raguard
+ dot1x timeout supp-timeout 5
+ dot1x timeout ratelimit-period 300
+ source template ENT-TEMPLATE_CLOSED_MODE
+ spanning-tree guard root


### PR DESCRIPTION
## Description
Added functionality in show_run.py ShowRunInterface class to parse additional lines of config - dot1x timeouts (supp_timeout, ratelimit_period), dot1x source template, ipv6_nd_raguard, spanning_tree_guard, and switchport for voice vlan.

## Motivation and Context
This change helps us parse the additional lines using genieparser, and helps us get complete characteristics of an interface configuration. Previously, we weren't able to use this parser to check whether an interface is dot1x (802.1x) configured or not, now we can.

## Impact (If any)
No negative impact

## Screenshots:

<img width="1161" alt="genieparser_pytest" src="https://github.com/CiscoTestAutomation/genieparser/assets/133776112/11ce0fb3-0cdf-4e3b-9970-c80ef0ff5d03">

<img width="627" alt="genienew_complied_output" src="https://github.com/CiscoTestAutomation/genieparser/assets/133776112/27f590c6-8cd0-4785-9c0e-e8bbbb134551">

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
