### PR TITLE
Standardize VRF Regex for IOSXE show_vrf.py

### DIFF
--- a/changelog/undistributed/change_log_show_vrf_iosxe_20231209154701.rst
+++ b/changelog/undistributed/change_log_show_vrf_iosxe_20231209154701.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowVrf:
+        * Standardized VRF Matching to include special characters beyond dash and dot

--- a/src/genie/libs/parser/iosxe/show_vrf.py
+++ b/src/genie/libs/parser/iosxe/show_vrf.py
@@ -65,7 +65,7 @@ class ShowVrf(ShowVrfSchema):
         # test                             10.116.83.34:100      ipv4,ipv6   Lo100
         # ce1                              <being deleted>       ipv4,ipv6   Et1/0
         # * ce1                              2:2                   ipv4,ipv6
-        p1 = re.compile(r'^(((?P<being_deleted>\*))\s+)?(?P<vrf>[\w\d\-\.]+)\s+(?P<rd>\<not +set\>|<being deleted>|[\.\d\:]+)(?:\s+(?P<protocols>[(?:ipv\d)\,]+))?(?:\s+(?P<intf>[\S\s]+))?$')
+        p1 = re.compile(r'^(((?P<being_deleted>\*))\s+)?(?P<vrf>[\S]+)\s+(?P<rd>\<not +set\>|<being deleted>|[\.\d\:]+)(?:\s+(?P<protocols>[(?:ipv\d)\,]+))?(?:\s+(?P<intf>[\S\s]+))?$')
 
         # Lo300
         # Gi2.390
@@ -282,7 +282,7 @@ class ShowVrfDetailSuperParser(ShowVrfDetailSchema):
                         r'current +count +(?P<count>\d+)$')
 
         # VRF label distribution protocol: not configured
-        p10 = re.compile(r'^VRF +label +distribution +protocol: +(?P<vrf_label>[\w\s\-]+)$')
+        p10 = re.compile(r'^VRF +label +distribution +protocol: +(?P<vrf_label>[\S]+)$')
 
         # VRF label allocation mode: per-prefix
         p11 = re.compile(r'^VRF +label +allocation +mode: +(?P<mode>[\w\s\-]+)'
@@ -591,7 +591,7 @@ class ShowVRFIPv6(ShowVRFIPv6Schema):
             output = self.device.execute(self.cli_command.format(vrf=vrf))
             
         res_dict = {}
-        p1 = re.compile(r'^(?P<vrf>[\w\d]+)+\s+(?P<default_rd>[\d\:\d]+)+\s+(?P<protocols>[\w\,\w]+)\s+\s\s(?P<interface>[\w\d]+)*$')
+        p1 = re.compile(r'^(?P<vrf>[\S]+)+\s+(?P<default_rd>[\d\:\d]+)+\s+(?P<protocols>[\w\,\w]+)\s+\s\s(?P<interface>[\w\d]+)*$')
         for line in output.splitlines():
             line = line.strip()
             # vrf21                                21:1              ipv4,ipv6   Vl21'''
@@ -648,7 +648,7 @@ class ShowPlatformSoftwareCefIpVrf(ShowPlatformSoftwareCefIpVrfSchema):
             output = self.device.execute(self.cli_command.format(protocol=protocol, option=option, ip=ip,mask=mask))
 
         # VRF Default
-        p1 = re.compile(r'^VRF\s+(?P<vrf_name>[\w\s\-]+)$')
+        p1 = re.compile(r'^VRF\s+(?P<vrf_name>[\S]+)$')
 
         # ------------------ show ip route vrf Default 11.1.6.1 255.255.255.0 ------------------
         # ------------------ show ip cef vrf vrf1000 11.1.6.1 255.255.255.0 internal ------------------

--- a/src/genie/libs/parser/iosxe/tests/ShowVrf/cli/equal/golden_output_4_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowVrf/cli/equal/golden_output_4_expected.py
@@ -1,0 +1,8 @@
+expected_output = {
+   "vrf": {
+        "t!#$%()*+@^:t/<>,.~`'\";t": {
+            "protocols": ["ipv4", "ipv6"],
+            "route_distinguisher": "1:1"
+            },
+    }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowVrf/cli/equal/golden_output_4_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowVrf/cli/equal/golden_output_4_output.txt
@@ -1,0 +1,2 @@
+  Name                             Default RD            Protocols   Interfaces
+  t!#$%()*+@^:t/<>,.~`'";t         1:1                   ipv4,ipv6


### PR DESCRIPTION
Currently ShowVrf doesn't match all valid special characters in VRF names, and uses different regexes for different commands throughout show_vrf.py. This change standardizes the regexes to all be the same and matches the special characters.

## Description
This is a minor commit that standardizes the vrf regex in "show_vrf.py" so that they all use the [\S\]+ rather than the mix of regexes that matched only certain special characters. This makes iosxe's show_vrf.py comparable with nxos's show_vrf.py. 

## Motivation and Context
IOS-XE parser didn't match VRF's with special characters.

## Impact (If any)
None that I'm aware of

## Screenshots:
Screenshot's of the relevant tests that had classes changed.
ShowVrf
<img width="807" alt="image" src="https://github.com/CiscoTestAutomation/genieparser/assets/11523190/6fb2c417-ce63-4621-a9d2-525bbcf9a692">
ShowVrfDetail
<img width="814" alt="image" src="https://github.com/CiscoTestAutomation/genieparser/assets/11523190/8d259a95-8b4f-464b-aaff-0587790b6772">
ShowVRFIPv6
<img width="812" alt="image" src="https://github.com/CiscoTestAutomation/genieparser/assets/11523190/580589cc-cfc3-4d2e-8085-91e2803dd77f">
ShowPlatformSoftwareCefIpVrf
<img width="815" alt="image" src="https://github.com/CiscoTestAutomation/genieparser/assets/11523190/e64e7cb0-0a81-4a5f-976e-3954d6a1120f">


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ x ] I have added tests to cover my changes (If applicable).
- [ x ] All new and existing tests passed.
- [ ] All new code passed compilation.
