### PR TITLE
[IOS-XE] Support space in SSID in ShowWlan

### DIFF
--- a/changelog/undistributed/20240327123253.rst
+++ b/changelog/undistributed/20240327123253.rst
@@ -1,0 +1,10 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOS-XE
+    * Modified ShowWlanAllSchema:
+        * Updated `radio_policy` from schema to Optional
+    * Modified ShowWlanAll:
+        * Updated regex pattern `p_name_ssid` to support SSID with spaces
+    * Modified ShowWlanSummary:
+        * Updated regex pattern `wlan_info_capture` to support SSID with spaces (2 spaces max between each word)

--- a/src/genie/libs/parser/iosxe/show_wlan.py
+++ b/src/genie/libs/parser/iosxe/show_wlan.py
@@ -61,7 +61,7 @@ class ShowWlanSummary(ShowWlanSummarySchema):
             r"^----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------$")
         # 17   lizzard_Global                  lizzard                         UP     [WPA2][802.1x][FT + 802.1x][AES],[FT Enabled]
         wlan_info_capture = re.compile(
-            r"^(?P<wlan_id>\d+)\s+(?P<profile_name>\S+)\s+(?P<ssid>\S+)\s+(?P<wlan_status>\S+)\s+(?P<status_security>.*$)")
+            r"^(?P<wlan_id>\d+)\s+(?P<profile_name>\S+)\s+(?P<ssid>.*?)(?:\s{2,})\s+(?P<wlan_status>\S+)\s+(?P<status_security>.*$)")
 
         for line in out.splitlines():
             line = line.strip()

--- a/src/genie/libs/parser/iosxe/show_wlan.py
+++ b/src/genie/libs/parser/iosxe/show_wlan.py
@@ -137,7 +137,7 @@ class ShowWlanAllSchema(MetaParser):
                 "media_stream_multicast_direct": str,
                 "ccx_aironet_support": str,
                 "p2p_blocking_action": str,
-                "radio_policy": str,
+                Optional("radio_policy"): str,
                 Optional("dtim_period_dot11a"): str,
                 Optional("dtim_period_dot11b"): str,
                 "local_eap_authentication": str,
@@ -393,7 +393,7 @@ class ShowWlanAll(ShowWlanAllSchema):
         p_description = re.compile(r"^Description\s+:\s+(?P<value>.*)$")
 
         # Network Name (SSID)                            : north
-        p_name_ssid = re.compile(r"^Network\s+Name\s+\(SSID\)\s+:\s+(?P<value>\S+)$")
+        p_name_ssid = re.compile(r"^Network\s+Name\s+\(SSID\)\s+:\s+(?P<value>.*)$")
 
         # Status                                         : Enabled
         p_status = re.compile(r"^Status\s+:\s+(?P<value>\S+)$")

--- a/src/genie/libs/parser/iosxe/tests/ShowWlanAll/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowWlanAll/cli/equal/golden_output_expected.py
@@ -353,6 +353,126 @@ expected_output = {
                 "advertise_support": "Enabled",
                 "share_data_with_client": "Disabled"
             }
-        }
+        },
+        'CUSTC_Global_NF_24a65b82': {
+            'identifier': 21,
+            'description': 'SSID-for-Factory-users',
+            'ssid': 'CUST Factory',
+            'status': 'Enabled',
+            'broadcast_ssid': 'Enabled',
+            'advertise_ap_name': 'Disabled',
+            'universal_ap_admin': 'Disabled',
+            'max_clients_wlan': 0,
+            'max_clients_ap': 0,
+            'max_clients_ap_radio': 200,
+            'okc': 'Enabled',
+            'active_clients': 51,
+            'chd_per_wlan': 'Enabled',
+            'wmm': 'Allowed',
+            'wifi_direct_policy': 'Disabled',
+            'channel_scan_defer_priority': {
+                'priority': [
+                    5,
+                    6
+                ]
+            },
+            'scan_defer_time_msecs': 100,
+            'media_stream_multicast_direct': 'Disabled',
+            'ccx_aironet_support': 'Disabled',
+            'p2p_blocking_action': 'Drop',
+            'dtim_period_dot11a': '1',
+            'dtim_period_dot11b': '1',
+            'local_eap_authentication': 'Disabled',
+            'mac_filter_authorization_list_name': 'dnac-cts-CUST-abcde86c6',
+            'mac_filter_override_authorization_list_name': 'Disabled',
+            'dot1x_authentication_list_name': 'Disabled',
+            'dot1x_authorization_list_name': 'Disabled',
+            'security': {
+                'dot11_authentication': 'Open System',
+                'static_wep_keys': 'Disabled',
+                'wifi_protected_access_wpa1_wpa2_wpa3': 'Enabled',
+                'wifi_protected_access_wpa': {
+                    'wpa_ssn_ie': 'Disabled'},
+                'wifi_protected_access_wpa2': {
+                    'wpa2_rsn_ie': 'Enabled',
+                    'wpa2_attributes': {
+                        'mpsk': 'Disabled',
+                        'aes': 'Disabled',
+                        'ccmp256': 'Disabled',
+                        'gcmp128': 'Disabled',
+                        'gcmp256': 'Enabled',
+                        'randomized_gtk': 'Disabled'}},
+                'wifi_protected_access_wpa3': {
+                    'wpa3_ie': 'Disabled'},
+                'auth_key_mgmt': {
+                    'dot1x': 'Disabled',
+                    'psk': 'Disabled',
+                    'cckm': 'Disabled',
+                    'ft_dot1x': 'Disabled',
+                    'ft_psk': 'Disabled',
+                    'dot1x_sha256': 'Disabled',
+                    'psk_sha256': 'Disabled',
+                    'sae': 'Enabled',
+                    'owe': 'Disabled',
+                    'suiteb_1x': 'Disabled',
+                    'suiteb192_1x': 'Disabled'},
+                'cckm_tsf_tolerance_msecs': 1000,
+                'owe_transition_mode': 'Disabled',
+                'osen': 'Disabled',
+                'ft_support': {
+                    'ft_support_status': 'Disabled',
+                    'ft_reassociation_timer_secs': 20,
+                    'ft_over_the_ds_mode': 'Disabled'},
+                'pmf_support': {
+                    'pmf_support_status': 'Disabled',
+                    'pmf_association_comeback_timeout_secs': 1,
+                    'pmf_sa_query_time_msecs': 200},
+                'web_based_authenticaion': 'Disabled',
+                'conditional_web_redirect': 'Disabled',
+                'splash_page_web_redirect': 'Disabled',
+                'webauth_on_mac_filter_failure': 'Disabled',
+                'webauth_authentication_list_name': 'Disabled',
+                'webauth_authorization_list_name': 'Disabled',
+                'webauth_parameter_map': 'Disabled'},
+            'band_select': 'Disabled',
+            'load_balancing': 'Enabled',
+            'multicast_buffer': 'Enabled',
+            'multicast_buffer_frames': 50,
+            'ip_source_guard': 'Disabled',
+            'assisted_roaming': {
+                'neighbbor_list': 'Disabled',
+                'prediction_list': 'Disabled',
+                'dual_band_support': 'Disabled'},
+            'ieee_dot11v_parameters': {
+                'directed_multicast_service': 'Disabled',
+                'bss_max_idle': {
+                    'bss_max_idle_status': 'Enabled',
+                    'protected_mode': 'Disabled'},
+                'traffic_filtering_servce': 'Disabled',
+                'bss_transition': {
+                    'bss_transition_status': 'Disabled',
+                    'disassociation_imminent': {
+                        'disassociation_imminent_status': 'Disabled',
+                        'optimised_roaming_timer': 40,
+                        'timer': 200},
+                    'dual_neighbor_list': 'Disabled'},
+                'wmn_sleep_mode': 'Disabled'},
+            'dot11ac_mu_mimo': 'Disabled',
+            'dot11ax_parameters': {
+                'ofdma_downlink': 'Enabled',
+                'ofdma_uplink': 'Enabled',
+                'mu_mimo_downlink': 'Enabled',
+                'mu_mimo_uplink': 'Enabled',
+                'bss_target_wake_up_time': 'Enabled',
+                'bss_target_wake_up_time_broadcast_support': 'Enabled'},
+            'mdns_gateway_status': 'Bridge',
+            'wifi_alliance_agile_multiband': 'Disabled',
+            'device_analytics': {
+                'advertise_support': 'Disabled',
+                'share_data_with_client': 'Disabled'},
+            'client_scan_report_11k_beacon_radio_measurement': {
+                'request_on_association': 'Disabled',
+                'request_on_roam': 'Disabled'},
+            'wifi_to_cellular_steering': 'Disabled'}
     }
 }

--- a/src/genie/libs/parser/iosxe/tests/ShowWlanAll/cli/equal/golden_output_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowWlanAll/cli/equal/golden_output_output.txt
@@ -291,3 +291,133 @@ WIFI Alliance Agile Multiband                  : Disabled
 Device Analytics
     Advertise Support                          : Enabled
     Share Data with Client                     : Disabled
+WLAN Profile Name     : CUSTC_Global_NF_24a65b82
+================================================
+Identifier                                     : 21
+Description                                    : SSID-for-Factory-users
+Network Name (SSID)                            : CUST Factory
+Status                                         : Enabled
+Broadcast SSID                                 : Enabled
+Advertise-Apname                               : Disabled
+Universal AP Admin                             : Disabled
+Max Associated Clients per WLAN                : 0
+Max Associated Clients per AP per WLAN         : 0
+Max Associated Clients per AP Radio per WLAN   : 200
+OKC                                            : Enabled
+Number of Active Clients                       : 51
+CHD per WLAN                                   : Enabled
+WMM                                            : Allowed
+WiFi Direct Policy                             : Disabled
+Channel Scan Defer Priority:
+  Priority (default)                           : 5
+  Priority (default)                           : 6
+Scan Defer Time (msecs)                        : 100
+Media Stream Multicast-direct                  : Disabled
+CCX - AironetIe Support                        : Disabled
+Peer-to-Peer Blocking Action                   : Drop
+Configured Radio Bands
+      5ghz                                     : Enabled
+      Slot                                     : Enabled on all slots
+Operational State of Radio Bands
+      5ghz                                     : UP
+      Slot                                     : Enabled on all slots
+DTIM period for 802.11a radio                  : 1
+DTIM period for 802.11b radio                  : 1
+Local EAP Authentication                       : Disabled
+Mac Filter Authorization list name             : dnac-cts-CUST-abcde86c6
+Mac Filter Override Authorization list name    : Disabled
+Accounting list name                           :
+802.1x authentication list name                : Disabled
+802.1x authorization list name                 : Disabled
+Security
+    802.11 Authentication                      : Open System
+    Static WEP Keys                            : Disabled
+    Wi-Fi Protected Access (WPA/WPA2/WPA3)     : Enabled
+        WPA (SSN IE)                           : Disabled
+        WPA2 (RSN IE)                          : Enabled
+            MPSK                               : Disabled
+            EasyPSK                            : Disabled
+            AES Cipher                         : Disabled
+            CCMP256 Cipher                     : Disabled
+            GCMP128 Cipher                     : Disabled
+            GCMP256 Cipher                     : Enabled
+            Randomized GTK                     : Disabled
+        WPA3 (WPA3 IE)                         : Disabled
+        Auth Key Management
+            802.1x                             : Disabled
+            PSK                                : Disabled
+            CCKM                               : Disabled
+            FT dot1x                           : Disabled
+            FT PSK                             : Disabled
+            FT SAE                             : Disabled
+            Dot1x-SHA256                       : Disabled
+            PSK-SHA256                         : Disabled
+            SAE                                : Enabled
+            OWE                                : Disabled
+            SUITEB-1X                          : Disabled
+            SUITEB192-1X                       : Disabled
+    SAE PWE Method                             : Hash to Element, Hunting and Pecking(H2E-HNP)
+    Transition Disable                         : Disabled
+    CCKM TSF Tolerance (msecs)                 : 1000
+    OWE Transition Mode                        : Disabled
+    OSEN                                       : Disabled
+    FT Support                                 : Disabled
+        FT Reassociation Timeout (secs)        : 20
+        FT Over-The-DS mode                    : Disabled
+    PMF Support                                : Disabled
+        PMF Association Comeback Timeout (secs): 1
+        PMF SA Query Time (msecs)              : 200
+    Web Based Authentication                   : Disabled
+    Conditional Web Redirect                   : Disabled
+    Splash-Page Web Redirect                   : Disabled
+    Webauth On-mac-filter Failure              : Disabled
+    Webauth Authentication List Name           : Disabled
+    Webauth Authorization List Name            : Disabled
+    Webauth Parameter Map                      : Disabled
+Band Select                                    : Disabled
+Load Balancing                                 : Enabled
+Multicast Buffer                               : Enabled
+Multicast Buffers (frames)                     : 50
+IP Source Guard                                : Disabled
+Assisted-Roaming
+    Neighbor List                              : Disabled
+    Prediction List                            : Disabled
+    Dual Band Support                          : Disabled
+IEEE 802.11v parameters
+    Directed Multicast Service                 : Disabled
+    BSS Max Idle                               : Enabled
+        Protected Mode                         : Disabled
+    Traffic Filtering Service                  : Disabled
+    BSS Transition                             : Disabled
+        Disassociation Imminent                : Disabled
+            Optimised Roaming Timer (TBTTS)    : 40
+            Timer (TBTTS)                      : 200
+        Dual Neighbor List                     : Disabled
+    WNM Sleep Mode                             : Disabled
+802.11ac MU-MIMO                               : Disabled
+802.11ax parameters
+    802.11ax Operation Status                  : Enabled
+    OFDMA Downlink                             : Enabled
+    OFDMA Uplink                               : Enabled
+    MU-MIMO Downlink                           : Enabled
+    MU-MIMO Uplink                             : Enabled
+    BSS Target Wake Up Time                    : Enabled
+    BSS Target Wake Up Time Broadcast Support  : Enabled
+802.11 protocols in 2.4ghz band
+    Protocol                                   : dot11bg
+Advanced Scheduling Requests Handling          : Disabled
+mDNS Gateway Status                            : Bridge
+WIFI Alliance Agile Multiband                  : Disabled
+Device Analytics
+    Advertise Support                          : Disabled
+    Advertise Support for PC analytics         : Disabled
+    Share Data with Client                     : Disabled
+Client Scan Report (11k Beacon Radio Measurement)
+    Request on Association                     : Disabled
+    Request on Roam                            : Disabled
+WiFi to Cellular Steering                      : Disabled
+Advanced Scheduling Requests Handling          : Disabled
+6Ghz Client Steering                           : Disabled
+Locally Administered Address Configuration
+    Deny LAA clients                           : Disabled
+Latency Measurements Announcements             : Disabled

--- a/src/genie/libs/parser/iosxe/tests/ShowWlanSummary/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowWlanSummary/cli/equal/golden_output_expected.py
@@ -25,6 +25,12 @@ expected_output = {
                 "ssid": "lizzard-legacy",
                 "status": "UP",
                 "security": "[WPA2][802.1x][AES]"
+            },
+            21: {
+                "profile_name": "CUSTC_Global_NF_24a65b82",
+                "ssid": "CUST Factory",
+                "status": "UP",
+                "security": "[WPA2][802.1x][AES]"
             }
         }
     }

--- a/src/genie/libs/parser/iosxe/tests/ShowWlanSummary/cli/equal/golden_output_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowWlanSummary/cli/equal/golden_output_output.txt
@@ -7,4 +7,4 @@ ID   Profile Name                     SSID                             Status Se
 18   wip_Global                      wip                             UP     [WPA2][802.1x + CCKM][AES]
 19   internet_Global                  internet                         UP     [open],MAC Filtering
 20   lizzard-l_Global                lizzard-legacy                  UP     [WPA2][802.1x][AES]
-
+21   CUSTC_Global_NF_24a65b82    CUST Factory                 UP     [WPA2][802.1x][AES]


### PR DESCRIPTION
## Description

I've made two changes to support SSID with spaces (ex : "My SSID Is Fun") for both commands :
- `show wlan summary` 
- `show wlan all` 

And also changed "radio_policy" to optional because it's not used when configured with dnac.

## Motivation and Context

A lot of customers are using spaces in their deployments, so it's better to support it :) 

## Impact (If any)

No negative impact !

## Screenshots:

### show wlan summary

![image](https://github.com/CiscoTestAutomation/genieparser/assets/59981580/102ec110-605c-4198-8abb-40baebd8626f)

### show wlan all

![image](https://github.com/CiscoTestAutomation/genieparser/assets/59981580/f7fa33ef-613d-48a1-ab8f-4d43d4d84e72)

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [X] I have added tests to cover my changes (If applicable).
- [X] All new and existing tests passed.
- [X] All new code passed compilation.
