### PR TITLE
Added functionality to "show object-group name" under iosxe

### DIFF
--- a/changelog/undistributed/changelog_show_object-group_name_iosxe_20240922151843.rst
+++ b/changelog/undistributed/changelog_show_object-group_name_iosxe_20240922151843.rst
@@ -1,0 +1,9 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* <IOSXE>
+    * Modified ShowObjectGroupName:
+        * Updated regex pattern p3 to accomodate ipv4 as well as ipv6 addresses.
+        * Added regex pattern p4 to accomodate ipv4 network addresses.
+        * Added regex pattern p5 to accomodate ipv4 address ranges.
+        * Addedd network_address and range to the schema as Optional.


### PR DESCRIPTION
## Description
Added network and range keys to the show object-group name schema and added regex for network and ranges for those keys.

## Motivation and Context
The parser only worked for services and ipv6 host addresses.  I needed it for ipv4 host addresses and ipv4 networks.

## Impact (If any)
not that i am aware of

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
- [x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
