### PR TITLE
add secViolEr status type for nxos

### DIFF
--- a/src/genie/libs/parser/nxos/show_interface.py
+++ b/src/genie/libs/parser/nxos/show_interface.py
@@ -3758,7 +3758,7 @@ class ShowInterfaceStatus(ShowInterfaceStatusSchema):
             # containing any number of blank spaces. This makes it very difficult to use a regular
             # expression to dynamically match the status column, so hard-coding offers a happy
             # middle ground.
-            r'(?P<status>connected|disabled|sfpAbsent|noOperMem|notconnec|xcvrAbsen|down|linkFlapE)\s+'
+            r'(?P<status>connected|disabled|sfpAbsent|noOperMem|notconnec|xcvrAbsen|down|linkFlapE|secViolEr)\s+'
             r'(?P<vlan>\S+)\s+'
             r'(?P<duplex_code>\S+)\s+'
             r'(?P<port_speed>\S+)\s*'


### PR DESCRIPTION
## Description
Missing interface status type for nxos

## Motivation and Context
It solves parsing the output when doing interface status.

CISCO Nexus 9000v Switch
https://www.cisco.com/c/en/us/support/switches/nexus-9000v-switch/model.html
```
N9K-1# show interface Ethernet1/3 status
--------------------------------------------------------------------------------
Port          Name               Status    Vlan      Duplex  Speed   Type
--------------------------------------------------------------------------------
Eth1/3        --                 secViolEr 100       auto    auto    10g  
```

## Impact (If any)
no negative impact

## Screenshots:
![Screenshot 2024-07-30 093531](https://github.com/user-attachments/assets/8383d7fd-dc48-40e4-a405-f113c8a2e141)
![Screenshot 2024-07-30 093546](https://github.com/user-attachments/assets/25a1fedf-2e4e-4687-8d31-7828697bba02)
![Screenshot 2024-07-30 093616](https://github.com/user-attachments/assets/73c5c661-e27b-4caa-a866-7f80b46d43b8)

## Checklist:
- [x ] I have updated the changelog.
- [x ] I have updated the documentation (If applicable).
- [x ] I have added tests to cover my changes (If applicable).
- [x ] All new and existing tests passed.
- [x ] All new code passed compilation.
