### PR TITLE
fix show isis adjacency  show_isis.py

### DIFF
--- a/src/genie/libs/parser/iosxr/show_isis.py
+++ b/src/genie/libs/parser/iosxr/show_isis.py
@@ -206,7 +206,7 @@ class ShowIsisAdjacency(ShowIsisAdjacencySchema):
         vrf = 'default'
 
         # IS-IS p Level-1 adjacencies:
-        p1 = re.compile(r'^IS-IS +(?P<isis_name>\w+) +(?P<level_name>\S+) adjacencies:$')
+        p1 = re.compile(r'^IS-IS +(?P<isis_name>[\w-]+) +(?P<level_name>\S+) adjacencies:$')
 
         # 12a4           PO0/1/0/1        *PtoP*         Up    23       00:00:06 Capable  None
         p2 = re.compile(r'^(?P<system_id>\S+) +(?P<interface>\S+) +(?P<snpa>\S+) +(?P<state>(Up|Down|None)) +(?P<hold>\S+) '


### PR DESCRIPTION
## Description
(?P<isis_name>[\w-]+): This group allows both word characters (\w, i.e., letters, digits, underscores) and hyphens (-). This would be used when the isis_name might contain a hyphen, making it more flexible than the first pattern.

## Motivation and Context
Purpose:
These patterns are typically used in parsing network outputs, particularly from IS-IS routing protocols, to extract specific information like the IS-IS process name (isis_name) and level (level_name) from lines that follow this structure.

For example, given the string:

vbnet
Copier le code
IS-IS test-Level-1 adjacencies:
In the first pattern, it will capture isis_name = "test".
In the second pattern, it will capture isis_name = "test-Level-1" because it allows for hyphens in the name.
