### PR TITLE
Fixes to doc values for show processes memory

### DIFF
--- a/changelog/undistributed/changelog_show_processes_memory_doc_20250709194704.rst
+++ b/changelog/undistributed/changelog_show_processes_memory_doc_20250709194704.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* Parser
+    * Modified Show Processes Memory Doc Value ():
+        * Updated doc value for "show processes memory" to match this, instead of "show switch detail"

--- a/src/genie/libs/parser/ios/show_platform.py
+++ b/src/genie/libs/parser/ios/show_platform.py
@@ -635,6 +635,5 @@ class ShowSwitchDetail(ShowSwitchDetail_iosxe):
 
 
 class ShowProcessesMemory(ShowProcessesMemory_iosxe):
-    """Parser for show switch detail"""
-
+    """Parser for show processes memory"""
     pass


### PR DESCRIPTION
## Description
Change doc values of `show processes memory` to match the command

## Motivation and Context
This brings more clarity to the command and its purpose.

## Impact (If any)
None

## Screenshots:
N/A

## Checklist:
- [ x] I have updated the changelog.
- [ x] I have updated the documentation (If applicable).
- [ x] I have added tests to cover my changes (If applicable).
- [ x] All new and existing tests passed.
- [x] All new code passed compilation.
