### PR TITLE
[IOSXR] New `ShowSubscriberSessionAllSummary` Genie parser for IOS XR `show subscriber session all summary`

### DIFF
--- a/changelog/undistributed/changelog_show_subscriber_iosxr_20250923220203.rst
+++ b/changelog/undistributed/changelog_show_subscriber_iosxr_20250923220203.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                                      New
+--------------------------------------------------------------------------------
+
+* IOSXR
+    * Added `ShowSubscriberSessionAllSummary` Parser
+        *  Added schema and parser for `show subscriber session all summary` command.

--- a/src/genie/libs/parser/iosxr/show_subscriber.py
+++ b/src/genie/libs/parser/iosxr/show_subscriber.py
@@ -1,0 +1,221 @@
+"""
+show_subscriber.py
+IOSXR parsers for the following show commands:
+
+* `show subscriber session all summary`
+"""
+
+# Python
+import re
+
+# parser utils
+from genie.libs.parser.utils.common import Common
+
+# Metaparser
+from genie.metaparser import MetaParser
+from genie.metaparser.util.schemaengine import Any, Optional, Or, Schema
+
+
+# =======================================
+# Schema for 'show subscriber session all summary'
+# =======================================
+class ShowSubscriberSessionAllSummarySchema(MetaParser):
+    """Schema for `show subscriber session all summary`"""
+
+    schema = {
+        "subscriber": {
+            "session_summary": {
+                "state": {
+                    Or(
+                        "pppoe", "ip_subscriber_dhcp", "ip_subscriber_packet"
+                    ): {
+                        Optional("initializing"): int,
+                        Optional("connecting"): int,
+                        Optional("connected"): int,
+                        Optional("activated"): int,
+                        Optional("idle"): int,
+                        Optional("disconnecting"): int,
+                        Optional("end"): int,
+                        Optional("total"): int,
+                    },
+                },
+                "address_family": {
+                    Or(
+                        "pppoe", "ip_subscriber_dhcp", "ip_subscriber_packet"
+                    ): {
+                        Optional("in_progress"): int,
+                        Optional("ipv4_only"): int,
+                        Optional("ipv6_only"): int,
+                        Optional("dual_partial_up"): int,
+                        Optional("dual_up"): int,
+                        Optional("lac"): int,
+                        Optional("total"): int,
+                    },
+                },
+            }
+        }
+    }
+
+
+# =======================================
+# Parser for 'show subscriber session all summary'
+# =======================================
+class ShowSubscriberSessionAllSummary(ShowSubscriberSessionAllSummarySchema):
+    """Parser for `show subscriber session all summary`"""
+
+    cli_command = "show subscriber session all summary"
+
+    # RP/0/RSP0/CPU0:Router#show subscriber session all summary
+    # Thu Jan 01 00:00:00.000 UTC
+
+    # Session Summary Information for all nodes
+
+    #                 Type            PPPoE           IPSub           IPSub
+    #                                                 (DHCP)          (PKT)
+    #                 ====            =====           ======          =====
+
+    # Session Counts by State:
+    #         initializing            0               0               0
+    #           connecting            0               0               0
+    #            connected            0               0               0
+    #            activated            0               0               666
+    #                 idle            0               0               0
+    #        disconnecting            0               0               0
+    #                  end            0               0               0
+    #               Total:            0               0               666
+
+    # Session Counts by Address-Family/LAC:
+    #          in progress            0               0               0
+    #            ipv4-only            0               0               333
+    #            ipv6-only            0               0               333
+    #      dual-partial-up            0               0               0
+    #              dual-up            0               0               0
+    #                  lac            0               0               0
+    #               Total:            0               0               666
+
+    def cli(self, output=None) -> dict[str, object]:
+        if output is None:
+            # Execute command to get the raw output
+            out = self.device.execute(self.cli_command)
+        else:
+            out = output
+
+        # initial return dictionary
+        ret_dict: dict = {}
+
+        # Locate sections with regex
+
+        # Session Counts by State:
+        #         initializing            0               0               0
+        #           connecting            0               0               0
+        #            connected            0               0               0
+        #            activated            0               0               666
+        #                 idle            0               0               0
+        #        disconnecting            0               0               0
+        #                  end            0               0               0
+        #               Total:            0               0               666
+        state_match = re.search(
+            r"Session Counts by State:\s*(.+?)(?:\n\s*\n|\Z)",
+            out,
+            re.DOTALL | re.IGNORECASE,
+        )
+
+        # Session Counts by Address-Family/LAC:
+        #          in progress            0               0               0
+        #            ipv4-only            0               0               333
+        #            ipv6-only            0               0               333
+        #      dual-partial-up            0               0               0
+        #              dual-up            0               0               0
+        #                  lac            0               0               0
+        #               Total:            0               0               666
+        af_match = re.search(
+            r"Session Counts by Address-Family/LAC:\s*(.+?)(?:\n\s*\n|\Z)",
+            out,
+            re.DOTALL | re.IGNORECASE,
+        )
+
+        # The actual section as string, or empty string if not found
+        state_sec = state_match.group(1) if state_match else ""
+        af_sec = af_match.group(1) if af_match else ""
+
+        if state_sec or af_sec:
+            # Column-to-key mapping (left-to-right numeric columns)
+            svc_keys: list[str] = [
+                "pppoe",
+                "ip_subscriber_dhcp",
+                "ip_subscriber_packet",
+            ]
+
+            # Build output skeleton
+            ret_dict = {
+                "subscriber": {
+                    "session_summary": {
+                        "state": {k: {} for k in svc_keys},
+                        "address_family": {k: {} for k in svc_keys},
+                    }
+                }
+            }
+
+            # The following regex will match lines like, excluding the colon sign:
+            #         initializing            0               0               0
+            #           connecting            0               0               0
+            #            connected            0               0               0
+            #            activated            0               0               666
+            #                 idle            0               0               0
+            #        disconnecting            0               0               0
+            #                  end            0               0               0
+            #               Total:            0               0               666
+            #          in progress            0               0               0
+            #            ipv4-only            0               0               333
+            #            ipv6-only            0               0               333
+            #      dual-partial-up            0               0               0
+            #              dual-up            0               0               0
+            #                  lac            0               0               0
+            #               Total:            0               0               666
+            p = re.compile(
+                r"^(?P<key>[A-Za-z0-9][A-Za-z0-9 \/\-\(\)\.]*?)(?::)?\s+(?P<pppoe>\d+)\s+(?P<dhcp>\d+)\s+(?P<pkt>\d+)$"
+            )
+
+            # State section the rows with regex only (fallback)
+            for line in state_sec.splitlines():
+                line = line.strip()
+
+                if m := p.match(line):
+                    key = (
+                        m.group("key")
+                        .replace(" ", "_")
+                        .replace("-", "_")
+                        .lower()
+                    )
+                    ret_dict["subscriber"]["session_summary"]["state"][
+                        "pppoe"
+                    ][key] = int(m.group("pppoe"))
+                    ret_dict["subscriber"]["session_summary"]["state"][
+                        "ip_subscriber_dhcp"
+                    ][key] = int(m.group("dhcp"))
+                    ret_dict["subscriber"]["session_summary"]["state"][
+                        "ip_subscriber_packet"
+                    ][key] = int(m.group("pkt"))
+
+            # Address-Family section the rows with regex only (fallback)
+            for line in af_sec.splitlines():
+                line = line.strip()
+
+                if m := p.match(line):
+                    key = (
+                        m.group("key")
+                        .replace(" ", "_")
+                        .replace("-", "_")
+                        .lower()
+                    )
+                    ret_dict["subscriber"]["session_summary"][
+                        "address_family"
+                    ]["pppoe"][key] = int(m.group("pppoe"))
+                    ret_dict["subscriber"]["session_summary"][
+                        "address_family"
+                    ]["ip_subscriber_dhcp"][key] = int(m.group("dhcp"))
+                    ret_dict["subscriber"]["session_summary"][
+                        "address_family"
+                    ]["ip_subscriber_packet"][key] = int(m.group("pkt"))
+
+        return ret_dict

--- a/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_1_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_1_expected.py
@@ -1,0 +1,67 @@
+expected_output = {
+    "subscriber": {
+        "session_summary": {
+            "state": {
+                "pppoe": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 0,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_dhcp": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 0,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_packet": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 666,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 666,
+                },
+            },
+            "address_family": {
+                "pppoe": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 0,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_dhcp": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 0,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_packet": {
+                    "in_progress": 0,
+                    "ipv4_only": 333,
+                    "ipv6_only": 333,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 666,
+                },
+            },
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_1_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_1_output.txt
@@ -1,0 +1,28 @@
+RP/0/RSP0/CPU0:Router#show subscriber session all summary
+Thu Jan 01 00:00:00.000 UTC
+
+Session Summary Information for all nodes
+
+                Type            PPPoE           IPSub           IPSub
+                                                (DHCP)          (PKT)
+                ====            =====           ======          =====
+
+Session Counts by State:
+        initializing            0               0               0
+          connecting            0               0               0
+           connected            0               0               0
+           activated            0               0               666
+                idle            0               0               0
+       disconnecting            0               0               0
+                 end            0               0               0
+              Total:            0               0               666
+
+
+Session Counts by Address-Family/LAC:
+         in progress            0               0               0
+           ipv4-only            0               0               333
+           ipv6-only            0               0               333
+     dual-partial-up            0               0               0
+             dual-up            0               0               0
+                 lac            0               0               0
+              Total:            0               0               666

--- a/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_2_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_2_expected.py
@@ -1,0 +1,67 @@
+expected_output = {
+    "subscriber": {
+        "session_summary": {
+            "state": {
+                "pppoe": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 666,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 666,
+                },
+                "ip_subscriber_dhcp": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 0,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_packet": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 0,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 0,
+                },
+            },
+            "address_family": {
+                "pppoe": {
+                    "in_progress": 0,
+                    "ipv4_only": 333,
+                    "ipv6_only": 333,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 666,
+                },
+                "ip_subscriber_dhcp": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 0,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_packet": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 0,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 0,
+                },
+            },
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_2_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_2_output.txt
@@ -1,0 +1,28 @@
+RP/0/RSP0/CPU0:Router#show subscriber session all summary
+Thu Jan 01 00:00:00.000 UTC
+
+Session Summary Information for all nodes
+
+                Type            PPPoE           IPSub           IPSub
+                                                (DHCP)          (PKT)
+                ====            =====           ======          =====
+
+Session Counts by State:
+        initializing            0               0               0
+          connecting            0               0               0
+           connected            0               0               0
+           activated            666             0               0
+                idle            0               0               0
+       disconnecting            0               0               0
+                 end            0               0               0
+              Total:            666             0               0
+
+
+Session Counts by Address-Family/LAC:
+         in progress            0               0               0
+           ipv4-only            333             0               0
+           ipv6-only            333             0               0
+     dual-partial-up            0               0               0
+             dual-up            0               0               0
+                 lac            0               0               0
+              Total:            666             0               0

--- a/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_3_expected.py
+++ b/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_3_expected.py
@@ -1,0 +1,67 @@
+expected_output = {
+    "subscriber": {
+        "session_summary": {
+            "state": {
+                "pppoe": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 0,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_dhcp": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 8777,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 8777,
+                },
+                "ip_subscriber_packet": {
+                    "initializing": 0,
+                    "connecting": 0,
+                    "connected": 0,
+                    "activated": 0,
+                    "idle": 0,
+                    "disconnecting": 0,
+                    "end": 0,
+                    "total": 0,
+                },
+            },
+            "address_family": {
+                "pppoe": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 0,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 0,
+                },
+                "ip_subscriber_dhcp": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 8777,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 8777,
+                },
+                "ip_subscriber_packet": {
+                    "in_progress": 0,
+                    "ipv4_only": 0,
+                    "ipv6_only": 0,
+                    "dual_partial_up": 0,
+                    "dual_up": 0,
+                    "lac": 0,
+                    "total": 0,
+                },
+            },
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_3_output.txt
+++ b/src/genie/libs/parser/iosxr/tests/ShowSubscriberSessionAllSummary/cli/equal/golden_output_3_output.txt
@@ -1,0 +1,28 @@
+RP/0/RSP0/CPU0:Router#show subscriber session all summary
+Thu Jan 01 00:00:00.000 UTC
+
+Session Summary Information for all nodes
+
+                Type            PPPoE           IPSub           IPSub
+                                                (DHCP)          (PKT)
+                ====            =====           ======          =====
+
+Session Counts by State:
+        initializing            0               0               0
+          connecting            0               0               0
+           connected            0               0               0
+           activated            0               8777            0
+                idle            0               0               0
+       disconnecting            0               0               0
+                 end            0               0               0
+              Total:            0               8777            0
+
+
+Session Counts by Address-Family/LAC:
+         in progress            0               0               0
+           ipv4-only            0               0               0
+           ipv6-only            0               8777            0
+     dual-partial-up            0               0               0
+             dual-up            0               0               0
+                 lac            0               0               0
+              Total:            0               8777            0


### PR DESCRIPTION
## Description

This PR introduces a new Genie parser for IOS XR:

* **Command:** `show subscriber session all summary`
* **Parser:** `ShowSubscriberSessionAllSummary`
* **Scope:** Extracts both “Session Counts by State” and “Session Counts by Address-Family/LAC” tables and maps them into a structured schema suitable for analytics and downstream automations.

### What this adds

* Robust extraction of the two summary sections using tolerant regex blocks.
* Consistent mapping of service columns (left-to-right) to:
  * `pppoe`, `ip_subscriber_dhcp`, `ip_subscriber_packet`.
* Case-insensitive section detection and whitespace-insensitive label parsing.
* Unit tests and golden outputs validating happy path, empty output, and various formatting nuances.

## Motivation and Context

Operators and test suites frequently rely on these subscriber summaries to monitor PPPoE and IP subscriber states across BNG deployments. Prior to this addition, there was no dedicated parser for `show subscriber session all summary`.

## Impact (If any)

**Breaking changes:** None.
**Runtime impact:** Minimal. The parser performs two block extractions and per-row regex matches.
**Behavioral notes:**

* If neither section is found, the parser returns an empty dict (mirrors current implementation).

## Screenshots:

### 1) Unit test run

```bash
$ python tests/folder_parsing_job.py
<output omitted>
2025-09-24T12:56:39: %AETEST-INFO: +------------------------------------------------------------------------------+
2025-09-24T12:56:39: %AETEST-INFO: |               Starting section ShowSubscriberSessionAllSummary               |
2025-09-24T12:56:39: %AETEST-INFO: +------------------------------------------------------------------------------+
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :          Starting STEP 1: iosxr -> ShowSubscriberSessionAllSummary           :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :    Starting STEP 1.1: Test Golden -> iosxr -> ShowSubscriberSessionAllSum    :
2025-09-24T12:56:39: %AETEST-INFO: :                                     mary                                     :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :    Starting STEP 1.1.1: Gold -> iosxr -> ShowSubscriberSessionAllSummary     :
2025-09-24T12:56:39: %AETEST-INFO: :                              -> golden_output_1                              :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1.1.1: Gold -> iosxr -> ShowSubscriberSessionAllSummary -> golden_output_1 is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :    Starting STEP 1.1.2: Gold -> iosxr -> ShowSubscriberSessionAllSummary     :
2025-09-24T12:56:39: %AETEST-INFO: :                              -> golden_output_2                              :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1.1.2: Gold -> iosxr -> ShowSubscriberSessionAllSummary -> golden_output_2 is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :    Starting STEP 1.1.3: Gold -> iosxr -> ShowSubscriberSessionAllSummary     :
2025-09-24T12:56:39: %AETEST-INFO: :                              -> golden_output_3                              :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1.1.3: Gold -> iosxr -> ShowSubscriberSessionAllSummary -> golden_output_3 is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1.1: Test Golden -> iosxr -> ShowSubscriberSessionAllSummary is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :    Starting STEP 1.2: Test Empty -> iosxr -> ShowSubscriberSessionAllSumm    :
2025-09-24T12:56:39: %AETEST-INFO: :                                     ary                                      :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: :    Starting STEP 1.2.1: Empty -> iosxr -> ShowSubscriberSessionAllSummary    :
2025-09-24T12:56:39: %AETEST-INFO: :                                -> empty_output                               :
2025-09-24T12:56:39: %AETEST-INFO: +..............................................................................+
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1.2.1: Empty -> iosxr -> ShowSubscriberSessionAllSummary -> empty_output is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1.2: Test Empty -> iosxr -> ShowSubscriberSessionAllSummary is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: The result of STEP 1: iosxr -> ShowSubscriberSessionAllSummary is => PASSED
2025-09-24T12:56:39: %AETEST-INFO: +..........................................................+
2025-09-24T12:56:39: %AETEST-INFO: :                       STEPS Report                       :
2025-09-24T12:56:39: %AETEST-INFO: +..........................................................+
2025-09-24T12:56:39: %AETEST-INFO: STEP 1 - iosxr -> ShowSubscriberSessionAllSummary Passed
2025-09-24T12:56:39: %AETEST-INFO: STEP 1.1 - Test Golden -> iosxr -> ShowSubscriberSessionAllSummaryPassed
2025-09-24T12:56:39: %AETEST-INFO: STEP 1.1.1 - Gold -> iosxr -> ShowSubscriberSessionAllSummary -> golden_output_1Passed
2025-09-24T12:56:39: %AETEST-INFO: STEP 1.1.2 - Gold -> iosxr -> ShowSubscriberSessionAllSummary -> golden_output_2Passed
2025-09-24T12:56:39: %AETEST-INFO: STEP 1.1.3 - Gold -> iosxr -> ShowSubscriberSessionAllSummary -> golden_output_3Passed
2025-09-24T12:56:39: %AETEST-INFO: STEP 1.2 - Test Empty -> iosxr -> ShowSubscriberSessionAllSummaryPassed
2025-09-24T12:56:39: %AETEST-INFO: STEP 1.2.1 - Empty -> iosxr -> ShowSubscriberSessionAllSummary -> empty_outputPassed
2025-09-24T12:56:39: %AETEST-INFO: ............................................................
2025-09-24T12:56:39: %AETEST-INFO: The result of section ShowSubscriberSessionAllSummary is => PASSED
<output omitted>
2025-09-24T13:00:00: %GENIE-INFO: |   |-- ShowSubscriberSessionAllSummary                                   PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   |-- Step 1: iosxr -> ShowSubscriberSessionAllSummary              PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   |-- Step 1.1: Test Golden -> iosxr -> ShowSubscriberSession...    PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   |-- Step 1.1.1: Gold -> iosxr -> ShowSubscriberSessionAllSu...    PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   |-- Step 1.1.2: Gold -> iosxr -> ShowSubscriberSessionAllSu...    PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   |-- Step 1.1.3: Gold -> iosxr -> ShowSubscriberSessionAllSu...    PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   |-- Step 1.2: Test Empty -> iosxr -> ShowSubscriberSessionA...    PASSED
2025-09-24T13:00:00: %GENIE-INFO: |   |   `-- Step 1.2.1: Empty -> iosxr -> ShowSubscriberSessionAllS...    PASSED
<output omitted>
2025-09-24T13:00:07: %GENIE-INFO: +------------------------------------------------------------------------------+
2025-09-24T13:00:07: %GENIE-INFO: |                                   Summary                                    |
2025-09-24T13:00:07: %GENIE-INFO: +------------------------------------------------------------------------------+
2025-09-24T13:00:07: %GENIE-INFO:  Number of ABORTED                                                            0
2025-09-24T13:00:07: %GENIE-INFO:  Number of BLOCKED                                                            0
2025-09-24T13:00:07: %GENIE-INFO:  Number of ERRORED                                                            0
2025-09-24T13:00:07: %GENIE-INFO:  Number of FAILED                                                             0
2025-09-24T13:00:07: %GENIE-INFO:  Number of PASSED                                                            24
2025-09-24T13:00:07: %GENIE-INFO:  Number of PASSX                                                              0
2025-09-24T13:00:07: %GENIE-INFO:  Number of SKIPPED                                                            0
2025-09-24T13:00:07: %GENIE-INFO:  Total Number                                                                24
2025-09-24T13:00:07: %GENIE-INFO:  Success Rate                                                            100.0%
2025-09-24T13:00:07: %GENIE-INFO: --------------------------------------------------------------------------------
2025-09-24T13:00:07: %GENIE-INFO:  Total Parsers Missing Unittests                                            365
2025-09-24T13:00:07: %GENIE-INFO: --------------------------------------------------------------------------------
2025-09-24T13:00:07: %GENIE-INFO:  Total Passing Unittests                                                  10679
2025-09-24T13:00:07: %GENIE-INFO:  Total Failed Unittests                                                       0
2025-09-24T13:00:07: %GENIE-INFO:  Total Errored Unittests                                                      0
2025-09-24T13:00:07: %GENIE-INFO:  Total Unittests                                                          10679
2025-09-24T13:00:07: %GENIE-INFO: --------------------------------------------------------------------------------```

### 2) Sample raw output

```bash
RP/0/RSP0/CPU0:Router#show subscriber session all summary
Thu Jan 01 00:00:00.000 UTC

Session Summary Information for all nodes

                Type            PPPoE           IPSub           IPSub
                                                (DHCP)          (PKT)
                ====            =====           ======          =====

Session Counts by State:
        initializing            0               0               0
          connecting            0               0               0
           connected            0               0               0
           activated            0               0               666
                idle            0               0               0
       disconnecting            0               0               0
                 end            0               0               0
              Total:            0               0               666


Session Counts by Address-Family/LAC:
         in progress            0               0               0
           ipv4-only            0               0               333
           ipv6-only            0               0               333
     dual-partial-up            0               0               0
             dual-up            0               0               0
                 lac            0               0               0
              Total:            0               0               666
```

### 3) Sample parsed structure (excerpt)

```python
{
  "subscriber": {
    "session_summary": {
      "state": {
        "pppoe": {
          "initializing": 0,
          "connecting": 0,
          "connected": 0,
          "activated": 0,
          "idle": 0,
          "disconnecting": 0,
          "end": 0,
          "total": 0
        },
        "ip_subscriber_dhcp": { ... },
        "ip_subscriber_packet": { "activated": 666, "total": 666, ... }
      },
      "address_family": {
        "pppoe": { ... },
        "ip_subscriber_dhcp": { ... },
        "ip_subscriber_packet": {
          "ipv4_only": 333,
          "ipv6_only": 333,
          "total": 666
        }
      }
    }
  }
}
```

## Checklist:

* [x] I have updated the changelog.
* [ ] I have updated the documentation (If applicable).
* [x] I have added tests to cover my changes (If applicable).
* [x] All new and existing tests passed.
* [x] All new code passed compilation.
