### PR TITLE
[IOS-XR] Fix `show vrf all detail` parser - capture all interface names

### DIFF
--- a/changelog/undistributed/changelog_show_vrf_all_detail_iosxr_20241108103720.rst
+++ b/changelog/undistributed/changelog_show_vrf_all_detail_iosxr_20241108103720.rst
@@ -1,0 +1,8 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXR
+    * Modified ShowVrfAllDetail:
+        * Modified regex <p4_1> to capture all interface names
+            * Replaced the previous regex that relied on specific interface prefixes (e.g., Gi, Bun, Ten, etc.) with a more general pattern.
+        * Introduced `in_interfaces_section` flag for accurate section tracking

--- a/src/genie/libs/parser/iosxr/tests/ShowVrfAllDetail/cli/equal/golden_output_5_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowVrfAllDetail/cli/equal/golden_output_5_expected.py
@@ -1,0 +1,94 @@
+expected_output = {
+    "TEST_1": {
+        "address_family": {
+            "ipv4 unicast": {
+                "route_target": {
+                    "1234:5678": {"route_target": "1234:5678", "rt_type": "import"},
+                    "8765:4321": {"route_target": "8765:4321", "rt_type": "export"},
+                }
+            },
+            "ipv6 unicast": {},
+        },
+        "description": "not set",
+        "interfaces": [
+            "GigabitEthernet0/0/0/0.2",
+            "Gi0/0/0/0.1",
+            "GigabitEthernet0/0/0/1",
+            "Gi0/0/0/4",
+            "TenGigE0/0/0/0.1",
+            "TenGigabitEthernet0/0/0/0.2",
+            "Te0/0/0/0.3",
+        ],
+        "route_distinguisher": "10.10.10.10:10",
+        "vrf_mode": "regular",
+    },
+    "TEST_2": {
+        "address_family": {
+            "ipv4 unicast": {
+                "route_target": {
+                    "1111:2222": {"route_target": "1111:2222", "rt_type": "import"},
+                    "2222:1111": {"route_target": "2222:1111", "rt_type": "export"},
+                }
+            },
+            "ipv6 unicast": {},
+        },
+        "description": "not set",
+        "interfaces": [
+            "FortyGigE0/0/0/0.1",
+            "FortyGigabitEthernet0/0/0/0.2",
+            "Fo0/0/0/0.3",
+            "FortyGigE0/0/0/1",
+            "FortyGigabitEthernet0/0/0/2",
+            "Fo0/0/0/3",
+            "HundredGigE0/0/0/0.1",
+            "HundredGigabitEthernet0/0/0/0.2",
+            "Hu0/0/0/0.3",
+            "HundredGigE0/0/0/1",
+            "HundredGigabitEthernet0/0/0/2",
+            "Hu0/0/0/3",
+        ],
+        "route_distinguisher": "1.2.3.4:5",
+        "vrf_mode": "regular",
+    },
+    "TEST_3": {
+        "address_family": {
+            "ipv4 unicast": {
+                "route_target": {
+                    "13285:56891": {"route_target": "13285:56891", "rt_type": "export"},
+                    "7984:4657": {"route_target": "7984:4657", "rt_type": "import"},
+                }
+            },
+            "ipv6 unicast": {},
+        },
+        "description": "not set",
+        "interfaces": [
+            "Bundle-Ether0",
+            "Bundle-Ethernet1",
+            "BE2",
+            "Loopback1",
+            "Lo0",
+            "Null0",
+            "Nu1",
+            "MgmtEth0/RP0/CPU0/0",
+            "ManagementEthernet1/RP0/CPU0/0",
+            "MgmtEth0/0/3",
+        ],
+        "route_distinguisher": "5.4.3.2:1",
+        "vrf_mode": "regular",
+    },
+    "TEST_4": {
+        "address_family": {
+            "ipv4 unicast": {
+                "route_target": {
+                    "1111:1111": {"route_target": "1111:1111", "rt_type": "export"},
+                    "7985:4654": {"route_target": "7985:4654", "rt_type": "import"},
+                }
+            },
+            "ipv6 unicast": {},
+        },
+        "description": "not set",
+        "interfaces": ["POS0/0/0/0", "PacketOverSonet0/0/0/1", "PoS0/0/0/2"],
+        "route_distinguisher": "1.1.1.1:1",
+        "vrf_mode": "regular",
+    },
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowVrfAllDetail/cli/equal/golden_output_5_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowVrfAllDetail/cli/equal/golden_output_5_output.txt
@@ -1,0 +1,99 @@
+VRF TEST_1; RD 10.10.10.10:10; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  GigabitEthernet0/0/0/0.2
+  Gi0/0/0/0.1
+  GigabitEthernet0/0/0/1
+  Gi0/0/0/4
+  TenGigE0/0/0/0.1
+  TenGigabitEthernet0/0/0/0.2
+  Te0/0/0/0.3
+Address family IPV4 Unicast
+  Import VPN route-target communities:
+    RT:1234:5678
+  Export VPN route-target communities:
+    RT:8765:4321
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF TEST_2; RD 1.2.3.4:5; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  FortyGigE0/0/0/0.1
+  FortyGigabitEthernet0/0/0/0.2
+  Fo0/0/0/0.3
+  FortyGigE0/0/0/1
+  FortyGigabitEthernet0/0/0/2
+  Fo0/0/0/3
+  HundredGigE0/0/0/0.1
+  HundredGigabitEthernet0/0/0/0.2
+  Hu0/0/0/0.3
+  HundredGigE0/0/0/1
+  HundredGigabitEthernet0/0/0/2
+  Hu0/0/0/3
+Address family IPV4 Unicast
+  Import VPN route-target communities:
+    RT:1111:2222
+  Export VPN route-target communities:
+    RT:2222:1111
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF TEST_3; RD 5.4.3.2:1; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  Bundle-Ether0
+  Bundle-Ethernet1
+  BE2
+  Loopback1
+  Lo0
+  Null0
+  Nu1
+  MgmtEth0/RP0/CPU0/0
+  ManagementEthernet1/RP0/CPU0/0
+  MgmtEth0/0/3
+Address family IPV4 Unicast
+  Import VPN route-target communities:
+    RT:7984:4657
+  Export VPN route-target communities:
+    RT:13285:56891
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF TEST_4; RD 1.1.1.1:1; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  POS0/0/0/0
+  PacketOverSonet0/0/0/1
+  PoS0/0/0/2
+Address family IPV4 Unicast
+  Import VPN route-target communities:
+    RT:7985:4654
+  Export VPN route-target communities:
+    RT:1111:1111
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy


### PR DESCRIPTION
## Description
Enhance interface parsing in 'show vrf all detail' parser

Implemented a general regex pattern to capture all interface names:

- Replaced the previous regex that relied on specific interface prefixes (e.g., Gi, Bun, Ten, etc.) with a more general pattern `r'^(?P<intf>[A-Za-z][-A-Za-z0-9/.:]+)$'.`
    - This allows the parser to match any interface name, accommodating various naming conventions and ensuring that all interfaces are properly captured.
- Introduced `in_interfaces_section` flag for accurate section tracking:
    - Initialized `in_interfaces_section` = False at the beginning of the parsing process.
    - Set `in_interfaces_section = True` upon encountering the **Interfaces:** line.
    - Used this flag to determine when interface lines should be parsed.
    - When a non-interface line is encountered within the Interfaces section, set `in_interfaces_section = False` 
    - This ensures that the parser continues to process the current line with other parsing rules, preventing the omission of critical sections like address families and route targets.


## Motivation and Context
Replaced the previous regex that relied on specific interface prefixes (e.g., Gi, Bun, Ten, etc.) with a more general pattern 


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.


Closes #910
