### PR TITLE
Adjusts parser for "show ap cdp neighbor"

### DIFF
--- a/changelog/undistributed/changelog_show_ap_cdp_neighbor_iosxe_2025061749625685170805.rst
+++ b/changelog/undistributed/changelog_show_ap_cdp_neighbor_iosxe_2025061749625685170805.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* IOSXE
+    * Modified ShowApCdpNeighbor:
+        * Updated regex pattern neighbor_info_capture to optionally capture the Neighbors IP if it exists

--- a/src/genie/libs/parser/iosxe/show_ap.py
+++ b/src/genie/libs/parser/iosxe/show_ap.py
@@ -1,7 +1,7 @@
 import re
 
 from genie.metaparser import MetaParser
-from genie.metaparser.util.schemaengine import Any, Optional, Or
+from genie.metaparser.util.schemaengine import Any, Optional, Or, ListOf
 
 
 # ====================
@@ -1149,7 +1149,7 @@ class ShowApCdpNeighborSchema(MetaParser):
                 Optional("neighbor_name"): str,
                 Optional("neighbor_port"): str,
                 Optional("neighbor_ip_count"): int,
-                Optional("neighbor_ip_addresses"): list
+                Optional("neighbor_ip_addresses"): ListOf(str)
             }
         }
     }
@@ -1199,8 +1199,9 @@ class ShowApCdpNeighbor(ShowApCdpNeighborSchema):
 
         neighbor_count_capture = re.compile(r"^Number\s+of\s+neighbors:\s+(?P<neighbor_count>\d+)$")
         # 0221-cap22                   10.8.33.106                              a02-21-sd-sw1.cisco.com TenGigabitEthernet3/0/47
+        # 0221-cap22                   10.8.33.106                              a02-21-sd-sw1.cisco.com 10.8.32.1   TenGigabitEthernet3/0/47
         neighbor_info_capture = re.compile(
-            r"^(?P<ap_name>\S+)\s+(?P<ap_ip>\d+\.\d+\.\d+\.\d+)\s+(?P<neighbor_name>\S+)\s+(?P<neighbor_port>\S+)$")
+            r"^(?P<ap_name>\S+)\s+(?P<ap_ip>\d+\.\d+\.\d+\.\d+)\s+(?P<neighbor_name>\S+)(\s+(?P<neighbor_ip>\S+))?\s+(?P<neighbor_port>\S+)$")
         # Neighbor IP Count: 1
         neighbor_ip_count_capture = re.compile(r"^Neighbor\s+IP\s+Count:\s+(?P<neighbor_ip_count>\d+)$")
         # 10.8.32.1
@@ -1222,6 +1223,7 @@ class ShowApCdpNeighbor(ShowApCdpNeighborSchema):
             elif line.startswith('-----'):
                 continue
             # 0221-cap22                   10.8.33.106                              a02-21-sd-sw1.cisco.com TenGigabitEthernet3/0/47
+            # 0221-cap22                   10.8.33.106                              a02-21-sd-sw1.cisco.com 10.8.32.1   TenGigabitEthernet3/0/47
             elif neighbor_info_capture.match(line):
                 neighbor_info_capture_match = neighbor_info_capture.match(line)
                 groups = neighbor_info_capture_match.groupdict()
@@ -1235,6 +1237,11 @@ class ShowApCdpNeighbor(ShowApCdpNeighborSchema):
                 ap_cdp_neighbor_dict['ap_name'][ap_name]['ap_ip'] = ap_ip
                 ap_cdp_neighbor_dict['ap_name'][ap_name]['neighbor_name'] = neighbor_name
                 ap_cdp_neighbor_dict['ap_name'][ap_name]['neighbor_port'] = neighbor_port
+                if groups['neighbor_ip']:
+                    neighbor_ip = groups['neighbor_ip']
+                    address_list = ap_cdp_neighbor_dict['ap_name'][ap_name].setdefault('neighbor_ip_addresses', [])
+                    address_list.append(neighbor_ip)
+                    
             # Neighbor IP Count: 1
             elif neighbor_ip_count_capture.match(line):
                 neighbor_ip_count_match = neighbor_ip_count_capture.match(line)

--- a/src/genie/libs/parser/iosxe/tests/ShowApCdpNeighbor/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowApCdpNeighbor/cli/equal/golden_output_2_expected.py
@@ -1,0 +1,65 @@
+expected_output = {
+    "ap_cdp_neighbor_count": 149,
+    "ap_name": {
+        "0221-cap22": {
+            "ap_ip": "10.8.33.106",
+            "neighbor_name": "a02-21-sd-sw1.cisco.com",
+            "neighbor_port": "TenGigabitEthernet3/0/47",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0232-cap15": {
+            "ap_ip": "10.8.32.46",
+            "neighbor_name": "a02-32-sd-sw1.cisco.com",
+            "neighbor_port": "TenGigabitEthernet9/0/47",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0211-cap27": {
+            "ap_ip": "10.8.32.188",
+            "neighbor_name": "a02-11-sd-sw1.cisco.com",
+            "neighbor_port": "TenGigabitEthernet4/0/46",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0212-cap11": {
+            "ap_ip": "10.8.33.160",
+            "neighbor_name": "a02-12-sd-sw2.cisco.com",
+            "neighbor_port": "TenGigabitEthernet1/0/40",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0212-cap10": {
+            "ap_ip": "10.8.33.102",
+            "neighbor_name": "a02-12-sd-sw1.cisco.com",
+            "neighbor_port": "TenGigabitEthernet1/0/43",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0212-cap17": {
+            "ap_ip": "10.8.32.203",
+            "neighbor_name": "a02-12-sd-sw2.cisco.com",
+            "neighbor_port": "TenGigabitEthernet1/0/47",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0212-ca.4": {
+            "ap_ip": "10.8.32.202",
+            "neighbor_name": "a02-12-sd-sw1.cisco.com",
+            "neighbor_port": "TenGigabitEthernet1/0/48",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0222-cap09": {
+            "ap_ip": "10.8.33.33",
+            "neighbor_name": "a02-22-sd-sw2.cisco.com",
+            "neighbor_port": "TenGigabitEthernet8/0/48",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0231-cap43": {
+            "ap_ip": "10.8.33.93",
+            "neighbor_name": "a02-31-sd-sw1.cisco.com",
+            "neighbor_port": "TenGigabitEthernet4/0/47",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+        "0222-cap08": {
+            "ap_ip": "10.8.32.166",
+            "neighbor_name": "a02-22-sd-sw2.cisco.com",
+            "neighbor_port": "TenGigabitEthernet4/0/47",
+            "neighbor_ip_addresses": ["10.8.32.1"],
+        },
+    },
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowApCdpNeighbor/cli/equal/golden_output_2_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowApCdpNeighbor/cli/equal/golden_output_2_output.txt
@@ -1,0 +1,14 @@
+Number of neighbors: 149
+
+AP Name                          AP IP                                     Neighbor Name                              Neighbor IP        Neighbor Port
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+0221-cap22                       10.8.33.106                               a02-21-sd-sw1.cisco.com                    10.8.32.1          TenGigabitEthernet3/0/47
+0232-cap15                       10.8.32.46                                a02-32-sd-sw1.cisco.com                    10.8.32.1          TenGigabitEthernet9/0/47
+0211-cap27                       10.8.32.188                               a02-11-sd-sw1.cisco.com                    10.8.32.1          TenGigabitEthernet4/0/46
+0212-cap11                       10.8.33.160                               a02-12-sd-sw2.cisco.com                    10.8.32.1          TenGigabitEthernet1/0/40
+0212-cap10                       10.8.33.102                               a02-12-sd-sw1.cisco.com                    10.8.32.1          TenGigabitEthernet1/0/43
+0212-cap17                       10.8.32.203                               a02-12-sd-sw2.cisco.com                    10.8.32.1          TenGigabitEthernet1/0/47
+0212-ca.4                        10.8.32.202                               a02-12-sd-sw1.cisco.com                    10.8.32.1          TenGigabitEthernet1/0/48
+0222-cap09                       10.8.33.33                                a02-22-sd-sw2.cisco.com                    10.8.32.1          TenGigabitEthernet8/0/48
+0231-cap43                       10.8.33.93                                a02-31-sd-sw1.cisco.com                    10.8.32.1          TenGigabitEthernet4/0/47
+0222-cap08                       10.8.32.166                               a02-22-sd-sw2.cisco.com                    10.8.32.1          TenGigabitEthernet4/0/47


### PR DESCRIPTION
## Description
Resolves #723

Adjust regex to include the ap neighbor IP as it is output on 9800 platform v17.x

## Motivation and Context
The parser fails as it's not able to match when the ap cdp neighbor IP is in the same line as the other information.