### PR TITLE
Fix regex and both for import and export route-targets NXOS

### DIFF
--- a/changelog/undistributed/changelog_show_running-config_vrf_{vrf}_|_sec_'^vrf'_20240426102247.rst
+++ b/changelog/undistributed/changelog_show_running-config_vrf_{vrf}_|_sec_'^vrf'_20240426102247.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* NXOS
+    * Modified ShowRunningConfigVrf:
+        * Updated regex pattern <p5> to include : match for route-target
+        * Updated so 'both' is used when route-target is imported and exported. (Already done the same way for IOS XE 'show vrf detail')

--- a/src/genie/libs/parser/nxos/show_vrf.py
+++ b/src/genie/libs/parser/nxos/show_vrf.py
@@ -292,7 +292,7 @@ class ShowRunningConfigVrf(ShowRunningConfigVrfSchema):
         #     route-target both auto
         #     route-target both auto mvpn
         #     route-target both auto evpn
-        p5 = re.compile(r'^\s*route-target +(?P<rt_type>\w+) +(?P<rt>\w+)( +(?P<rt_evpn_mvpn>\w+))?$')
+        p5 = re.compile(r'^\s*route-target +(?P<rt_type>\w+) +(?P<rt>\w+:\w+)( +(?P<rt_evpn_mvpn>\w+))?$')
 
         # find all list of vrfs
         if vrf:
@@ -341,7 +341,10 @@ class ShowRunningConfigVrf(ShowRunningConfigVrfSchema):
                     rt = m.groupdict()['rt']
                     rt_type = m.groupdict()['rt_type']
                     route_target_dict = af_dict.setdefault('route_target', {}).setdefault(rt, {})
-                    route_target_dict.update({'rt_type': m.groupdict()['rt_type']})
+                    if 'rt_type' in route_target_dict:
+                        route_target_dict.update({'rt_type': 'both'})
+                    else:
+                        route_target_dict.update({'rt_type': rt_type})
 
                     if m.groupdict()['rt_evpn_mvpn']:
                         if 'evpn' in m.groupdict()['rt_evpn_mvpn']:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I have changed the regex pattern for matching route-target to include ':'.
A ':' is required when configuring a import/export route-target.

I have also fixed, so a route-target can be 'both' imported and exported at the same time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes the "show running-config vrf {vrf} | sec '^vrf'" command on NXOS.
Before route-targets would not be parsed, and not appear in parsed output.

## Impact (If any)
<!--- If there is any negative impact - what is it? -->
No negative impact, as this did not work previously.

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ ] All new and existing tests passed.
- [ ] All new code passed compilation.
