### PR TITLE
Fixes related to whitespace for parsing "show interfaces accounting"

### DIFF
--- a/changelog/undistributed/changelog_show_interfaces_accounting_202510291800.rst
+++ b/changelog/undistributed/changelog_show_interfaces_accounting_202510291800.rst
@@ -1,0 +1,8 @@
+----------------------
+         Fix
+----------------------
+* iosxe
+    * Modified class ShowInterfacesAccounting
+        * Modified regex pattern to support interface descriptions with multiple spaces
+        * Only right-strip whitespace from lines and modify regex for lines containing counters to add explicit leading
+          whitespace

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -3828,10 +3828,11 @@ class ShowInterfacesAccounting(ShowInterfacesAccountingSchema):
         # initial regexp pattern
         # GigabitEthernet0/0/0/0
         # GigabitEthernet11 OOB Net
+        # TenGigabitEthernet0/0/0 rvartr101 e1/9  rack  107-37 N2C-BE VRF
         # (need to exclude below line)
         # -------------------------------------------------------------------------------------------------------------------------
         p1 = re.compile(
-            r'^(?!-)(?P<interface>[a-zA-Z\-\d\/\.]+)(?P<description>( (\S)+)*)$'
+            r'^(?!-)(?P<interface>[a-zA-Z\-\d/.]+)(\s+(?P<description>[\S\s]+?))?$'
         )
 
         # Tunnel0 Pim Register Tunnel (Encap) for RP 10.186.1.1
@@ -3843,7 +3844,7 @@ class ShowInterfacesAccounting(ShowInterfacesAccountingSchema):
         #   DEC MOP          2        154          2        154
         #   Other           15          900          861       370708           0            0            0            0
         p2 = re.compile(
-            r'^(?P<protocol>\S+(\s\S+)?)\s+(?P<pkts_in>\d+)\s+(?P<chars_in>\d+)\s+(?P<pkts_out>\d+)\s+(?P<chars_out>\d+)(\s+(?P<rxbs>\d+)\s+(?P<rxps>\d+)\s+(?P<txbs>\d+)\s+(?P<txps>\d+))?'
+            r'^\s+(?P<protocol>\S+(\s\S+)?)\s+(?P<pkts_in>\d+)\s+(?P<chars_in>\d+)\s+(?P<pkts_out>\d+)\s+(?P<chars_out>\d+)(\s+(?P<rxbs>\d+)\s+(?P<rxps>\d+)\s+(?P<txbs>\d+)\s+(?P<txps>\d+))?'
         )
 
         # No traffic sent or received on this interface.
@@ -3852,7 +3853,7 @@ class ShowInterfacesAccounting(ShowInterfacesAccountingSchema):
 
         for line in out.splitlines():
             if line:
-                line = line.strip()
+                line = line.rstrip()
             else:
                 continue
 

--- a/src/genie/libs/parser/iosxe/tests/ShowInterfacesAccounting/cli/equal/golden_output4_expected.py
+++ b/src/genie/libs/parser/iosxe/tests/ShowInterfacesAccounting/cli/equal/golden_output4_expected.py
@@ -1,0 +1,382 @@
+expected_output = {
+  'TenGigabitEthernet0/0/0': {
+    'accounting': {
+      'other': {
+        'pkts_in': 5106,
+        'chars_in': 2230137,
+        'pkts_out': 5138,
+        'chars_out': 1964273,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'ip': {
+        'pkts_in': 338457249,
+        'chars_in': 167816970857,
+        'pkts_out': 403143873,
+        'chars_out': 57956524883,
+        'rxbs': 3274000,
+        'rxps': 774,
+        'txbs': 847000,
+        'txps': 593
+      },
+      'arp': {
+        'pkts_in': 135,
+        'chars_in': 8100,
+        'pkts_out': 135,
+        'chars_out': 8100,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'lldp': {
+        'pkts_in': 4971,
+        'chars_in': 2222037,
+        'pkts_out': 5003,
+        'chars_out': 1956173,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'rvartr101 e1/9  rack  107-37 N2C-BE VRF'
+  },
+  'TenGigabitEthernet0/1/0': {
+    'accounting': {
+      'other': {
+        'pkts_in': 5106,
+        'chars_in': 2240079,
+        'pkts_out': 5138,
+        'chars_out': 1959270,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'ip': {
+        'pkts_in': 381356839,
+        'chars_in': 126948444814,
+        'pkts_out': 664982649,
+        'chars_out': 370327269434,
+        'rxbs': 1148000,
+        'rxps': 307,
+        'txbs': 7418000,
+        'txps': 1584
+      },
+      'arp': {
+        'pkts_in': 135,
+        'chars_in': 8100,
+        'pkts_out': 135,
+        'chars_out': 8100,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'lldp': {
+        'pkts_in': 4971,
+        'chars_in': 2231979,
+        'pkts_out': 5003,
+        'chars_out': 1951170,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'rvartr101 e1/21 Rack 107-37 NRG VRF'
+  },
+  'TenGigabitEthernet1/0/0': {
+    'accounting': {
+      'other': {
+        'pkts_in': 5106,
+        'chars_in': 2230137,
+        'pkts_out': 5138,
+        'chars_out': 1959270,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'ip': {
+        'pkts_in': 325005411,
+        'chars_in': 157348328540,
+        'pkts_out': 387857211,
+        'chars_out': 108103397434,
+        'rxbs': 3273000,
+        'rxps': 791,
+        'txbs': 2365000,
+        'txps': 1419
+      },
+      'arp': {
+        'pkts_in': 135,
+        'chars_in': 8100,
+        'pkts_out': 135,
+        'chars_out': 8100,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'lldp': {
+        'pkts_in': 4971,
+        'chars_in': 2222037,
+        'pkts_out': 5003,
+        'chars_out': 1951170,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'rvartr102 e1/9  rack 207-37 N2C-BE VRF'
+  },
+  'TenGigabitEthernet1/1/0': {
+    'accounting': {
+      'other': {
+        'pkts_in': 5106,
+        'chars_in': 2240079,
+        'pkts_out': 5138,
+        'chars_out': 1964273,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'ip': {
+        'pkts_in': 412136589,
+        'chars_in': 94935119130,
+        'pkts_out': 95813,
+        'chars_out': 8034918,
+        'rxbs': 3217000,
+        'rxps': 1740,
+        'txbs': 0,
+        'txps': 0
+      },
+      'arp': {
+        'pkts_in': 135,
+        'chars_in': 8100,
+        'pkts_out': 135,
+        'chars_out': 8100,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'lldp': {
+        'pkts_in': 4971,
+        'chars_in': 2231979,
+        'pkts_out': 5003,
+        'chars_out': 1956173,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'rvartr102 e1/21 Rack 207-37  NRG VRF'
+  },
+  'GigabitEthernet0': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 25051,
+        'chars_in': 1853314,
+        'pkts_out': 1617107,
+        'chars_out': 605785532,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 24000,
+        'txps': 7
+      },
+      'arp': {
+        'pkts_in': 98549,
+        'chars_in': 5912940,
+        'pkts_out': 548,
+        'chars_out': 32880,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      },
+      'lldp': {
+        'pkts_in': 0,
+        'chars_in': 0,
+        'pkts_out': 10036,
+        'chars_out': 3733392,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'rvartr001_002 eth 1/44'
+  },
+  'Loopback0': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 672,
+        'chars_in': 62644,
+        'pkts_out': 672,
+        'chars_out': 62644,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'Router-ID'
+  },
+  'Loopback1': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 672,
+        'chars_in': 62644,
+        'pkts_out': 672,
+        'chars_out': 62644,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'External VPN peering address'
+  },
+  'Loopback2': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 672,
+        'chars_in': 62644,
+        'pkts_out': 672,
+        'chars_out': 62644,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'External BGP peering address'
+  },
+  'Tunnel3': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 251293253,
+        'chars_in': 29461147054,
+        'pkts_out': 166645644,
+        'chars_out': 78101624305,
+        'rxbs': 119000,
+        'rxps': 104,
+        'txbs': 31000,
+        'txps': 57
+      }
+    },
+    'description': 'SVTI to XXXX'
+  },
+  'Tunnel4': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 572804,
+        'chars_in': 62566815,
+        'pkts_out': 575926,
+        'chars_out': 63164261,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 1
+      }
+    },
+    'description': 'Tunnel to LAB-DR, EUROPE'
+  },
+  'Tunnel5': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 180719,
+        'chars_in': 9369841,
+        'pkts_out': 181541,
+        'chars_out': 9444110,
+        'rxbs': 0,
+        'rxps': 1,
+        'txbs': 0,
+        'txps': 1
+      }
+    },
+    'description': 'Tunnel to LAB, Arkansas, India'
+  },
+  'Tunnel7': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 179860,
+        'chars_in': 13450037,
+        'pkts_out': 201101,
+        'chars_out': 10419536,
+        'rxbs': 0,
+        'rxps': 1,
+        'txbs': 0,
+        'txps': 1
+      }
+    },
+    'description': 'SVTI to BAY PRI'
+  },
+  'Tunnel8': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 179880,
+        'chars_in': 13451274,
+        'pkts_out': 201191,
+        'chars_out': 10424293,
+        'rxbs': 0,
+        'rxps': 1,
+        'txbs': 0,
+        'txps': 1
+      }
+    },
+    'description': 'SVTI to BAY SEC'
+  },
+  'Tunnel9': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 0,
+        'chars_in': 0,
+        'pkts_out': 672,
+        'chars_out': 62644,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'Tunnel to LONA_UK Secondary'
+  },
+  'Tunnel10': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 19680326,
+        'chars_in': 2164494900,
+        'pkts_out': 14388523,
+        'chars_out': 5226520320,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 1
+      }
+    },
+    'description': 'Tunnel to GRE_PRIS_WEST Secondary'
+  },
+  'Tunnel11': {
+    'accounting': {
+      'ip': {
+        'pkts_in': 31059,
+        'chars_in': 2286134,
+        'pkts_out': 31689,
+        'chars_out': 2360983,
+        'rxbs': 0,
+        'rxps': 0,
+        'txbs': 0,
+        'txps': 0
+      }
+    },
+    'description': 'GRE  Tunnel to NUVA-DMP'
+  }
+}

--- a/src/genie/libs/parser/iosxe/tests/ShowInterfacesAccounting/cli/equal/golden_output4_output.txt
+++ b/src/genie/libs/parser/iosxe/tests/ShowInterfacesAccounting/cli/equal/golden_output4_output.txt
@@ -1,0 +1,142 @@
+TenGigabitEthernet0/0/0 rvartr101 e1/9  rack  107-37 N2C-BE VRF
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+       Other         5106      2230137         5138      1964273           0            0            0            0
+          IP    338457249 167816970857    403143873  57956524883     3274000          774       847000          593
+         ARP          135         8100          135         8100           0            0            0            0
+        LLDP         4971      2222037         5003      1956173           0            0            0            0
+TenGigabitEthernet0/1/0 rvartr101 e1/21 Rack 107-37 NRG VRF
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+       Other         5106      2240079         5138      1959270           0            0            0            0
+          IP    381356839 126948444814    664982649 370327269434     1148000          307      7418000         1584
+         ARP          135         8100          135         8100           0            0            0            0
+        LLDP         4971      2231979         5003      1951170           0            0            0            0
+TenGigabitEthernet1/0/0 rvartr102 e1/9  rack 207-37 N2C-BE VRF
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+       Other         5106      2230137         5138      1959270           0            0            0            0
+          IP    325005411 157348328540    387857211 108103397434     3273000          791      2365000         1419
+         ARP          135         8100          135         8100           0            0            0            0
+        LLDP         4971      2222037         5003      1951170           0            0            0            0
+TenGigabitEthernet1/1/0 rvartr102 e1/21 Rack 207-37  NRG VRF
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+       Other         5106      2240079         5138      1964273           0            0            0            0
+          IP    412136589  94935119130        95813      8034918     3217000         1740            0            0
+         ARP          135         8100          135         8100           0            0            0            0
+        LLDP         4971      2231979         5003      1956173           0            0            0            0
+GigabitEthernet0 rvartr001_002 eth 1/44
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP        25051      1853314      1617107    605785532           0            0        24000            7
+         ARP        98549      5912940          548        32880           0            0            0            0
+        LLDP            0            0        10036      3733392           0            0            0            0
+Loopback0 Router-ID
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP          672        62644          672        62644           0            0            0            0
+Loopback1 External VPN peering address
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP          672        62644          672        62644           0            0            0            0
+Loopback2 External BGP peering address
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP          672        62644          672        62644           0            0            0            0
+Tunnel3 SVTI to XXXX
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP    251293253  29461147054    166645644  78101624305      119000          104        31000           57
+Tunnel4 Tunnel to LAB-DR, EUROPE
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP       572804     62566815       575926     63164261           0            0            0            1
+Tunnel5 Tunnel to LAB, Arkansas, India
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP       180719      9369841       181541      9444110           0            1            0            1
+Tunnel7 SVTI to BAY PRI
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP       179860     13450037       201101     10419536           0            1            0            1
+Tunnel8 SVTI to BAY SEC
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP       179880     13451274       201191     10424293           0            1            0            1
+Tunnel9 Tunnel to LONA_UK Secondary
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP            0            0          672        62644           0            0            0            0
+Tunnel10 Tunnel to GRE_PRIS_WEST Secondary
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP     19680326   2164494900     14388523   5226520320           0            0            0            1
+Tunnel11 GRE  Tunnel to NUVA-DMP
+ Pkts In: input pkts                 Pkts Out: output pkts
+ Chars In: input bytes received      Chars Out: output bytes transmitted
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+    Protocol      Pkts In     Chars In     Pkts Out    Chars Out        RXBS         RXPS         TXBS         TXPS
+-------------------------------------------------------------------------------------------------------------------------
+          IP        31059      2286134        31689      2360983           0            0            0            0


### PR DESCRIPTION
## Description
* iosxe
    * Modified class ShowInterfacesAccounting
        * Modified regex pattern to support interface descriptions with multiple spaces
        * Only right-strip whitespace from lines and modify regex for lines containing counters to add explicit leading
          whitespace

## Motivation and Context
learn("interface") was crashing on output from an iosxe device where interface descriptions had multiple spaces

## Impact (If any)
The output that was failing now parses successfully


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the changelog.
- [x] I have updated the documentation (If applicable).
- [x] I have added tests to cover my changes (If applicable).
- [x] All new and existing tests passed.
- [ ] All new code passed compilation.
