### PR TITLE
Update of show_ptp and show_frequency_synchronization to work with IOS-XR 24.x.x and higher

### DIFF
--- a/changelog/undistributed/changelog_show_frequency_synchronization_iosxr_20251007133300.rst
+++ b/changelog/undistributed/changelog_show_frequency_synchronization_iosxr_20251007133300.rst
@@ -1,0 +1,12 @@
+
+
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+
+* iosxr
+    * Modified ShowFrequencySynchronizationInterfaces:
+        * Changed wait_to_restore_time from schema to Optional.
+        
+
+

--- a/changelog/undistributed/changelog_show_ptp_iosxr_20251007133300.rst
+++ b/changelog/undistributed/changelog_show_ptp_iosxr_20251007133300.rst
@@ -1,0 +1,16 @@
+
+
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+
+* iosxr
+    * Modified ShowPtpPlatformServo:
+        * Changed <key1>, <key2> from schema to Optional.
+        * Updated regex pattern p13, p14 to accommodate various time formats.
+
+    * Modified ShowPtpForeignMastersInterface:
+        * Changed announce_messages from Schema to Optional.
+        * Updated regex pattern p2 to accommodate also Multicast (for G.8275.2).
+        * Added a logic to get only the first 'Clock ID'.
+        

--- a/src/genie/libs/parser/iosxr/show_frequency_synchronization.py
+++ b/src/genie/libs/parser/iosxr/show_frequency_synchronization.py
@@ -28,7 +28,7 @@ class ShowFrequencySynchronizationInterfacesSchema(MetaParser):
                 'interface': str,
                 'interface_status': str,
                 Optional('selection'): str,
-                'wait_to_restore_time': int,
+                Optional('wait_to_restore_time'): int,
                 'ssm': {
                     'status': str,
                     Optional('peer_time'): str,
@@ -49,7 +49,7 @@ class ShowFrequencySynchronizationInterfacesSchema(MetaParser):
                     }
                 },
                 'input': {
-                    'status': str,
+                    Optional('status'): str,
                     Optional('selection'): str,
                     Optional('restore'): str,
                     Optional('last_received_ql'): str,


### PR DESCRIPTION
## Description
* iosxr (show_ptp)
    * Modified ShowPtpPlatformServo:
        * Updated regex pattern p13, p14 to accommodate various time formats.

    * Modified ShowPtpForeignMastersInterface:
        * Changed announce_messages from Schema to Optional.
        * Updated regex pattern p2 to accommodate also Multicast (for G.8275.2).
        * Added a logic to get only the first 'Clock ID'.

* iosxr (show_frequency_synchronization)
    * Modified ShowFrequencySynchronizationInterfaces:
        * Changed wait_to_restore_time from schema to Optional.

## Motivation and Context
Make the parsers usable for IOS-XR 24.x.x and higher

## Impact (If any)
'offset_from_master' and 'mean_path_delay' is one string and not a separation of secs and nsecs

## Screenshots:


## Checklist:

- [ x] I have updated the changelog.
- [ ] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [x] All new code passed compilation.
