### PR TITLE
Updated ASA regex

### DIFF
--- a/changelog/undistributed/changelog_asa_show_failover_202404110935.rst
+++ b/changelog/undistributed/changelog_asa_show_failover_202404110935.rst
@@ -1,0 +1,8 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* ASA
+    * Modified ShowFailoverSchema:
+        * Updated regex to handle Ethernet type interface names
+    * Modified ShowVersionSchema:
+        * Updated regex to '/' in Processor type

--- a/src/genie/libs/parser/asa/show_failover.py
+++ b/src/genie/libs/parser/asa/show_failover.py
@@ -141,7 +141,7 @@ class ShowFailover(ShowFailoverSchema):
         # Failover LAN Interface: folink GigabitEthernet0/1 (up)
         p3 = re.compile(
             r'^Failover +LAN +Interface:\s(?P<name>[A-Za-z0-9\-\_]+)\s+'
-            '(?P<interface>(Lo\S*|Fa\S*|Gi\S*|Ten\S*|\S*(SL|VL)\S*|Se\S*|VoIP\S*|Configured))'
+            '(?P<interface>(Lo\S*|Fa\S*|Eth\S*|Gi\S*|Ten\S*|\S*(SL|VL)\S*|Se\S*|VoIP\S*|Configured))'
             '( +\((?P<status>[A-Za-z0-0_\-\s]+)\))?$'
         )
 
@@ -223,7 +223,7 @@ class ShowFailover(ShowFailoverSchema):
         p17_1 = re.compile(r'^Stateful +Failover +Logical +Update +Statistics$')
         p17_2 = re.compile(
             r'^Link\s+:\s+(?P<name>[A-Za-z0-9]+)\s+'
-            '(?P<interface>(Lo\S*|Fa\S*|Gi\S*|Ten\S*|\S*(SL|VL)\S*|Se\S*|VoIP\S*|Configured))'
+            '(?P<interface>(Lo\S*|Fa\S*|Eth\S*|Gi\S*|Ten\S*|\S*(SL|VL)\S*|Se\S*|VoIP\S*|Configured))'
             '( +\((?P<status>[A-Za-z0-0_\-\s]+)\))?$'
         )
 

--- a/src/genie/libs/parser/asa/show_version.py
+++ b/src/genie/libs/parser/asa/show_version.py
@@ -124,7 +124,7 @@ class ShowVersion(ShowVersionSchema):
         # Hardware:   FPR9K-SM-24, 230696 MB RAM, CPU Xeon E5 series 2200 MHz, 2 CPUs (48 cores)
         # Hardware:   ASA5555, 16384 MB RAM, CPU Lynnfield 2800 MHz, 1 CPU (8 cores)
         p7 = re.compile(r'^Hardware:\s+(?P<platform>\S+),\s+(?P<mem_size>[\w\s]+) RAM,'
-                        r'\s+CPU (?P<processor_type>[\s\w]+),? ?(?P<cpu_count>\d+)?\s?(\w+|)? ?\(?(?P<core_count>\d+)?( cores\))?$')
+                        r'\s+CPU (?P<processor_type>[\s\w\/]+),? ?(?P<cpu_count>\d+)?\s?(\w+|)? ?\(?(?P<core_count>\d+)?( cores\))?$')
 
         # SSP Slot Number: 1
         p7_1 = re.compile(r'^SSP Slot Number: (?P<ssp_slot_number>\d+)$')


### PR DESCRIPTION
## Description
Updated regex for ASA 'show failover' and 'show version' commands.

## Motivation and Context
Previous regex did not handle interfaces with names starting with "Ethernet". 
Previous regex did not handle processor types with '/' in the output.

## Impact (If any)
None

## Screenshots:
![pyats test pass](https://github.com/CiscoTestAutomation/genieparser/assets/10276043/58865f93-5a18-4794-8837-aef13e61f277)


## Checklist:
- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
