### PR TITLE
Fix: IOS-XE: "show ip interface brief | include Vlan" 

### DIFF
--- a/changelog/undistributed/changelog_fix_iosxe_show_ip_interface_brief_pipe_vlan_20260605142510.rst
+++ b/changelog/undistributed/changelog_fix_iosxe_show_ip_interface_brief_pipe_vlan_20260605142510.rst
@@ -1,0 +1,6 @@
+--------------------------------------------------------------------------------
+                            Fix
+--------------------------------------------------------------------------------
+* <IOSXE>
+    * <Modified> <ShowIpInterfaceBriefPipeVlan>:
+        * Using custom parser for cli instead of referencing ShowIpInterfaceBrief.cli()

--- a/src/genie/libs/parser/iosxe/show_interface.py
+++ b/src/genie/libs/parser/iosxe/show_interface.py
@@ -1775,7 +1775,7 @@ class ShowIpInterfaceBrief(ShowIpInterfaceBriefSchema):
         return merged_output
 
 
-class ShowIpInterfaceBriefPipeVlan(ShowIpInterfaceBrief):
+class ShowIpInterfaceBriefPipeVlan(ShowIpInterfaceBriefSchema):
     """Parser for:
      show ip interface brief | include Vlan
      parser class implements detail parsing mechanisms for cli and yang output.
@@ -1794,8 +1794,55 @@ class ShowIpInterfaceBriefPipeVlan(ShowIpInterfaceBrief):
         super().__init__(*args, **kwargs)
         self.cmd = self.cli_command
 
-    def cli(self):
-        super(ShowIpInterfaceBriefPipeVlan, self).cli()
+    def cli(self, output=None):
+
+        """parsing mechanism: cli
+
+        Function cli() defines the cli type output parsing mechanism which
+        typically contains 3 steps: exe
+        cuting, transforming, returning
+        """
+
+        if output is None:
+            cmd = self.cli_command
+            out = self.device.execute(cmd)
+        else:
+            out = output
+
+        if out:
+            interface_dict = {}
+
+            # GigabitEthernet0/0     10.1.18.80      YES manual up                    up
+            p = re.compile(r'^\s*(?P<interface>[a-zA-Z0-9\/\.\-]+) '
+                r'+(?P<ip_address>[a-z0-9\.]+) +(?P<interface_is_ok>[A-Z]+) '
+                r'+(?P<method>[a-zA-Z]+) +(?P<status>[a-z\s]+) '
+                r'+(?P<protocol>[a-z]+)$')
+
+            for line in out.splitlines():
+                line = line.strip()
+
+                m = p.match(line)
+                if m:
+                    interface = m.groupdict()['interface']
+                    if 'interface' not in interface_dict:
+                        interface_dict['interface'] = {}
+                    if interface not in interface_dict['interface']:
+                        interface_dict['interface'][interface] = {}
+
+                    interface_dict['interface'][interface]['ip_address'] = \
+                        m.groupdict()['ip_address']
+                    interface_dict['interface'][interface]['interface_is_ok'] = \
+                        m.groupdict()['interface_is_ok']
+                    interface_dict['interface'][interface]['method'] = \
+                        m.groupdict()['method']
+                    interface_dict['interface'][interface]['status'] = \
+                        m.groupdict()['status'].strip()
+                    interface_dict['interface'][interface]['protocol'] = \
+                        m.groupdict()['protocol']
+
+                    continue
+
+        return interface_dict
 
     def yang(self):
         """parsing mechanism: yang


### PR DESCRIPTION
## Description
- For "show ip interface brief | include Vlan", use its own code for parsing instead of the super, which was not working at all.

## Motivation and Context
- This makes this command properly parse.
- This fixes #993 
## Impact (If any)
None

## Screenshots:
<!--- Provide screenshots of tests/compile/demo/etc -->

## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have updated the changelog.
- [ x] I have updated the documentation (If applicable).
- [ ] I have added tests to cover my changes (If applicable).
- [ x] All new and existing tests passed.
- [ x] All new code passed compilation.
