### PR TITLE
Update show_ospf.py

### DIFF
--- a/src/genie/libs/parser/iosxe/show_ospf.py
+++ b/src/genie/libs/parser/iosxe/show_ospf.py
@@ -5224,7 +5224,7 @@ class ShowIpOspfMplsTrafficEngLink(ShowIpOspfMplsTrafficEngLinkSchema):
                             ' +(?P<fragment>(\d+))\. +Link +instance +is'
                             ' +(?P<link_instance>(\d+))$')
 
-        p6 = re.compile(r'^Link +connected +to +(?P<type>([a-zA-Z\s]+))$')
+        p6 = re.compile(r'^Link +connected +to +(?P<type>([a-zA-Z-\s]+))$')
 
         p7 = re.compile(r'^Link +ID *: +(?P<link_id>(\S+))$')
 


### PR DESCRIPTION
Fix for Issue #887

## Description
Update src/genie/libs/parser/iosxe/show_ospf.py, update ShowIpOspfMplsTrafficEngLink regex for link type, "Point-to-Point" is a valid value and errors on IOS-XE 17.06.03.

## Motivation and Context
Resolves https://github.com/CiscoTestAutomation/genieparser/issues/887
