### PR TITLE
Update show_hsrp.py

### DIFF
--- a/src/genie/libs/parser/iosxr/show_hsrp.py
+++ b/src/genie/libs/parser/iosxr/show_hsrp.py
@@ -229,8 +229,8 @@ class ShowHsrpDetailSchema(MetaParser):
             'interface': str,
             Optional('bfd'): {
                 'enabled': bool,
-                'detection_multiplier': int,
-                'interval': int,
+                Optional('detection_multiplier'): int,
+                Optional('interval'): int,
             },            Optional('use_bia'): bool,
             Optional('delay'): {
                 'minimum_delay': int,


### PR DESCRIPTION
Parsing fails if the p9.match(line) parses the second case of your example (bfd enabled but interface unknown)

hsrp_detail_dict[interface]['bfd']['enabled'] gets set in line 668 but line 669 will prevent that hsrp_detail_dict[interface]['bfd']['detection_multiplier'] & hsrp_detail_dict[interface]['bfd']['interval'] gets written. Therefore the later 2 should be optional.

## Description
hsrp_detail_dict[interface]['bfd']['enabled'] gets set in line 668 but line 669 will prevent that hsrp_detail_dict[interface]['bfd']['detection_multiplier'] & hsrp_detail_dict[interface]['bfd']['interval'] gets written. Therefore the later 2 should be optional.

## Motivation and Context
Parsing fails if BFD is enabled on a HSRP interface in INIT State / down

## Impact (If any)
<!--- If there is any negative impact - what is it? -->

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
