### PR TITLE
Show Environment All - C9400s with Multiple switches

### DIFF
--- a/changelog/undistributed/changelog_fix_c9400_show_environment_all_20251216005343.rst
+++ b/changelog/undistributed/changelog_fix_c9400_show_environment_all_20251216005343.rst
@@ -1,0 +1,7 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* C9400
+    * Modified/Revised ShowEnvironmentAll:
+        * Changed schema to include "switch" for every switch in the stack.
+        * Updated regex pattern to accomodate for "Switch:1" and "Switch: 1" outputs and use those as keys to the power supply and fantray parsing.

--- a/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/__init__.py
+++ b/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/__init__.py
@@ -1,0 +1,2 @@
+from genie import abstract
+abstract.declare_token(revision='1')

--- a/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/show_platform.py
+++ b/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/show_platform.py
@@ -1,0 +1,269 @@
+# Python
+import re
+
+# Metaparser
+from genie.metaparser import MetaParser
+from genie.metaparser.util.schemaengine import Any, Optional, Or
+
+class ShowEnvironmentAllSchema(MetaParser):
+    """Schema for show environment all
+                  show environment all | include {include} """
+
+    schema = {
+        Optional('critical_alarms'): int,
+        Optional('major_alarms'): int,
+        Optional('minor_alarms'): int,
+        'sensor_list': {
+            Any(): {
+                'slot': {
+                    Any(): {
+                        'sensor': {
+                            Any(): {
+                                'state': str,
+                                'reading': str,
+                                Optional('threshold'): {
+                                    'minor': int,
+                                    'major': int,
+                                    'critical': int,
+                                    'shutdown': int,
+                                    'unit': str,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        'switch': {
+            Any(): {
+                'power_supply': {
+                    'slot': {
+                        Any(): {
+                            'model_no': str,
+                            'type': str,
+                            'capacity': str,
+                            'status': str,
+                            'fan_1_state': str,
+                            'fan_2_state': str,
+                        }
+                    },
+                    'current_configuration_mode': str,
+                    'current_operating_state': str,
+                    'currently_active': int,
+                    'currently_available': int,
+                },
+                'fantray': {
+                    'status': str,
+                    'power_consumed_by_fantray_watts': int,
+                    'fantray_airflow_direction': str,
+                    'fantray_beacon_led': str,
+                    'fantray_status_led': str,
+                    'system': str,
+                },
+            },
+        },
+    }
+
+
+class ShowEnvironmentAll(ShowEnvironmentAllSchema):
+    """Parser for show environment all
+                  show environment all | include {include}"""
+
+    cli_command = [
+        'show environment all', 'show environment all | include {include}'
+    ]
+
+    def cli(self, include='', output=None):
+        if not output:
+            if include:
+                cmd = self.cli_command[1].format(include=include)
+            else:
+                cmd = self.cli_command[0]
+            output = self.device.execute(cmd)
+
+        # initial return dictionary
+        ret_dict = {}
+
+        # Number of Critical alarms:  0
+        p1 = re.compile(
+            r'^Number +of +Critical +alarms: +(?P<critic_alarms>\d+)$')
+
+        # Number of Major alarms:     0
+        p2 = re.compile(r'^Number +of +Major +alarms: +(?P<maj_alarms>\d+)$')
+
+        # Number of Minor alarms:     0
+        p3 = re.compile(r'^Number +of +Minor +alarms: +(?P<min_alarms>\d+)$')
+
+        # Sensor List:  Environmental Monitoring
+        p4 = re.compile(r'Sensor\s+List:\s+(?P<sensor_list>.+)')
+
+        # Sensor           Location          State          Reading           Threshold(Minor,Major,Critical,Shutdown)
+        # Temp: Coretemp   Chassis1-R0       Normal            46 Celsius                (107,117,123,125)(Celsius)
+        # Temp: UADP       Chassis1-R0       Normal            54 Celsius                (107,117,123,125)(Celsius)
+        # V1: VX1          Chassis1-R0       Normal            871 mV                    na
+        # V1: VX2          Chassis1-R0       Normal            1498 mV                   na
+        # V1: VX3          Chassis1-R0       Normal            1055 mV                   na
+        # V1: VX4          Chassis1-R0       Normal            852 mV                    na
+        # V1: VX5          Chassis1-R0       Normal            1507 mV                   na
+        # V1: VX6          Chassis1-R0       Normal            1301 mV                   na
+        # V1: VX7          Chassis1-R0       Normal            1005 mV                   na
+        p5 = re.compile(
+            r'(?P<sensor_name>\S+(:\s+\S+)?)\s+(?P<slot>\S+[0-9])\s+(?P<state>\S+)\s+(?P<reading>\d+\s+\S+(\s+(AC|DC))?)\s+(\((?P<minor>\d+\s*),(?P<major>\d+\s*),(?P<critical>\d+\s*),(?P<shutdown>\d+\s*)\)\((?P<unit>\S+)\))?'
+        )
+
+        # Switch:1
+        p6 = re.compile(r'^Switch:(?P<switch>\d+)')
+
+        # Power                                                       Fan States
+        # Supply  Model No              Type  Capacity  Status        1     2
+        # ------  --------------------  ----  --------  ------------  -----------
+        # PS1     C9400-PWR-3200AC      ac    3200 W    active        good  good
+        # PS2     C9400-PWR-3200AC      ac    n.a.      faulty        good  good
+        p7 = re.compile(
+            r'(?P<ps_slot>PS\S+)\s+(?P<model_no>\S+)\s+(?P<type>\S+)\s+(?P<capacity>\S+(\s+\S+)?)\s+(?P<status>\S+)\s+(?P<fan_1_state>\S+)\s+(?P<fan_2_state>\S+)$'
+        )
+
+        # PS Current Configuration Mode : Combined
+        # PS Current Operating State    : Combined
+        # Power supplies currently active    : 1
+        # Power supplies currently available : 1
+        p8 = re.compile(
+            r'(PS|Power supplies)\s+(?P<ps_key>.+)\s+:\s+(?P<ps_value>\S+)')
+
+        # Switch 1:
+        p9 = re.compile(r'^Switch +(?P<switch>\d+)')
+
+        # Fantray : good
+        # Power consumed by Fantray : 540 Watts
+        # Fantray airflow direction : side-to-side
+        # Fantray beacon LED: off
+        # Fantray status LED: green
+        # SYSTEM : GREEN
+        p10 = re.compile(
+            r'(?P<fantray_key>((.+)?Fantray(.+)?)|SYSTEM)(\s+)?:\s+(?P<fantray_value>(\S+)|(\d+\s+Watts))'
+        )
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            # Number of Critical alarms:  0
+            m = p1.match(line)
+            if m:
+                group = m.groupdict()
+                ret_dict['critical_alarms'] = int(group['critic_alarms'])
+                continue
+
+            # Number of Major alarms:     0
+            m = p2.match(line)
+            if m:
+                group = m.groupdict()
+                ret_dict['major_alarms'] = int(group['maj_alarms'])
+                continue
+
+            # Number of Minor alarms:     0
+            m = p3.match(line)
+            if m:
+                group = m.groupdict()
+                ret_dict['minor_alarms'] = int(group['min_alarms'])
+                continue
+
+            # Sensor List:  Environmental Monitoring
+            m = p4.match(line)
+            if m:
+                group = m.groupdict()
+                sensor_dict = ret_dict.setdefault('sensor_list',
+                                                  {}).setdefault(
+                                                      group['sensor_list'], {})
+                continue
+
+            #  Sensor           Location          State          Reading           Threshold(Minor,Major,Critical,Shutdown)
+            #  Temp: Coretemp   R0                Normal            48 Celsius          	(107,117,123,125)(Celsius)
+            #  Temp: UADP       R0                Normal            56 Celsius          	(107,117,123,125)(Celsius)
+            #  V1: VX1          R0                Normal            869 mV               	na
+            #  Temp:    inlet   R0                Normal            32 Celsius          	(56 ,66 ,96 ,98 )(Celsius)
+            m = p5.match(line)
+            if m:
+                group = m.groupdict()
+                sensor_name = group.pop('sensor_name')
+                slot = group.pop('slot')
+                fin_dict = sensor_dict.setdefault('slot', {}).setdefault(slot, {}).\
+                    setdefault('sensor', {}).setdefault(sensor_name, {})
+
+                fin_dict['state'] = group['state']
+                fin_dict['reading'] = group['reading']
+                if group['minor']:
+                    fin_dict.setdefault('threshold', {})
+                    for key in [
+                            'minor', 'major', 'critical', 'shutdown', 'unit'
+                    ]:
+                        fin_dict['threshold'][key] = int(
+                            group[key]) if key != 'unit' else group[key]
+                continue
+
+            # Switch:1
+            m = p6.match(line)
+            if m:
+                group = m.groupdict()
+                switch = group['switch']
+                sw_dict = ret_dict.setdefault('switch', {}).setdefault(switch, {})
+
+            # Power                                                       Fan States
+            # Supply  Model No              Type  Capacity  Status        1     2
+            # ------  --------------------  ----  --------  ------------  -----------
+            # PS1     C9400-PWR-3200AC      ac    3200 W    active        good  good
+            # PS2     C9400-PWR-3200AC      ac    n.a.      faulty        good  good
+            m = p7.match(line)
+            if m:
+                group = m.groupdict()
+                ps_slot = group.pop('ps_slot')
+                ps_dict = sw_dict.setdefault('power_supply', {})
+                ps_slot_dict = ps_dict.setdefault('slot',
+                                                  {}).setdefault(ps_slot, {})
+                ps_slot_dict.update({k: v for k, v in group.items()})
+
+            # PS Current Configuration Mode : Combined
+            # PS Current Operating State    : Combined
+            # Power supplies currently active    : 1
+            # Power supplies currently available : 1
+            m = p8.match(line)
+            if m:
+                group = m.groupdict()
+                ps_key = group['ps_key'].strip().lower().replace(' ', '_')
+                if 'active' in ps_key or 'available' in ps_key:
+                    ps_value = int(group['ps_value'])
+                else:
+                    ps_value = group['ps_value']
+                ps_dict.setdefault(ps_key, ps_value)
+
+            # Switch 1:
+            m = p9.match(line)
+            if m:
+                group = m.groupdict()
+                switch = group['switch']
+                sw_dict = ret_dict.setdefault('switch', {}).setdefault(switch, {})
+
+            # Fantray : good
+            # Power consumed by Fantray : 540 Watts
+            # Fantray airflow direction : side-to-side
+            # Fantray beacon LED: off
+            # Fantray status LED: green
+            # SYSTEM : GREEN
+            m = p10.match(line)
+            if m:
+                group = m.groupdict()
+                fantray_key = group['fantray_key'].strip().lower().replace(
+                    ' ', '_')
+                if 'power_consumed' in fantray_key:
+                    fantray_value = int(group['fantray_value'])
+                    fantray_key += '_watts'
+                else:
+                    fantray_value = group['fantray_value']
+                if 'fantray' == fantray_key:
+                    sw_dict.setdefault('fantray',
+                                        {}).setdefault('status', fantray_value)
+                else:
+                    sw_dict.setdefault('fantray',
+                                        {}).setdefault(fantray_key,
+                                                       fantray_value)
+
+        return ret_dict

--- a/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/tests/ShowEnvironmentAll/cli/equal/golden_output_actual.json
+++ b/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/tests/ShowEnvironmentAll/cli/equal/golden_output_actual.json
@@ -1,0 +1,633 @@
+{
+    "critical_alarms": 0,
+    "major_alarms": 0,
+    "minor_alarms": 0,
+    "sensor_list": {
+        "Environmental Monitoring": {
+            "slot": {
+                "Chassis1-R0": {
+                    "sensor": {
+                        "Temp: Coretemp": {
+                            "state": "Normal",
+                            "reading": "44 Celsius",
+                            "threshold": {
+                                "minor": 107,
+                                "major": 117,
+                                "critical": 123,
+                                "shutdown": 125,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp: UADP": {
+                            "state": "Normal",
+                            "reading": "53 Celsius",
+                            "threshold": {
+                                "minor": 107,
+                                "major": 117,
+                                "critical": 123,
+                                "shutdown": 125,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "V1: VX1": {
+                            "state": "Normal",
+                            "reading": "871 mV"
+                        },
+                        "V1: VX2": {
+                            "state": "Normal",
+                            "reading": "1495 mV"
+                        },
+                        "V1: VX3": {
+                            "state": "Normal",
+                            "reading": "1055 mV"
+                        },
+                        "V1: VX4": {
+                            "state": "Normal",
+                            "reading": "851 mV"
+                        },
+                        "V1: VX5": {
+                            "state": "Normal",
+                            "reading": "1509 mV"
+                        },
+                        "V1: VX6": {
+                            "state": "Normal",
+                            "reading": "1301 mV"
+                        },
+                        "V1: VX7": {
+                            "state": "Normal",
+                            "reading": "1004 mV"
+                        },
+                        "V1: VX8": {
+                            "state": "Normal",
+                            "reading": "1100 mV"
+                        },
+                        "V1: VX9": {
+                            "state": "Normal",
+                            "reading": "1204 mV"
+                        },
+                        "V1: VX10": {
+                            "state": "Normal",
+                            "reading": "1699 mV"
+                        },
+                        "V1: VX11": {
+                            "state": "Normal",
+                            "reading": "1224 mV"
+                        },
+                        "V1: VX12": {
+                            "state": "Normal",
+                            "reading": "1806 mV"
+                        },
+                        "V1: VX13": {
+                            "state": "Normal",
+                            "reading": "2506 mV"
+                        },
+                        "V1: VX14": {
+                            "state": "Normal",
+                            "reading": "3290 mV"
+                        },
+                        "V1: VX15": {
+                            "state": "Normal",
+                            "reading": "5033 mV"
+                        },
+                        "V1: VX16": {
+                            "state": "Normal",
+                            "reading": "898 mV"
+                        },
+                        "Temp:   Outlet": {
+                            "state": "Normal",
+                            "reading": "37 Celsius",
+                            "threshold": {
+                                "minor": 63,
+                                "major": 73,
+                                "critical": 103,
+                                "shutdown": 105,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp:    Inlet": {
+                            "state": "Normal",
+                            "reading": "25 Celsius",
+                            "threshold": {
+                                "minor": 56,
+                                "major": 66,
+                                "critical": 96,
+                                "shutdown": 98,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "HotSwap: Volts": {
+                            "state": "Normal",
+                            "reading": "53 V DC"
+                        },
+                        "HotSwap: Power": {
+                            "state": "Normal",
+                            "reading": "272 Watts"
+                        }
+                    }
+                },
+                "Chassis2-R0": {
+                    "sensor": {
+                        "Temp: Coretemp": {
+                            "state": "Normal",
+                            "reading": "45 Celsius",
+                            "threshold": {
+                                "minor": 107,
+                                "major": 117,
+                                "critical": 123,
+                                "shutdown": 125,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp: UADP": {
+                            "state": "Normal",
+                            "reading": "52 Celsius",
+                            "threshold": {
+                                "minor": 107,
+                                "major": 117,
+                                "critical": 123,
+                                "shutdown": 125,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "V1: VX1": {
+                            "state": "Normal",
+                            "reading": "870 mV"
+                        },
+                        "V1: VX2": {
+                            "state": "Normal",
+                            "reading": "1491 mV"
+                        },
+                        "V1: VX3": {
+                            "state": "Normal",
+                            "reading": "1054 mV"
+                        },
+                        "V1: VX4": {
+                            "state": "Normal",
+                            "reading": "851 mV"
+                        },
+                        "V1: VX5": {
+                            "state": "Normal",
+                            "reading": "1516 mV"
+                        },
+                        "V1: VX6": {
+                            "state": "Normal",
+                            "reading": "1302 mV"
+                        },
+                        "V1: VX7": {
+                            "state": "Normal",
+                            "reading": "1005 mV"
+                        },
+                        "V1: VX8": {
+                            "state": "Normal",
+                            "reading": "1099 mV"
+                        },
+                        "V1: VX9": {
+                            "state": "Normal",
+                            "reading": "1205 mV"
+                        },
+                        "V1: VX10": {
+                            "state": "Normal",
+                            "reading": "1706 mV"
+                        },
+                        "V1: VX11": {
+                            "state": "Normal",
+                            "reading": "1226 mV"
+                        },
+                        "V1: VX12": {
+                            "state": "Normal",
+                            "reading": "1805 mV"
+                        },
+                        "V1: VX13": {
+                            "state": "Normal",
+                            "reading": "2508 mV"
+                        },
+                        "V1: VX14": {
+                            "state": "Normal",
+                            "reading": "3302 mV"
+                        },
+                        "V1: VX15": {
+                            "state": "Normal",
+                            "reading": "5045 mV"
+                        },
+                        "V1: VX16": {
+                            "state": "Normal",
+                            "reading": "900 mV"
+                        },
+                        "Temp:   Outlet": {
+                            "state": "Normal",
+                            "reading": "37 Celsius",
+                            "threshold": {
+                                "minor": 63,
+                                "major": 73,
+                                "critical": 103,
+                                "shutdown": 105,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp:    Inlet": {
+                            "state": "Normal",
+                            "reading": "25 Celsius",
+                            "threshold": {
+                                "minor": 56,
+                                "major": 66,
+                                "critical": 96,
+                                "shutdown": 98,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "HotSwap: Volts": {
+                            "state": "Normal",
+                            "reading": "53 V DC"
+                        },
+                        "HotSwap: Power": {
+                            "state": "Normal",
+                            "reading": "280 Watts"
+                        }
+                    }
+                },
+                "Chassis1-2/0": {
+                    "sensor": {
+                        "V1: VX1": {
+                            "state": "Normal",
+                            "reading": "1002 mV"
+                        },
+                        "V1: VX2": {
+                            "state": "Normal",
+                            "reading": "1500 mV"
+                        },
+                        "V1: VX3": {
+                            "state": "Normal",
+                            "reading": "1800 mV"
+                        },
+                        "V1: VX4": {
+                            "state": "Normal",
+                            "reading": "3296 mV"
+                        },
+                        "V1: VX5": {
+                            "state": "Normal",
+                            "reading": "3314 mV"
+                        },
+                        "V1: VX6": {
+                            "state": "Normal",
+                            "reading": "1499 mV"
+                        },
+                        "V1: VX7": {
+                            "state": "Normal",
+                            "reading": "1029 mV"
+                        },
+                        "V1: VX8": {
+                            "state": "Normal",
+                            "reading": "3291 mV"
+                        },
+                        "V1: VX9": {
+                            "state": "Normal",
+                            "reading": "12019 mV"
+                        },
+                        "V1: VX10": {
+                            "state": "Normal",
+                            "reading": "1004 mV"
+                        },
+                        "V1: VX11": {
+                            "state": "Normal",
+                            "reading": "1035 mV"
+                        },
+                        "Temp:   Outlet": {
+                            "state": "Normal",
+                            "reading": "26 Celsius",
+                            "threshold": {
+                                "minor": 55,
+                                "major": 65,
+                                "critical": 75,
+                                "shutdown": 100,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp:    Inlet": {
+                            "state": "Normal",
+                            "reading": "20 Celsius",
+                            "threshold": {
+                                "minor": 45,
+                                "major": 55,
+                                "critical": 65,
+                                "shutdown": 72,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "HotSwap: Volts": {
+                            "state": "Normal",
+                            "reading": "54 V DC"
+                        },
+                        "HotSwap: Power": {
+                            "state": "Normal",
+                            "reading": "354 Watts"
+                        }
+                    }
+                },
+                "Chassis1-7/0": {
+                    "sensor": {
+                        "V1: VX1": {
+                            "state": "Normal",
+                            "reading": "1001 mV"
+                        },
+                        "V1: VX2": {
+                            "state": "Normal",
+                            "reading": "1505 mV"
+                        },
+                        "V1: VX3": {
+                            "state": "Normal",
+                            "reading": "1800 mV"
+                        },
+                        "V1: VX4": {
+                            "state": "Normal",
+                            "reading": "3296 mV"
+                        },
+                        "V1: VX5": {
+                            "state": "Normal",
+                            "reading": "3324 mV"
+                        },
+                        "V1: VX6": {
+                            "state": "Normal",
+                            "reading": "1497 mV"
+                        },
+                        "V1: VX7": {
+                            "state": "Normal",
+                            "reading": "1032 mV"
+                        },
+                        "V1: VX8": {
+                            "state": "Normal",
+                            "reading": "3299 mV"
+                        },
+                        "V1: VX9": {
+                            "state": "Normal",
+                            "reading": "12063 mV"
+                        },
+                        "V1: VX10": {
+                            "state": "Normal",
+                            "reading": "999 mV"
+                        },
+                        "V1: VX11": {
+                            "state": "Normal",
+                            "reading": "1034 mV"
+                        },
+                        "Temp:   Outlet": {
+                            "state": "Normal",
+                            "reading": "30 Celsius",
+                            "threshold": {
+                                "minor": 53,
+                                "major": 63,
+                                "critical": 110,
+                                "shutdown": 112,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp:    Inlet": {
+                            "state": "Normal",
+                            "reading": "24 Celsius",
+                            "threshold": {
+                                "minor": 48,
+                                "major": 58,
+                                "critical": 105,
+                                "shutdown": 107,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "HotSwap: Volts": {
+                            "state": "Normal",
+                            "reading": "53 V DC"
+                        },
+                        "HotSwap: Power": {
+                            "state": "Normal",
+                            "reading": "438 Watts"
+                        }
+                    }
+                },
+                "Chassis2-2/0": {
+                    "sensor": {
+                        "V1: VX1": {
+                            "state": "Normal",
+                            "reading": "1001 mV"
+                        },
+                        "V1: VX2": {
+                            "state": "Normal",
+                            "reading": "1498 mV"
+                        },
+                        "V1: VX3": {
+                            "state": "Normal",
+                            "reading": "1802 mV"
+                        },
+                        "V1: VX4": {
+                            "state": "Normal",
+                            "reading": "3290 mV"
+                        },
+                        "V1: VX5": {
+                            "state": "Normal",
+                            "reading": "3319 mV"
+                        },
+                        "V1: VX6": {
+                            "state": "Normal",
+                            "reading": "1499 mV"
+                        },
+                        "V1: VX7": {
+                            "state": "Normal",
+                            "reading": "1033 mV"
+                        },
+                        "V1: VX8": {
+                            "state": "Normal",
+                            "reading": "3305 mV"
+                        },
+                        "V1: VX9": {
+                            "state": "Normal",
+                            "reading": "11999 mV"
+                        },
+                        "V1: VX10": {
+                            "state": "Normal",
+                            "reading": "1000 mV"
+                        },
+                        "V1: VX11": {
+                            "state": "Normal",
+                            "reading": "1030 mV"
+                        },
+                        "Temp:   Outlet": {
+                            "state": "Normal",
+                            "reading": "26 Celsius",
+                            "threshold": {
+                                "minor": 55,
+                                "major": 65,
+                                "critical": 75,
+                                "shutdown": 100,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp:    Inlet": {
+                            "state": "Normal",
+                            "reading": "20 Celsius",
+                            "threshold": {
+                                "minor": 45,
+                                "major": 55,
+                                "critical": 65,
+                                "shutdown": 72,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "HotSwap: Volts": {
+                            "state": "Normal",
+                            "reading": "53 V DC"
+                        },
+                        "HotSwap: Power": {
+                            "state": "Normal",
+                            "reading": "345 Watts"
+                        }
+                    }
+                },
+                "Chassis2-7/0": {
+                    "sensor": {
+                        "V1: VX1": {
+                            "state": "Normal",
+                            "reading": "1003 mV"
+                        },
+                        "V1: VX2": {
+                            "state": "Normal",
+                            "reading": "1499 mV"
+                        },
+                        "V1: VX3": {
+                            "state": "Normal",
+                            "reading": "1800 mV"
+                        },
+                        "V1: VX4": {
+                            "state": "Normal",
+                            "reading": "3303 mV"
+                        },
+                        "V1: VX5": {
+                            "state": "Normal",
+                            "reading": "3341 mV"
+                        },
+                        "V1: VX6": {
+                            "state": "Normal",
+                            "reading": "1501 mV"
+                        },
+                        "V1: VX7": {
+                            "state": "Normal",
+                            "reading": "1029 mV"
+                        },
+                        "V1: VX8": {
+                            "state": "Normal",
+                            "reading": "3310 mV"
+                        },
+                        "V1: VX9": {
+                            "state": "Normal",
+                            "reading": "12051 mV"
+                        },
+                        "V1: VX10": {
+                            "state": "Normal",
+                            "reading": "1001 mV"
+                        },
+                        "V1: VX11": {
+                            "state": "Normal",
+                            "reading": "1032 mV"
+                        },
+                        "Temp:   Outlet": {
+                            "state": "Normal",
+                            "reading": "29 Celsius",
+                            "threshold": {
+                                "minor": 53,
+                                "major": 63,
+                                "critical": 110,
+                                "shutdown": 112,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "Temp:    Inlet": {
+                            "state": "Normal",
+                            "reading": "23 Celsius",
+                            "threshold": {
+                                "minor": 48,
+                                "major": 58,
+                                "critical": 105,
+                                "shutdown": 107,
+                                "unit": "Celsius"
+                            }
+                        },
+                        "HotSwap: Volts": {
+                            "state": "Normal",
+                            "reading": "53 V DC"
+                        },
+                        "HotSwap: Power": {
+                            "state": "Normal",
+                            "reading": "435 Watts"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "switch": {
+        "1": {
+            "power_supply": {
+                "slot": {
+                    "PS1": {
+                        "model_no": "C9400-PWR-3200AC",
+                        "type": "ac",
+                        "capacity": "3200 W",
+                        "status": "active",
+                        "fan_1_state": "good",
+                        "fan_2_state": "good"
+                    },
+                    "PS2": {
+                        "model_no": "C9400-PWR-3200AC",
+                        "type": "ac",
+                        "capacity": "3200 W",
+                        "status": "active",
+                        "fan_1_state": "good",
+                        "fan_2_state": "good"
+                    }
+                },
+                "current_configuration_mode": "Combined",
+                "current_operating_state": "Combined",
+                "currently_active": 2,
+                "currently_available": 2
+            },
+            "fantray": {
+                "status": "good",
+                "power_consumed_by_fantray_watts": 540,
+                "fantray_airflow_direction": "side-to-side",
+                "fantray_beacon_led": "off",
+                "fantray_status_led": "green",
+                "system": "GREEN"
+            }
+        },
+        "2": {
+            "power_supply": {
+                "slot": {
+                    "PS1": {
+                        "model_no": "C9400-PWR-3200AC",
+                        "type": "ac",
+                        "capacity": "3200 W",
+                        "status": "active",
+                        "fan_1_state": "good",
+                        "fan_2_state": "good"
+                    },
+                    "PS2": {
+                        "model_no": "C9400-PWR-3200AC",
+                        "type": "ac",
+                        "capacity": "3200 W",
+                        "status": "active",
+                        "fan_1_state": "good",
+                        "fan_2_state": "good"
+                    }
+                },
+                "current_configuration_mode": "Combined",
+                "current_operating_state": "Combined",
+                "currently_active": 2,
+                "currently_available": 2
+            },
+            "fantray": {
+                "status": "good",
+                "power_consumed_by_fantray_watts": 540,
+                "fantray_airflow_direction": "side-to-side",
+                "fantray_beacon_led": "off",
+                "fantray_status_led": "green",
+                "system": "GREEN"
+            }
+        }
+    }
+}

--- a/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/tests/ShowEnvironmentAll/cli/equal/golden_output_expected.py
+++ b/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/tests/ShowEnvironmentAll/cli/equal/golden_output_expected.py
@@ -1,0 +1,633 @@
+expected_output = {
+  "critical_alarms": 0,
+  "major_alarms": 0,
+  "minor_alarms": 0,
+  "sensor_list": {
+    "Environmental Monitoring": {
+      "slot": {
+        "Chassis1-2/0": {
+          "sensor": {
+            "HotSwap: Power": {
+              "reading": "354 Watts",
+              "state": "Normal"
+            },
+            "HotSwap: Volts": {
+              "reading": "54 V DC",
+              "state": "Normal"
+            },
+            "Temp:    Inlet": {
+              "reading": "20 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 65,
+                "major": 55,
+                "minor": 45,
+                "shutdown": 72,
+                "unit": "Celsius"
+              }
+            },
+            "Temp:   Outlet": {
+              "reading": "26 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 75,
+                "major": 65,
+                "minor": 55,
+                "shutdown": 100,
+                "unit": "Celsius"
+              }
+            },
+            "V1: VX1": {
+              "reading": "1002 mV",
+              "state": "Normal"
+            },
+            "V1: VX10": {
+              "reading": "1004 mV",
+              "state": "Normal"
+            },
+            "V1: VX11": {
+              "reading": "1035 mV",
+              "state": "Normal"
+            },
+            "V1: VX2": {
+              "reading": "1500 mV",
+              "state": "Normal"
+            },
+            "V1: VX3": {
+              "reading": "1800 mV",
+              "state": "Normal"
+            },
+            "V1: VX4": {
+              "reading": "3296 mV",
+              "state": "Normal"
+            },
+            "V1: VX5": {
+              "reading": "3314 mV",
+              "state": "Normal"
+            },
+            "V1: VX6": {
+              "reading": "1499 mV",
+              "state": "Normal"
+            },
+            "V1: VX7": {
+              "reading": "1029 mV",
+              "state": "Normal"
+            },
+            "V1: VX8": {
+              "reading": "3291 mV",
+              "state": "Normal"
+            },
+            "V1: VX9": {
+              "reading": "12019 mV",
+              "state": "Normal"
+            }
+          }
+        },
+        "Chassis1-7/0": {
+          "sensor": {
+            "HotSwap: Power": {
+              "reading": "438 Watts",
+              "state": "Normal"
+            },
+            "HotSwap: Volts": {
+              "reading": "53 V DC",
+              "state": "Normal"
+            },
+            "Temp:    Inlet": {
+              "reading": "24 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 105,
+                "major": 58,
+                "minor": 48,
+                "shutdown": 107,
+                "unit": "Celsius"
+              }
+            },
+            "Temp:   Outlet": {
+              "reading": "30 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 110,
+                "major": 63,
+                "minor": 53,
+                "shutdown": 112,
+                "unit": "Celsius"
+              }
+            },
+            "V1: VX1": {
+              "reading": "1001 mV",
+              "state": "Normal"
+            },
+            "V1: VX10": {
+              "reading": "999 mV",
+              "state": "Normal"
+            },
+            "V1: VX11": {
+              "reading": "1034 mV",
+              "state": "Normal"
+            },
+            "V1: VX2": {
+              "reading": "1505 mV",
+              "state": "Normal"
+            },
+            "V1: VX3": {
+              "reading": "1800 mV",
+              "state": "Normal"
+            },
+            "V1: VX4": {
+              "reading": "3296 mV",
+              "state": "Normal"
+            },
+            "V1: VX5": {
+              "reading": "3324 mV",
+              "state": "Normal"
+            },
+            "V1: VX6": {
+              "reading": "1497 mV",
+              "state": "Normal"
+            },
+            "V1: VX7": {
+              "reading": "1032 mV",
+              "state": "Normal"
+            },
+            "V1: VX8": {
+              "reading": "3299 mV",
+              "state": "Normal"
+            },
+            "V1: VX9": {
+              "reading": "12063 mV",
+              "state": "Normal"
+            }
+          }
+        },
+        "Chassis1-R0": {
+          "sensor": {
+            "HotSwap: Power": {
+              "reading": "272 Watts",
+              "state": "Normal"
+            },
+            "HotSwap: Volts": {
+              "reading": "53 V DC",
+              "state": "Normal"
+            },
+            "Temp:    Inlet": {
+              "reading": "25 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 96,
+                "major": 66,
+                "minor": 56,
+                "shutdown": 98,
+                "unit": "Celsius"
+              }
+            },
+            "Temp:   Outlet": {
+              "reading": "37 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 103,
+                "major": 73,
+                "minor": 63,
+                "shutdown": 105,
+                "unit": "Celsius"
+              }
+            },
+            "Temp: Coretemp": {
+              "reading": "44 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 123,
+                "major": 117,
+                "minor": 107,
+                "shutdown": 125,
+                "unit": "Celsius"
+              }
+            },
+            "Temp: UADP": {
+              "reading": "53 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 123,
+                "major": 117,
+                "minor": 107,
+                "shutdown": 125,
+                "unit": "Celsius"
+              }
+            },
+            "V1: VX1": {
+              "reading": "871 mV",
+              "state": "Normal"
+            },
+            "V1: VX10": {
+              "reading": "1699 mV",
+              "state": "Normal"
+            },
+            "V1: VX11": {
+              "reading": "1224 mV",
+              "state": "Normal"
+            },
+            "V1: VX12": {
+              "reading": "1806 mV",
+              "state": "Normal"
+            },
+            "V1: VX13": {
+              "reading": "2506 mV",
+              "state": "Normal"
+            },
+            "V1: VX14": {
+              "reading": "3290 mV",
+              "state": "Normal"
+            },
+            "V1: VX15": {
+              "reading": "5033 mV",
+              "state": "Normal"
+            },
+            "V1: VX16": {
+              "reading": "898 mV",
+              "state": "Normal"
+            },
+            "V1: VX2": {
+              "reading": "1495 mV",
+              "state": "Normal"
+            },
+            "V1: VX3": {
+              "reading": "1055 mV",
+              "state": "Normal"
+            },
+            "V1: VX4": {
+              "reading": "851 mV",
+              "state": "Normal"
+            },
+            "V1: VX5": {
+              "reading": "1509 mV",
+              "state": "Normal"
+            },
+            "V1: VX6": {
+              "reading": "1301 mV",
+              "state": "Normal"
+            },
+            "V1: VX7": {
+              "reading": "1004 mV",
+              "state": "Normal"
+            },
+            "V1: VX8": {
+              "reading": "1100 mV",
+              "state": "Normal"
+            },
+            "V1: VX9": {
+              "reading": "1204 mV",
+              "state": "Normal"
+            }
+          }
+        },
+        "Chassis2-2/0": {
+          "sensor": {
+            "HotSwap: Power": {
+              "reading": "345 Watts",
+              "state": "Normal"
+            },
+            "HotSwap: Volts": {
+              "reading": "53 V DC",
+              "state": "Normal"
+            },
+            "Temp:    Inlet": {
+              "reading": "20 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 65,
+                "major": 55,
+                "minor": 45,
+                "shutdown": 72,
+                "unit": "Celsius"
+              }
+            },
+            "Temp:   Outlet": {
+              "reading": "26 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 75,
+                "major": 65,
+                "minor": 55,
+                "shutdown": 100,
+                "unit": "Celsius"
+              }
+            },
+            "V1: VX1": {
+              "reading": "1001 mV",
+              "state": "Normal"
+            },
+            "V1: VX10": {
+              "reading": "1000 mV",
+              "state": "Normal"
+            },
+            "V1: VX11": {
+              "reading": "1030 mV",
+              "state": "Normal"
+            },
+            "V1: VX2": {
+              "reading": "1498 mV",
+              "state": "Normal"
+            },
+            "V1: VX3": {
+              "reading": "1802 mV",
+              "state": "Normal"
+            },
+            "V1: VX4": {
+              "reading": "3290 mV",
+              "state": "Normal"
+            },
+            "V1: VX5": {
+              "reading": "3319 mV",
+              "state": "Normal"
+            },
+            "V1: VX6": {
+              "reading": "1499 mV",
+              "state": "Normal"
+            },
+            "V1: VX7": {
+              "reading": "1033 mV",
+              "state": "Normal"
+            },
+            "V1: VX8": {
+              "reading": "3305 mV",
+              "state": "Normal"
+            },
+            "V1: VX9": {
+              "reading": "11999 mV",
+              "state": "Normal"
+            }
+          }
+        },
+        "Chassis2-7/0": {
+          "sensor": {
+            "HotSwap: Power": {
+              "reading": "435 Watts",
+              "state": "Normal"
+            },
+            "HotSwap: Volts": {
+              "reading": "53 V DC",
+              "state": "Normal"
+            },
+            "Temp:    Inlet": {
+              "reading": "23 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 105,
+                "major": 58,
+                "minor": 48,
+                "shutdown": 107,
+                "unit": "Celsius"
+              }
+            },
+            "Temp:   Outlet": {
+              "reading": "29 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 110,
+                "major": 63,
+                "minor": 53,
+                "shutdown": 112,
+                "unit": "Celsius"
+              }
+            },
+            "V1: VX1": {
+              "reading": "1003 mV",
+              "state": "Normal"
+            },
+            "V1: VX10": {
+              "reading": "1001 mV",
+              "state": "Normal"
+            },
+            "V1: VX11": {
+              "reading": "1032 mV",
+              "state": "Normal"
+            },
+            "V1: VX2": {
+              "reading": "1499 mV",
+              "state": "Normal"
+            },
+            "V1: VX3": {
+              "reading": "1800 mV",
+              "state": "Normal"
+            },
+            "V1: VX4": {
+              "reading": "3303 mV",
+              "state": "Normal"
+            },
+            "V1: VX5": {
+              "reading": "3341 mV",
+              "state": "Normal"
+            },
+            "V1: VX6": {
+              "reading": "1501 mV",
+              "state": "Normal"
+            },
+            "V1: VX7": {
+              "reading": "1029 mV",
+              "state": "Normal"
+            },
+            "V1: VX8": {
+              "reading": "3310 mV",
+              "state": "Normal"
+            },
+            "V1: VX9": {
+              "reading": "12051 mV",
+              "state": "Normal"
+            }
+          }
+        },
+        "Chassis2-R0": {
+          "sensor": {
+            "HotSwap: Power": {
+              "reading": "280 Watts",
+              "state": "Normal"
+            },
+            "HotSwap: Volts": {
+              "reading": "53 V DC",
+              "state": "Normal"
+            },
+            "Temp:    Inlet": {
+              "reading": "25 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 96,
+                "major": 66,
+                "minor": 56,
+                "shutdown": 98,
+                "unit": "Celsius"
+              }
+            },
+            "Temp:   Outlet": {
+              "reading": "37 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 103,
+                "major": 73,
+                "minor": 63,
+                "shutdown": 105,
+                "unit": "Celsius"
+              }
+            },
+            "Temp: Coretemp": {
+              "reading": "45 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 123,
+                "major": 117,
+                "minor": 107,
+                "shutdown": 125,
+                "unit": "Celsius"
+              }
+            },
+            "Temp: UADP": {
+              "reading": "52 Celsius",
+              "state": "Normal",
+              "threshold": {
+                "critical": 123,
+                "major": 117,
+                "minor": 107,
+                "shutdown": 125,
+                "unit": "Celsius"
+              }
+            },
+            "V1: VX1": {
+              "reading": "870 mV",
+              "state": "Normal"
+            },
+            "V1: VX10": {
+              "reading": "1706 mV",
+              "state": "Normal"
+            },
+            "V1: VX11": {
+              "reading": "1226 mV",
+              "state": "Normal"
+            },
+            "V1: VX12": {
+              "reading": "1805 mV",
+              "state": "Normal"
+            },
+            "V1: VX13": {
+              "reading": "2508 mV",
+              "state": "Normal"
+            },
+            "V1: VX14": {
+              "reading": "3302 mV",
+              "state": "Normal"
+            },
+            "V1: VX15": {
+              "reading": "5045 mV",
+              "state": "Normal"
+            },
+            "V1: VX16": {
+              "reading": "900 mV",
+              "state": "Normal"
+            },
+            "V1: VX2": {
+              "reading": "1491 mV",
+              "state": "Normal"
+            },
+            "V1: VX3": {
+              "reading": "1054 mV",
+              "state": "Normal"
+            },
+            "V1: VX4": {
+              "reading": "851 mV",
+              "state": "Normal"
+            },
+            "V1: VX5": {
+              "reading": "1516 mV",
+              "state": "Normal"
+            },
+            "V1: VX6": {
+              "reading": "1302 mV",
+              "state": "Normal"
+            },
+            "V1: VX7": {
+              "reading": "1005 mV",
+              "state": "Normal"
+            },
+            "V1: VX8": {
+              "reading": "1099 mV",
+              "state": "Normal"
+            },
+            "V1: VX9": {
+              "reading": "1205 mV",
+              "state": "Normal"
+            }
+          }
+        }
+      }
+    }
+  },
+  "switch": {
+    "1": {
+      "fantray": {
+        "fantray_airflow_direction": "side-to-side",
+        "fantray_beacon_led": "off",
+        "fantray_status_led": "green",
+        "power_consumed_by_fantray_watts": 540,
+        "status": "good",
+        "system": "GREEN"
+      },
+      "power_supply": {
+        "current_configuration_mode": "Combined",
+        "current_operating_state": "Combined",
+        "currently_active": 2,
+        "currently_available": 2,
+        "slot": {
+          "PS1": {
+            "capacity": "3200 W",
+            "fan_1_state": "good",
+            "fan_2_state": "good",
+            "model_no": "C9400-PWR-3200AC",
+            "status": "active",
+            "type": "ac"
+          },
+          "PS2": {
+            "capacity": "3200 W",
+            "fan_1_state": "good",
+            "fan_2_state": "good",
+            "model_no": "C9400-PWR-3200AC",
+            "status": "active",
+            "type": "ac"
+          }
+        }
+      }
+    },
+    "2": {
+      "fantray": {
+        "fantray_airflow_direction": "side-to-side",
+        "fantray_beacon_led": "off",
+        "fantray_status_led": "green",
+        "power_consumed_by_fantray_watts": 540,
+        "status": "good",
+        "system": "GREEN"
+      },
+      "power_supply": {
+        "current_configuration_mode": "Combined",
+        "current_operating_state": "Combined",
+        "currently_active": 2,
+        "currently_available": 2,
+        "slot": {
+          "PS1": {
+            "capacity": "3200 W",
+            "fan_1_state": "good",
+            "fan_2_state": "good",
+            "model_no": "C9400-PWR-3200AC",
+            "status": "active",
+            "type": "ac"
+          },
+          "PS2": {
+            "capacity": "3200 W",
+            "fan_1_state": "good",
+            "fan_2_state": "good",
+            "model_no": "C9400-PWR-3200AC",
+            "status": "active",
+            "type": "ac"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/tests/ShowEnvironmentAll/cli/equal/golden_output_output.txt
+++ b/src/genie/libs/parser/iosxe/cat9k/c9400/rv1/tests/ShowEnvironmentAll/cli/equal/golden_output_output.txt
@@ -1,0 +1,156 @@
+Number of Critical alarms:  0
+Number of Major alarms:     0
+Number of Minor alarms:     0
+
+
+Sensor List:  Environmental Monitoring
+ Sensor           Location          State          Reading           Threshold(Minor,Major,Critical,Shutdown)
+ Temp: Coretemp   Chassis1-R0       Normal            44 Celsius                (107,117,123,125)(Celsius)
+ Temp: UADP       Chassis1-R0       Normal            53 Celsius                (107,117,123,125)(Celsius)
+ V1: VX1          Chassis1-R0       Normal            871 mV                    na
+ V1: VX2          Chassis1-R0       Normal            1495 mV                   na
+ V1: VX3          Chassis1-R0       Normal            1055 mV                   na
+ V1: VX4          Chassis1-R0       Normal            851 mV                    na
+ V1: VX5          Chassis1-R0       Normal            1509 mV                   na
+ V1: VX6          Chassis1-R0       Normal            1301 mV                   na
+ V1: VX7          Chassis1-R0       Normal            1004 mV                   na
+ V1: VX8          Chassis1-R0       Normal            1100 mV                   na
+ V1: VX9          Chassis1-R0       Normal            1204 mV                   na
+ V1: VX10         Chassis1-R0       Normal            1699 mV                   na
+ V1: VX11         Chassis1-R0       Normal            1224 mV                   na
+ V1: VX12         Chassis1-R0       Normal            1806 mV                   na
+ V1: VX13         Chassis1-R0       Normal            2506 mV                   na
+ V1: VX14         Chassis1-R0       Normal            3290 mV                   na
+ V1: VX15         Chassis1-R0       Normal            5033 mV                   na
+ V1: VX16         Chassis1-R0       Normal            898 mV                    na
+ Temp:   Outlet   Chassis1-R0       Normal            37 Celsius                (63 ,73 ,103,105)(Celsius)
+ Temp:    Inlet   Chassis1-R0       Normal            25 Celsius                (56 ,66 ,96 ,98 )(Celsius)
+ HotSwap: Volts   Chassis1-R0       Normal            53 V DC                   na
+ HotSwap: Power   Chassis1-R0       Normal            272 Watts                 na
+ Temp: Coretemp   Chassis2-R0       Normal            45 Celsius                (107,117,123,125)(Celsius)
+ Temp: UADP       Chassis2-R0       Normal            52 Celsius                (107,117,123,125)(Celsius)
+ V1: VX1          Chassis2-R0       Normal            870 mV                    na
+ V1: VX2          Chassis2-R0       Normal            1491 mV                   na
+ V1: VX3          Chassis2-R0       Normal            1054 mV                   na
+ V1: VX4          Chassis2-R0       Normal            851 mV                    na
+ V1: VX5          Chassis2-R0       Normal            1516 mV                   na
+ V1: VX6          Chassis2-R0       Normal            1302 mV                   na
+ V1: VX7          Chassis2-R0       Normal            1005 mV                   na
+ V1: VX8          Chassis2-R0       Normal            1099 mV                   na
+ V1: VX9          Chassis2-R0       Normal            1205 mV                   na
+ V1: VX10         Chassis2-R0       Normal            1706 mV                   na
+ V1: VX11         Chassis2-R0       Normal            1226 mV                   na
+ V1: VX12         Chassis2-R0       Normal            1805 mV                   na
+ V1: VX13         Chassis2-R0       Normal            2508 mV                   na
+ V1: VX14         Chassis2-R0       Normal            3302 mV                   na
+ V1: VX15         Chassis2-R0       Normal            5045 mV                   na
+ V1: VX16         Chassis2-R0       Normal            900 mV                    na
+ Temp:   Outlet   Chassis2-R0       Normal            37 Celsius                (63 ,73 ,103,105)(Celsius)
+ Temp:    Inlet   Chassis2-R0       Normal            25 Celsius                (56 ,66 ,96 ,98 )(Celsius)
+ HotSwap: Volts   Chassis2-R0       Normal            53 V DC                   na
+ HotSwap: Power   Chassis2-R0       Normal            280 Watts                 na
+ V1: VX1          Chassis1-2/0      Normal            1002 mV                   na
+ V1: VX2          Chassis1-2/0      Normal            1500 mV                   na
+ V1: VX3          Chassis1-2/0      Normal            1800 mV                   na
+ V1: VX4          Chassis1-2/0      Normal            3296 mV                   na
+ V1: VX5          Chassis1-2/0      Normal            3314 mV                   na
+ V1: VX6          Chassis1-2/0      Normal            1499 mV                   na
+ V1: VX7          Chassis1-2/0      Normal            1029 mV                   na
+ V1: VX8          Chassis1-2/0      Normal            3291 mV                   na
+ V1: VX9          Chassis1-2/0      Normal            12019 mV                  na
+ V1: VX10         Chassis1-2/0      Normal            1004 mV                   na
+ V1: VX11         Chassis1-2/0      Normal            1035 mV                   na
+ Temp:   Outlet   Chassis1-2/0      Normal            26 Celsius                (55 ,65 ,75 ,100)(Celsius)
+ Temp:    Inlet   Chassis1-2/0      Normal            20 Celsius                (45 ,55 ,65 ,72 )(Celsius)
+ HotSwap: Volts   Chassis1-2/0      Normal            54 V DC                   na
+ HotSwap: Power   Chassis1-2/0      Normal            354 Watts                 na
+ V1: VX1          Chassis1-7/0      Normal            1001 mV                   na
+ V1: VX2          Chassis1-7/0      Normal            1505 mV                   na
+ V1: VX3          Chassis1-7/0      Normal            1800 mV                   na
+ V1: VX4          Chassis1-7/0      Normal            3296 mV                   na
+ V1: VX5          Chassis1-7/0      Normal            3324 mV                   na
+ V1: VX6          Chassis1-7/0      Normal            1497 mV                   na
+ V1: VX7          Chassis1-7/0      Normal            1032 mV                   na
+ V1: VX8          Chassis1-7/0      Normal            3299 mV                   na
+ V1: VX9          Chassis1-7/0      Normal            12063 mV                  na
+ V1: VX10         Chassis1-7/0      Normal            999 mV                    na
+ V1: VX11         Chassis1-7/0      Normal            1034 mV                   na
+ Temp:   Outlet   Chassis1-7/0      Normal            30 Celsius                (53 ,63 ,110,112)(Celsius)
+ Temp:    Inlet   Chassis1-7/0      Normal            24 Celsius                (48 ,58 ,105,107)(Celsius)
+ HotSwap: Volts   Chassis1-7/0      Normal            53 V DC                   na
+ HotSwap: Power   Chassis1-7/0      Normal            438 Watts                 na
+ V1: VX1          Chassis2-2/0      Normal            1001 mV                   na
+ V1: VX2          Chassis2-2/0      Normal            1498 mV                   na
+ V1: VX3          Chassis2-2/0      Normal            1802 mV                   na
+ V1: VX4          Chassis2-2/0      Normal            3290 mV                   na
+ V1: VX5          Chassis2-2/0      Normal            3319 mV                   na
+ V1: VX6          Chassis2-2/0      Normal            1499 mV                   na
+ V1: VX7          Chassis2-2/0      Normal            1033 mV                   na
+ V1: VX8          Chassis2-2/0      Normal            3305 mV                   na
+ V1: VX9          Chassis2-2/0      Normal            11999 mV                  na
+ V1: VX10         Chassis2-2/0      Normal            1000 mV                   na
+ V1: VX11         Chassis2-2/0      Normal            1030 mV                   na
+ Temp:   Outlet   Chassis2-2/0      Normal            26 Celsius                (55 ,65 ,75 ,100)(Celsius)
+ Temp:    Inlet   Chassis2-2/0      Normal            20 Celsius                (45 ,55 ,65 ,72 )(Celsius)
+ HotSwap: Volts   Chassis2-2/0      Normal            53 V DC                   na
+ HotSwap: Power   Chassis2-2/0      Normal            345 Watts                 na
+ V1: VX1          Chassis2-7/0      Normal            1003 mV                   na
+ V1: VX2          Chassis2-7/0      Normal            1499 mV                   na
+ V1: VX3          Chassis2-7/0      Normal            1800 mV                   na
+ V1: VX4          Chassis2-7/0      Normal            3303 mV                   na
+ V1: VX5          Chassis2-7/0      Normal            3341 mV                   na
+ V1: VX6          Chassis2-7/0      Normal            1501 mV                   na
+ V1: VX7          Chassis2-7/0      Normal            1029 mV                   na
+ V1: VX8          Chassis2-7/0      Normal            3310 mV                   na
+ V1: VX9          Chassis2-7/0      Normal            12051 mV                  na
+ V1: VX10         Chassis2-7/0      Normal            1001 mV                   na
+ V1: VX11         Chassis2-7/0      Normal            1032 mV                   na
+ Temp:   Outlet   Chassis2-7/0      Normal            29 Celsius                (53 ,63 ,110,112)(Celsius)
+ Temp:    Inlet   Chassis2-7/0      Normal            23 Celsius                (48 ,58 ,105,107)(Celsius)
+ HotSwap: Volts   Chassis2-7/0      Normal            53 V DC                   na
+ HotSwap: Power   Chassis2-7/0      Normal            435 Watts                 na
+
+Switch:1
+
+Power                                                       Fan States
+Supply  Model No              Type  Capacity  Status        1     2
+------  --------------------  ----  --------  ------------  -----------
+PS1     C9400-PWR-3200AC      ac    3200 W    active        good  good
+PS2     C9400-PWR-3200AC      ac    3200 W    active        good  good
+
+PS Current Configuration Mode : Combined
+PS Current Operating State    : Combined
+
+Power supplies currently active    : 2
+Power supplies currently available : 2
+
+
+Switch:2
+
+Power                                                       Fan States
+Supply  Model No              Type  Capacity  Status        1     2
+------  --------------------  ----  --------  ------------  -----------
+PS1     C9400-PWR-3200AC      ac    3200 W    active        good  good
+PS2     C9400-PWR-3200AC      ac    3200 W    active        good  good
+
+PS Current Configuration Mode : Combined
+PS Current Operating State    : Combined
+
+Power supplies currently active    : 2
+Power supplies currently available : 2
+
+
+Switch 1:
+Fantray : good
+Power consumed by Fantray : 540 Watts
+Fantray airflow direction : side-to-side
+Fantray beacon LED: off
+Fantray status LED: green
+SYSTEM : GREEN
+Switch 2:
+Fantray : good
+Power consumed by Fantray : 540 Watts
+Fantray airflow direction : side-to-side
+Fantray beacon LED: off
+Fantray status LED: green
+SYSTEM : GREEN


### PR DESCRIPTION
## Description
Switches are included in the "show environment all" output on the CLI, but not being parsed for each switch
## Motivation and Context
Now for 9400s with multiple switches, we can parse all power supply and fantray info.

## Impact (If any)
New paths, but should support more cases


## Screenshots:
<img width="1462" height="778" alt="image" src="https://github.com/user-attachments/assets/564b483c-da29-4efe-8743-e475454268d9" />
## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have updated the changelog.
- [ x] I have updated the documentation (If applicable).
- [ x] I have added tests to cover my changes (If applicable).
- [ x] All new and existing tests passed.
- [ x] All new code passed compilation.
