### PR TITLE
[IOS-XR] Fix `show l2vpn bridge-domain detail `: Parses variations in the EVI field format correctly

### DIFF
--- a/changelog/undistributed/changelog_show_l2vpn_bridge_domain_detail_iosxr_20241029105539.rst
+++ b/changelog/undistributed/changelog_show_l2vpn_bridge_domain_detail_iosxr_20241029105539.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowL2vpnBridgeDomainDetail:
+        * Modified regex <p63> in to support optional suffix (e.g., "(SRv6)") for EVI values

--- a/src/genie/libs/parser/iosxr/show_l2vpn.py
+++ b/src/genie/libs/parser/iosxr/show_l2vpn.py
@@ -1585,7 +1585,8 @@ class ShowL2vpnBridgeDomainDetail(ShowL2vpnBridgeDomainDetailSchema):
         p62 = re.compile(r'^(?P<evpn>\S+), +state: +(?P<state>\S+)$')
 
         # evi: 1000
-        p63 = re.compile(r'^evi: +(?P<evi>\d+)$')
+        # evi: 1000 (SRv6)
+        p63 = re.compile(r'^evi: +(?P<evi>\d+)(?:\s*\(.*\))?$')
 
         # XC ID 0x80000009
         p64 = re.compile(r'^XC +ID (?P<xc_id>\S+)$')

--- a/src/genie/libs/parser/iosxr/tests/ShowL2vpnBridgeDomainDetail/cli/equal/golden9_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowL2vpnBridgeDomainDetail/cli/equal/golden9_expected.py
@@ -98,6 +98,7 @@ expected_output = {
 				'evpn': {
 					'EVPN': {
 						'state': 'up',
+                        'evi': '1002',
 						'xc_id': '0x80000003',
 						'statistics': {
 							'packet_totals': {


### PR DESCRIPTION
- Modified `p63` regex in `show_l2vpn.py` to support optional suffix (e.g., "(SRv6)") for EVI values
- Updated `golden9_expected.py` to reflect new test output for EVI field
- Adjusted URL in `github_parser.json` for the updated line reference

These changes enhance the parser's compatibility with new formats in `ShowL2vpnBridgeDomainDetail`.

## Description
The `ShowL2vpnBridgeDomainDetail` parser for IOS-XR devices was not handling some variations in the EVI field format correctly, resulting in parsing errors or missed data. Specifically, when the evi field includes additional suffix information (e.g., (SRv6)), the parser could not match this pattern and failed to extract the EVI value.

## Motivation and Context
- Support optional suffix (e.g., "(SRv6)") for EVI values

Closes #906 

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
