### PR TITLE
"show authentication sessions" returns  "Parser Output is empty" when "No sessions currently exist" cli output is returned from device.

### DIFF
--- a/changelog/undistributed/fix_show_authentication_sessions.rst
+++ b/changelog/undistributed/fix_show_authentication_sessions.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowAuthenticationSessions:
+        * Added default value for "No sessions currently exist" cli output.

--- a/src/genie/libs/parser/iosxe/show_authentication_sessions.py
+++ b/src/genie/libs/parser/iosxe/show_authentication_sessions.py
@@ -82,6 +82,9 @@ class ShowAuthenticationSessions(ShowAuthenticationSessionsSchema):
         else:
             out = output
 
+        if "No sessions currently exist" in out:
+            return {"interfaces": {}, "session_count": 0}
+
         # initial return dictionary
         ret_dict = {}
 

--- a/src/genie/libs/parser/iosxe/tests/ShowAuthenticationSessions/cli/equal/golden_output_4_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowAuthenticationSessions/cli/equal/golden_output_4_expected.py
@@ -1,0 +1,6 @@
+expected_output = {
+    "interfaces": {
+
+    },
+    "session_count": 0
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowAuthenticationSessions/cli/equal/golden_output_4_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowAuthenticationSessions/cli/equal/golden_output_4_output.txt
@@ -1,0 +1,2 @@
+show authentication sessions
+No sessions currently exist


### PR DESCRIPTION
## Description

When there are no authentication sessions, this is when CLI outputs:

```
access-switch-01#show authentication sessions
No sessions currently exist
```

 `` Unable to parse output for command 'show authentication sesssions" (Parser Output is empty)`` error is returned.

## Motivation and Context
Return proper response when authentication service is not enabled or there are currently no active sessions. 

```
{
    "interfaces": {

    },
    "session_count": 0
}
```

Ansible failed run:
```
fatal: [access-switch-01]: FAILED! =>
  msg: Unable to parse output for command 'show authentication sessions' (Parser Output is empty)
```

Ansible successful run:
```
ok: [access-switch-01] =>
  msg:
    show_authentication_sessions:
      interfaces: {}
      session_count: 0
```
