### PR TITLE
Adds support for IN-RESET and SW_INACTIVE state to iosxr ShowPlatform

### DIFF
--- a/changelog/undistributed/changelog_show_platform_iosxr_20240710132134.rst
+++ b/changelog/undistributed/changelog_show_platform_iosxr_20240710132134.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowPlatform:
+        * Updated regex pattern p1 to allow for both IN-RESET and SW_INACTIVE as valid states.

--- a/src/genie/libs/parser/iosxr/show_platform.py
+++ b/src/genie/libs/parser/iosxr/show_platform.py
@@ -406,7 +406,7 @@ class ShowPlatform(ShowPlatformSchema):
                             '\s+(?P<name>[a-zA-Z0-9\-\.]+)'
                             '(?:\((?P<redundancy_state>[a-zA-Z]+)\))?'
                             '(?: +(?P<plim>[a-zA-Z0-9(\/|\-| )]+))?'
-                            '\s+(?P<state>(UNPOWERED|DISABLED|IOS XR RUN|OK|OPERATIONAL|POWERED_ON))'
+                            '\s+(?P<state>(SW_INACTIVE|IN-RESET|UNPOWERED|DISABLED|IOS XR RUN|OK|OPERATIONAL|POWERED_ON))'
                             '\s+(?P<config_state>[a-zA-Z\,]+)$')
 
         # Init vars

--- a/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output8_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output8_expected.py
@@ -1,0 +1,46 @@
+expected_output = {
+    "slot": {
+        "rp": {
+            "0/RSP0": {
+                "name": "A9K-RSP440-SE",
+                "full_slot": "0/RSP0/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "PWR,NSHUT,MON",
+                "redundancy_state": "Active",
+            },
+            "0/RSP1": {
+                "name": "A9K-RSP440-SE",
+                "full_slot": "0/RSP1/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "PWR,NSHUT,MON",
+                "redundancy_state": "Standby",
+            },
+        },
+        "lc": {
+            "0/0": {
+                "name": "A9K-24x10GE-TR",
+                "full_slot": "0/0/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "PWR,NSHUT,MON",
+            },
+            "0/1": {
+                "name": "A9K-2T20GE-L",
+                "full_slot": "0/1/CPU0",
+                "state": "IN-RESET",
+                "config_state": "PWR,NSHUT,MON",
+            },
+            "0/2": {
+                "name": "A9K-24x10GE-TR",
+                "full_slot": "0/2/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "PWR,NSHUT,MON",
+            },
+            "0/3": {
+                "name": "A9K-2x100GE-TR",
+                "full_slot": "0/3/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "PWR,NSHUT,MON",
+            },
+        },
+    }
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output8_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output8_output.txt
@@ -1,0 +1,9 @@
+Tue Jul  2 15:22:55.819 EST
+Node            Type                      State            Config State
+-----------------------------------------------------------------------------
+0/RSP0/CPU0     A9K-RSP440-SE(Active)     IOS XR RUN       PWR,NSHUT,MON
+0/RSP1/CPU0     A9K-RSP440-SE(Standby)    IOS XR RUN       PWR,NSHUT,MON
+0/0/CPU0        A9K-24x10GE-TR            IOS XR RUN       PWR,NSHUT,MON
+0/1/CPU0        A9K-2T20GE-L              IN-RESET         PWR,NSHUT,MON
+0/2/CPU0        A9K-24x10GE-TR            IOS XR RUN       PWR,NSHUT,MON
+0/3/CPU0        A9K-2x100GE-TR            IOS XR RUN       PWR,NSHUT,MON

--- a/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output9_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output9_expected.py
@@ -1,0 +1,102 @@
+expected_output = {
+    "slot": {
+        "rp": {
+            "0/RSP0": {
+                "name": "A9K-RSP5-SE",
+                "full_slot": "0/RSP0/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "NSHUT",
+                "redundancy_state": "Active",
+            },
+            "0/RSP1": {
+                "name": "A9K-RSP5-SE",
+                "full_slot": "0/RSP1/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "NSHUT",
+                "redundancy_state": "Standby",
+            },
+        },
+        "oc": {
+            "0/FT0": {
+                "name": "ASR-9910-FAN",
+                "full_slot": "0/FT0",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/FT1": {
+                "name": "ASR-9910-FAN",
+                "full_slot": "0/FT1",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/FC0": {
+                "name": "A99-SFC3-S",
+                "full_slot": "0/FC0",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/FC1": {
+                "name": "A99-SFC3-S",
+                "full_slot": "0/FC1",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/FC2": {
+                "name": "A99-SFC3-S",
+                "full_slot": "0/FC2",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/FC3": {
+                "name": "A99-SFC3-S",
+                "full_slot": "0/FC3",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/FC4": {
+                "name": "A99-SFC3-S",
+                "full_slot": "0/FC4",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/PT0": {
+                "name": "A9K-DC-PEM-V3",
+                "full_slot": "0/PT0",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+            "0/PT1": {
+                "name": "A9K-DC-PEM-V3",
+                "full_slot": "0/PT1",
+                "state": "OPERATIONAL",
+                "config_state": "NSHUT",
+            },
+        },
+        "lc": {
+            "0/1": {
+                "name": "A9K-MOD400-TR",
+                "full_slot": "0/1/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "NSHUT",
+            },
+            "0/3": {
+                "name": "A99-32X100GE-CM",
+                "full_slot": "0/3",
+                "state": "SW_INACTIVE",
+                "config_state": "NSHUT",
+            },
+            "0/5": {
+                "name": "A9K-MOD400-TR",
+                "full_slot": "0/5/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "NSHUT",
+            },
+            "0/6": {
+                "name": "A99-32X100GE-TR",
+                "full_slot": "0/6/CPU0",
+                "state": "IOS XR RUN",
+                "config_state": "NSHUT",
+            },
+        },
+    }
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output9_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowPlatform/cli/equal/golden_output9_output.txt
@@ -1,0 +1,22 @@
+Thu Jun 27 13:14:00.563 UTC
+Node              Type                       State             Config state
+--------------------------------------------------------------------------------
+0/RSP0/CPU0       A9K-RSP5-SE(Active)        IOS XR RUN        NSHUT
+0/RSP1/CPU0       A9K-RSP5-SE(Standby)       IOS XR RUN        NSHUT
+0/FT0             ASR-9910-FAN               OPERATIONAL       NSHUT
+0/FT1             ASR-9910-FAN               OPERATIONAL       NSHUT
+0/1/CPU0          A9K-MOD400-TR              IOS XR RUN        NSHUT
+0/1/0             A9K-MPA-20X10GE            OK
+0/1/1             A9K-MPA-20X10GE            OK
+0/3               A99-32X100GE-CM            SW_INACTIVE       NSHUT
+0/5/CPU0          A9K-MOD400-TR              IOS XR RUN        NSHUT
+0/5/0             A9K-MPA-20X10GE            OK
+0/5/1             A9K-MPA-20X10GE            OK
+0/6/CPU0          A99-32X100GE-TR            IOS XR RUN        NSHUT
+0/FC0             A99-SFC3-S                 OPERATIONAL       NSHUT
+0/FC1             A99-SFC3-S                 OPERATIONAL       NSHUT
+0/FC2             A99-SFC3-S                 OPERATIONAL       NSHUT
+0/FC3             A99-SFC3-S                 OPERATIONAL       NSHUT
+0/FC4             A99-SFC3-S                 OPERATIONAL       NSHUT
+0/PT0             A9K-DC-PEM-V3              OPERATIONAL       NSHUT
+0/PT1             A9K-DC-PEM-V3              OPERATIONAL       NSHUT


### PR DESCRIPTION
## Description
Adds IN-RESET and SW_INACTIVE as valid states in the regex for ShowPlatform IOSXR

## Motivation and Context
These states were missing from the regex

## Impact (If any)

## Screenshots:

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
