### PR TITLE
Updating iosxe/show_aaa.py/ShowAAServers p1b regex for RADSEC port consideration

### DIFF
--- a/changelog/undistributed/changelog_show_aaa_family_iosxe_20240616105529.rst
+++ b/changelog/undistributed/changelog_show_aaa_family_iosxe_20240616105529.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowAAServers:
+        * Updated regex pattern p1b to allow for both RADSEC-port and RADSEC port as valid auth ports. 

--- a/src/genie/libs/parser/iosxe/show_aaa.py
+++ b/src/genie/libs/parser/iosxe/show_aaa.py
@@ -197,8 +197,8 @@ class ShowAAServers(ShowAAServersSchema):
         # RADIUS: id 9, priority 1, host 11.15.24.174, auth-port 1812, acct-port 1813, hostname ISE-RAD
         p1a = re.compile(r'(^.*)\:\s+id\s+(?P<id>\d+)\,\s+priority\s+(?P<priority>(\d+))\,\s+host\s+(?P<host>(.*))\,\s+auth\-port\s+(?P<auth_port>(\d+))\,\s+acct\-port\s+(?P<acct_port>(\d+))\,\s*hostname\s*(?P<hostname>(.*))$')
 
-        # RADIUS: id 9, priority 1, host 11.15.24.174, RADSEC-port 1812,hostname ISE-RAD
-        p1b = re.compile(r'(.*)\:\s+id\s+(?P<id>\d+)\,\s+priority\s+(?P<priority>(\d+))\,\s+host\s+(?P<host>(.*))\,\s*(RADSEC\-port\s*(?P<radsec_port>(\d+)))\,\s*hostname\s+(?P<hostname>(.*))$')
+        # RADIUS: id 9, priority 1, host 11.15.24.174, RADSEC[- ]port 1812,hostname ISE-RAD
+        p1b = re.compile(r'(.*)\:\s+id\s+(?P<id>\d+)\,\s+priority\s+(?P<priority>(\d+))\,\s+host\s+(?P<host>(.*))\,\s*(RADSEC[- ]port\s*(?P<radsec_port>(\d+)))\,\s*hostname\s+(?P<hostname>(.*))$')
 
         # RADIUS: id 9, priority 1, host 11.15.24.174, auth-port 1812, acct-port 1813
         p1c = re.compile(r'(^.*)\:\s+id\s+(?P<id>\d+)\,\s+priority\s+(?P<priority>(\d+))\,\s+host\s+(?P<host>(.*))\,\s+auth\-port\s+(?P<auth_port>(\d+))\,\s+acct\-port\s+(?P<acct_port>(\d+))$')


### PR DESCRIPTION
## Description
Adding regex logic to include both RADSEC-port and RADSEC port as valid auth port values. 
C9800 version 17.12.3 uses RADSEC port while current logic only identifies RADSEC-port.

## Motivation and Context
This change is required to match RADSEC AAA servers on the C9800. 

## Impact (If any)
None at the moment. 

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ x] All new and existing tests passed.
- [ x] All new code passed compilation.
