### PR TITLE
Port-channel Fixes for iosxe ShowCtsInterface parser (iosxe/show_cts)

### DIFF
--- a/changelog/undistributed/changelog_fix_show_cts_iosxe_20200807212611.rst
+++ b/changelog/undistributed/changelog_fix_show_cts_iosxe_20200807212611.rst
@@ -1,0 +1,13 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowCtsInterfaceSchema:
+        * Changed global_dot1x_feature from schema to Optional (not present on port-channel interfaces)
+        * Changed cts mode value from schema to Optional to (not present when cts status is disabled)
+    * Modified ShowCtsInterface:
+        * Updated regex pattern p2 to also match Port-channel interfaces
+        * Updated regex pattern p3 to also match CTS disabled status
+        * Added conditional to cts_dict so mode key is not generated if cts is disabled
+    * Modified golden_output2_expected test data
+        * Added expected output for Port-channel interfaces

--- a/src/genie/libs/parser/iosxe/show_cts.py
+++ b/src/genie/libs/parser/iosxe/show_cts.py
@@ -2215,7 +2215,7 @@ class ShowCtsInterfaceSchema(MetaParser):
     """Schema for show cts interface'"""
 
     schema = {
-        'global_dot1x_feature': str,
+        Optional('global_dot1x_feature'): str,
         'interfaces': {
             Any(): {
                 'cts': {
@@ -2282,10 +2282,10 @@ class ShowCtsInterface(ShowCtsInterfaceSchema):
         # TenGigabitEthernet1/0/6:
         # Tunnel100: 
         # TenGigabitEthernet1/0/6.30:
-        p2 = re.compile(r'^Interface\s+(?P<interface>\S+\d+\/\d+\/\d+|Tunnel\d+|\S+\d+\/\d+\/\d+\.\d+):')
+        p2 = re.compile(r'^Interface\s+(?P<interface>\S+\d+\/\d+\/\d+|(Tunnel|Port-channel)\d+|\S+\d+\/\d+\/\d+\.\d+):')
 
         # CTS_status : enabled,mode: MANUAL
-        p3 = re.compile(r'^CTS\s+is\s+(?P<cts_status>\S+),\s+mode:\s+(?P<mode>\S+)')
+        p3 = re.compile(r'^CTS\s+is\s+(?P<cts_status>\S+)(\.|,\s+mode:\s+(?P<mode>\S+))')
 
         # IFC state: OPEN
         p4 = re.compile(r'^IFC state:\s+(?P<ifc_state>\S+)')
@@ -2381,7 +2381,8 @@ class ShowCtsInterface(ShowCtsInterfaceSchema):
                 mode = group['mode']
                 cts_dict = intf_dict.setdefault('cts', {})
                 cts_dict['cts_status'] = cts_status
-                cts_dict['mode'] = mode
+                if mode:
+                    cts_dict['mode'] = mode
 
             # IFC state: OPEN
             m = p4.match(line)

--- a/src/genie/libs/parser/iosxe/tests/ShowCtsInterface/cli/equal/golden_output2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowCtsInterface/cli/equal/golden_output2_expected.py
@@ -106,6 +106,42 @@ expected_output={
         'port_auth_fail': 0
       },
       'l3_ipm': 'disabled'
+    },
+    'Port-channel2': {
+        'cts': {
+            'cts_status': 'disabled'
+        },
+        'l3_ipm': 'disabled'
+    },
+    'Port-channel20': {
+        'cts': {
+            'cts_status': 'disabled'
+        },
+        'l3_ipm': 'disabled'
+    },
+    'Port-channel22': {
+        'cts': {
+            'cts_status': 'disabled'
+        },
+        'l3_ipm': 'disabled'
+    },
+    'Port-channel47': {
+        'cts': {
+            'cts_status': 'disabled'
+        },
+        'l3_ipm': 'disabled'
+    },
+    'Port-channel58': {
+        'cts': {
+            'cts_status': 'disabled'
+        },
+        'l3_ipm': 'disabled'
+    },
+    'Port-channel69': {
+        'cts': {
+            'cts_status': 'disabled'
+        },
+        'l3_ipm': 'disabled'
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes/Updates to show_cts iosxe parser and associated tests to support port-channel interfaces.  
* IOSXE
    * Modified ShowCtsInterfaceSchema:
        * Changed global_dot1x_feature from schema to Optional (not present on port-channel interfaces)
        * Changed cts mode value from schema to Optional to (not present when cts status is disabled)
    * Modified ShowCtsInterface:
        * Updated regex pattern p2 to also match Port-channel interfaces
        * Updated regex pattern p3 to also match CTS disabled status
        * Added conditional to cts_dict so mode key is not generated if cts is disabled
    * Modified golden_output2_expected test data
        * Added expected output for Port-channel interfaces
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolves #812 
## Impact (If any)
<!--- If there is any negative impact - what is it? -->

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->
![gh_actions_screenshot](https://github.com/CiscoTestAutomation/genieparser/assets/17861337/67cf7f7c-0fc1-4f84-960c-468ee6e353a6)

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
