### PR TITLE
Fix iosxe show ip ospf interface brief regex to parse area correctly

### DIFF
--- a/changelog/undistributed/changelog_show_ospf_iosxe_20240820091556.rst
+++ b/changelog/undistributed/changelog_show_ospf_iosxe_20240820091556.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* iosxe
+    * Modified ShowIpOspfInterfaceBrief:
+        * Updated regex pattern <p1> parse OSPF area as string to facilitate parsing dot notation areas, as well as numeric.

--- a/src/genie/libs/parser/iosxe/show_ospf.py
+++ b/src/genie/libs/parser/iosxe/show_ospf.py
@@ -1405,7 +1405,7 @@ class ShowIpOspfInterfaceBrief(ShowIpOspfInterfaceBriefSchema):
         # Init vars
         ret_dict = {}
         
-        p1 = re.compile(r'^(?P<interface>\S+) +(?P<instance>\S+) +(?P<area>\d+) +'
+        p1 = re.compile(r'^(?P<interface>\S+) +(?P<instance>\S+) +(?P<area>\S+) +'
             '(?P<address>\S+) +(?P<cost>\d+) +(?P<state>\S+) +(?P<nbrs_full>\d+)'
             '\/(?P<nbrs_count>\d+)$$')
 


### PR DESCRIPTION
## Description
The iosxe parser for `show ip ospf interface brief` was capturing the area as a numerical value. I've updated it to capture a string.

## Motivation and Context
When using the iosxe parser for `show ip ospf interface brief`, as the parser was looking for numerical values only, it would skip entries where the OSPF area was written in dot notation (i.e. 0.0.0.0). 

This change brings it in line with the `show ip ospf interface` parser which correctly captures the area as a string.

## Impact (If any)
There is no negative impact as the returned value (even for numerical-only area captures) is converted to dot notation in the generated output.

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ X] All new and existing tests passed.
- [ X] All new code passed compilation.
