### PR TITLE
Fix 3 line output for nxos ShowBgpVrfAllAllSummary

### DIFF
--- a/changelog/undistributed/20231206203629
+++ b/changelog/undistributed/20231206203629
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* NXOS
+    * Modified ShowBgpVrfAllAllSummary:
+        * Added support for parsing 3 lines when v6 neighbor and AS require 3 line output

--- a/src/genie/libs/parser/nxos/show_bgp.py
+++ b/src/genie/libs/parser/nxos/show_bgp.py
@@ -3602,6 +3602,9 @@ class ShowBgpVrfAllAllSummary(ShowBgpVrfAllAllSummarySchema):
                             ' +(?P<outq>[0-9]+) +(?P<up_down>[a-zA-Z0-9\:]+)'
                             ' +(?P<state_pfxrcd>(?P<state>[a-zA-Z\s\(\)]+)?(?P<prx_rcd>\d+)?([\w\(\)\s]+)?)$')
         # Neighbor        V             AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+        #                 4 123456
+        p8_2_1 = re.compile(r'^\s*(?P<v>[0-9]+) +(?P<as>[0-9]+)$')
+        # Neighbor        V             AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
         # 10.10.10.10     4 4211111111
         p8_3 = re.compile(r'^\s*(?P<neighbor>[a-zA-Z0-9\.\:]+) +(?P<v>[0-9]+) +(?P<as>[0-9]+)$')
         # Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
@@ -3851,6 +3854,23 @@ class ShowBgpVrfAllAllSummary(ShowBgpVrfAllAllSummarySchema):
                     nbr_af_dict['path']['total_entries'] = num_path_entries
                     nbr_af_dict['path']['memory_usage'] = memory_usage
                     continue
+
+            # Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+            #                 4 4211111111
+            m = p8_2_1.match(line)
+            if m and data_on_nextline:
+
+                # Add address family to this neighbor
+                if 'address_family' not in nbr_dict:
+                    nbr_dict['address_family'] = {}
+                if address_family not in nbr_dict['address_family']:
+                    nbr_dict['address_family'][address_family] = {}
+                nbr_af_dict = nbr_dict['address_family'][address_family]
+
+                # Add keys for this address_family
+                nbr_af_dict['neighbor_table_version'] = int(m.groupdict()['v'])
+                nbr_af_dict['as'] = int(m.groupdict()['as'])
+                continue
 
             # Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
             # 10.10.10.10     4 4211111111

--- a/src/genie/libs/parser/nxos/tests/ShowBgpVrfAllAllSummary/cli/equal/golden_output_6_expected.py
+++ b/src/genie/libs/parser/nxos/tests/ShowBgpVrfAllAllSummary/cli/equal/golden_output_6_expected.py
@@ -1,0 +1,237 @@
+expected_output = {
+    "vrf": {
+        "default": {
+            "neighbor": {
+                "2001:db8:c006:0:3e57:31ff:feb8:5dc4": {
+                    "address_family": {
+                        "ipv6 unicast": {
+                            "neighbor_table_version": 4,
+                            "as": 65011,
+                            "msg_rcvd": 0,
+                            "msg_sent": 0,
+                            "tbl_ver": 0,
+                            "inq": 0,
+                            "outq": 0,
+                            "up_down": "05:49:52",
+                            "state_pfxrcd": "shut (admin)",
+                            "state": "shut (admin)",
+                            "route_identifier": "172.22.251.3",
+                            "local_as": 65101,
+                            "bgp_table_version": 47,
+                            "config_peers": 6,
+                            "capable_peers": 1,
+                            "attribute_entries": "[4/688]",
+                            "as_path_entries": "[0/0]",
+                            "community_entries": "[0/0]",
+                            "clusterlist_entries": "[0/0]",
+                            "soft_reconfig_recvd_paths": 9,
+                            "soft_reconfig_identical_paths": 9,
+                            "soft_reconfig_combo_paths": 0,
+                            "soft_reconfig_filtered_recvd": 0,
+                            "soft_reconfig_bytes": 0,
+                            "prefixes": {
+                                "total_entries": 9,
+                                "memory_usage": 3744
+                            },
+                            "path": {
+                                "total_entries": 21,
+                                "memory_usage": 3744
+                            }
+                        }
+                    }
+                },
+                "2001:db8:c006:ee::25": {
+                    "address_family": {
+                        "ipv6 unicast": {
+                            "neighbor_table_version": 4,
+                            "as": 65120,
+                            "msg_rcvd": 0,
+                            "msg_sent": 0,
+                            "tbl_ver": 0,
+                            "inq": 0,
+                            "outq": 0,
+                            "up_down": "05:49:52",
+                            "state_pfxrcd": "idle",
+                            "state": "idle",
+                            "route_identifier": "172.22.251.3",
+                            "local_as": 65101,
+                            "bgp_table_version": 47,
+                            "config_peers": 6,
+                            "capable_peers": 1,
+                            "attribute_entries": "[4/688]",
+                            "as_path_entries": "[0/0]",
+                            "community_entries": "[0/0]",
+                            "clusterlist_entries": "[0/0]",
+                            "soft_reconfig_recvd_paths": 9,
+                            "soft_reconfig_identical_paths": 9,
+                            "soft_reconfig_combo_paths": 0,
+                            "soft_reconfig_filtered_recvd": 0,
+                            "soft_reconfig_bytes": 0,
+                            "prefixes": {
+                                "total_entries": 9,
+                                "memory_usage": 3744
+                            },
+                            "path": {
+                                "total_entries": 21,
+                                "memory_usage": 3744
+                            }
+                        }
+                    }
+                },
+                "2001:db8:c006:ff:1::8": {
+                    "address_family": {
+                        "ipv6 unicast": {
+                            "neighbor_table_version": 4,
+                            "as": 65152,
+                            "msg_rcvd": 0,
+                            "msg_sent": 0,
+                            "tbl_ver": 0,
+                            "inq": 0,
+                            "outq": 0,
+                            "up_down": "05:49:52",
+                            "state_pfxrcd": "idle",
+                            "state": "idle",
+                            "route_identifier": "172.22.251.3",
+                            "local_as": 65101,
+                            "bgp_table_version": 47,
+                            "config_peers": 6,
+                            "capable_peers": 1,
+                            "attribute_entries": "[4/688]",
+                            "as_path_entries": "[0/0]",
+                            "community_entries": "[0/0]",
+                            "clusterlist_entries": "[0/0]",
+                            "soft_reconfig_recvd_paths": 9,
+                            "soft_reconfig_identical_paths": 9,
+                            "soft_reconfig_combo_paths": 0,
+                            "soft_reconfig_filtered_recvd": 0,
+                            "soft_reconfig_bytes": 0,
+                            "prefixes": {
+                                "total_entries": 9,
+                                "memory_usage": 3744
+                            },
+                            "path": {
+                                "total_entries": 21,
+                                "memory_usage": 3744
+                            }
+                        }
+                    }
+                },
+                "2001:db8:c006:ff:1::9": {
+                    "address_family": {
+                        "ipv6 unicast": {
+                            "neighbor_table_version": 4,
+                            "as": 65152,
+                            "msg_rcvd": 0,
+                            "msg_sent": 0,
+                            "tbl_ver": 0,
+                            "inq": 0,
+                            "outq": 0,
+                            "up_down": "05:49:52",
+                            "state_pfxrcd": "idle",
+                            "state": "idle",
+                            "route_identifier": "172.22.251.3",
+                            "local_as": 65101,
+                            "bgp_table_version": 47,
+                            "config_peers": 6,
+                            "capable_peers": 1,
+                            "attribute_entries": "[4/688]",
+                            "as_path_entries": "[0/0]",
+                            "community_entries": "[0/0]",
+                            "clusterlist_entries": "[0/0]",
+                            "soft_reconfig_recvd_paths": 9,
+                            "soft_reconfig_identical_paths": 9,
+                            "soft_reconfig_combo_paths": 0,
+                            "soft_reconfig_filtered_recvd": 0,
+                            "soft_reconfig_bytes": 0,
+                            "prefixes": {
+                                "total_entries": 9,
+                                "memory_usage": 3744
+                            },
+                            "path": {
+                                "total_entries": 21,
+                                "memory_usage": 3744
+                            }
+                        }
+                    }
+                },
+                "2001:db8:c006:ff:251::1": {
+                    "address_family": {
+                        "ipv6 unicast": {
+                            "neighbor_table_version": 4,
+                            "as": 406942,
+                            "msg_rcvd": 0,
+                            "msg_sent": 0,
+                            "tbl_ver": 0,
+                            "inq": 0,
+                            "outq": 0,
+                            "up_down": "05:49:52",
+                            "state_pfxrcd": "idle",
+                            "state": "idle",
+                            "route_identifier": "172.22.251.3",
+                            "local_as": 65101,
+                            "bgp_table_version": 47,
+                            "config_peers": 6,
+                            "capable_peers": 1,
+                            "attribute_entries": "[4/688]",
+                            "as_path_entries": "[0/0]",
+                            "community_entries": "[0/0]",
+                            "clusterlist_entries": "[0/0]",
+                            "soft_reconfig_recvd_paths": 9,
+                            "soft_reconfig_identical_paths": 9,
+                            "soft_reconfig_combo_paths": 0,
+                            "soft_reconfig_filtered_recvd": 0,
+                            "soft_reconfig_bytes": 0,
+                            "prefixes": {
+                                "total_entries": 9,
+                                "memory_usage": 3744
+                            },
+                            "path": {
+                                "total_entries": 21,
+                                "memory_usage": 3744
+                            }
+                        }
+                    }
+                },
+                "2001:db8:c006:ff:251::4": {
+                    "address_family": {
+                        "ipv6 unicast": {
+                            "neighbor_table_version": 4,
+                            "as": 65101,
+                            "msg_rcvd": 2104,
+                            "msg_sent": 2101,
+                            "tbl_ver": 47,
+                            "inq": 0,
+                            "outq": 0,
+                            "up_down": "05:49:31",
+                            "state_pfxrcd": "9",
+                            "prefix_received": "9",
+                            "state": "established",
+                            "route_identifier": "172.22.251.3",
+                            "local_as": 65101,
+                            "bgp_table_version": 47,
+                            "config_peers": 6,
+                            "capable_peers": 1,
+                            "attribute_entries": "[4/688]",
+                            "as_path_entries": "[0/0]",
+                            "community_entries": "[0/0]",
+                            "clusterlist_entries": "[0/0]",
+                            "soft_reconfig_recvd_paths": 9,
+                            "soft_reconfig_identical_paths": 9,
+                            "soft_reconfig_combo_paths": 0,
+                            "soft_reconfig_filtered_recvd": 0,
+                            "soft_reconfig_bytes": 0,
+                            "prefixes": {
+                                "total_entries": 9,
+                                "memory_usage": 3744
+                            },
+                            "path": {
+                                "total_entries": 21,
+                                "memory_usage": 3744
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/genie/libs/parser/nxos/tests/ShowBgpVrfAllAllSummary/cli/equal/golden_output_6_output.txt
+++ b/src/genie/libs/parser/nxos/tests/ShowBgpVrfAllAllSummary/cli/equal/golden_output_6_output.txt
@@ -1,0 +1,24 @@
+show bgp vrf default ipv6 uni summary
+BGP summary information for VRF default, address family IPv6 Unicast
+BGP router identifier 172.22.251.3, local AS number 65101
+BGP table version is 47, IPv6 Unicast config peers 6, capable peers 1
+9 network entries and 21 paths using 3744 bytes of memory
+BGP attribute entries [4/688], BGP AS path entries [0/0]
+BGP community entries [0/0], BGP clusterlist entries [0/0]
+9 received paths for inbound soft reconfiguration
+9 identical, 0 modified, 0 filtered received paths using 0 bytes
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+2001:db8:c006:0:3e57:31ff:feb8:5dc4
+                4 65011       0       0        0    0    0 05:49:52 Shut (Admin)
+2001:db8:c006:ee::25
+                4 65120       0       0        0    0    0 05:49:52 Idle
+2001:db8:c006:ff:1::8
+                4 65152       0       0        0    0    0 05:49:52 Idle
+2001:db8:c006:ff:1::9
+                4 65152       0       0        0    0    0 05:49:52 Idle
+2001:db8:c006:ff:251::1
+                4 406942
+                              0       0        0    0    0 05:49:52 Idle
+2001:db8:c006:ff:251::4
+                4 65101    2104    2101       47    0    0 05:49:31 9


### PR DESCRIPTION
## Description
With IPv6 addresses the show bgp summary output sometimes has to wrap to two lines. When using a 4-byte ASN it can cause it to wrap to 3 lines, the first line for the IP, the second line for the version and the ASN, and the third line the remaining values. This change parses 3 line output correctly.

## Motivation and Context
see descr

## Impact (If any)
none


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
