### PR TITLE
C9400 Show Environment All

### DIFF
--- a/changelog/undistributed/changelog_show_env_all_c9400_20250604141244.rst
+++ b/changelog/undistributed/changelog_show_env_all_c9400_20250604141244.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowEnvironmentAll (c9400):
+        * Updated REGEX for "Sensor List:  Environmental Monitoring" table. Accomodating for Location instead of Slot and also to catch more complex Locations such as Chassis2-4/0

--- a/src/genie/libs/parser/iosxe/cat9k/c9400/show_platform.py
+++ b/src/genie/libs/parser/iosxe/cat9k/c9400/show_platform.py
@@ -237,13 +237,18 @@ class ShowEnvironmentAll(ShowEnvironmentAllSchema):
         # Sensor List:  Environmental Monitoring
         p4 = re.compile(r'Sensor\s+List:\s+(?P<sensor_list>.+)')
 
-        #  Sensor           Location          State          Reading           Threshold(Minor,Major,Critical,Shutdown)
-        #  Temp: Coretemp   R0                Normal            48 Celsius          	(107,117,123,125)(Celsius)
-        #  Temp: UADP       R0                Normal            56 Celsius          	(107,117,123,125)(Celsius)
-        #  V1: VX1          R0                Normal            869 mV               	na
-        #  Temp:    inlet   R0                Normal            32 Celsius          	(56 ,66 ,96 ,98 )(Celsius)
+        # Sensor           Location          State          Reading           Threshold(Minor,Major,Critical,Shutdown)
+        # Temp: Coretemp   Chassis1-R0       Normal            46 Celsius                (107,117,123,125)(Celsius)
+        # Temp: UADP       Chassis1-R0       Normal            54 Celsius                (107,117,123,125)(Celsius)
+        # V1: VX1          Chassis1-R0       Normal            871 mV                    na
+        # V1: VX2          Chassis1-R0       Normal            1498 mV                   na
+        # V1: VX3          Chassis1-R0       Normal            1055 mV                   na
+        # V1: VX4          Chassis1-R0       Normal            852 mV                    na
+        # V1: VX5          Chassis1-R0       Normal            1507 mV                   na
+        # V1: VX6          Chassis1-R0       Normal            1301 mV                   na
+        # V1: VX7          Chassis1-R0       Normal            1005 mV                   na
         p5 = re.compile(
-            r'(?P<sensor_name>\S+(:\s+\S+)?)\s+(?P<slot>([A-Z][0-9]|\d/\d))\s+(?P<state>\S+)\s+(?P<reading>\d+\s+\S+(\s+(AC|DC))?)\s+(\((?P<minor>\d+\s*),(?P<major>\d+\s*),(?P<critical>\d+\s*),(?P<shutdown>\d+\s*)\)\((?P<unit>\S+)\))?'
+            r'(?P<sensor_name>\S+(:\s+\S+)?)\s+(?P<slot>\S+[0-9])\s+(?P<state>\S+)\s+(?P<reading>\d+\s+\S+(\s+(AC|DC))?)\s+(\((?P<minor>\d+\s*),(?P<major>\d+\s*),(?P<critical>\d+\s*),(?P<shutdown>\d+\s*)\)\((?P<unit>\S+)\))?'
         )
 
         # Power                                                       Fan States


### PR DESCRIPTION
## Description
For C9400s, "show environment all" recognizes the slot field of the Environmental Monitoring table as a capital letter followed by a number or two digits separated by a slash (/).

## Motivation and Context
This does not parse on C9400s due to regex used for "slot" (changed to location to match verbiage), but for locations such as "Chassis1-R0" or "Chassis2-3/0", they were not recognized.

## Impact (If any)
Can now parse 'show environment all' on C9400s where could not before.

## Screenshots:


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have updated the changelog.
- [ x ] I have updated the documentation (If applicable).
- [ x] I have added tests to cover my changes (If applicable).
- [ x] All new and existing tests passed.
- [ x] All new code passed compilation.
